### PR TITLE
Ensure the quickstarts build with JDK > 1.8

### DIFF
--- a/application-configuration/pom.xml
+++ b/application-configuration/pom.xml
@@ -7,8 +7,8 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <shamrock.version>0.1.0</shamrock.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>

--- a/application-lifecycle-events/pom.xml
+++ b/application-lifecycle-events/pom.xml
@@ -7,8 +7,8 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <shamrock.version>0.1.0</shamrock.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <shamrock.version>0.1.0</shamrock.version>
         <surefire.version>2.21.0</surefire.version>
-
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>

--- a/getting-started-kubernetes/pom.xml
+++ b/getting-started-kubernetes/pom.xml
@@ -9,6 +9,9 @@
     <properties>
         <shamrock.version>0.1.0</shamrock.version>
         <surefire.version>2.21.0</surefire.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
 

--- a/getting-started-native/pom.xml
+++ b/getting-started-native/pom.xml
@@ -9,6 +9,9 @@
     <properties>
         <shamrock.version>0.1.0</shamrock.version>
         <surefire.version>2.21.0</surefire.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
 

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,6 +9,9 @@
     <properties>
         <shamrock.version>0.1.0</shamrock.version>
         <surefire.version>2.21.0</surefire.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
 

--- a/scheduling-periodic-tasks/pom.xml
+++ b/scheduling-periodic-tasks/pom.xml
@@ -7,8 +7,8 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <shamrock.version>0.1.0</shamrock.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>


### PR DESCRIPTION
Since Maven targets Java 1.5 by default (which is no longer
supported in more recent JDKs), the build fails when running on JDK 9 or
more recent.

With this fix, the examples build and seem to work on Java 11.

Also added project source encoding property where missing.