### PR TITLE
Use a different artifactId for each module, and configure finalName

### DIFF
--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -2,8 +2,8 @@
 <project>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.acme.async</groupId>
-    <artifactId>shamrock-quickstart</artifactId>
+    <groupId>org.acme</groupId>
+    <artifactId>shamrock-quickstart-async</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
@@ -16,6 +16,7 @@
 
 
     <build>
+        <finalName>shamrock-quickstart</finalName>
         <plugins>
             <plugin>
                 <groupId>org.jboss.shamrock</groupId>

--- a/getting-started-kubernetes/pom.xml
+++ b/getting-started-kubernetes/pom.xml
@@ -2,8 +2,8 @@
 <project>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.acme.kubernetes</groupId>
-    <artifactId>shamrock-quickstart</artifactId>
+    <groupId>org.acme</groupId>
+    <artifactId>shamrock-quickstart-kubernetes</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
@@ -16,6 +16,7 @@
 
 
     <build>
+        <finalName>shamrock-quickstart</finalName>
         <plugins>
             <plugin>
                 <groupId>org.jboss.shamrock</groupId>

--- a/getting-started-native/pom.xml
+++ b/getting-started-native/pom.xml
@@ -2,8 +2,8 @@
 <project>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.acme.native</groupId>
-    <artifactId>shamrock-quickstart</artifactId>
+    <groupId>org.acme</groupId>
+    <artifactId>shamrock-quickstart-native</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
@@ -16,6 +16,7 @@
 
 
     <build>
+        <finalName>shamrock-quickstart</finalName>
         <plugins>
             <plugin>
                 <groupId>org.jboss.shamrock</groupId>


### PR DESCRIPTION
The issue was reported in #3.  It was using different groupIds but the same artifactId to avoid having specificities for each (getting started) guide. It causes issues in VS Code.

As a workaround, this commit sets the finalName and update the groupIds (to be always the same) and artifactIds (to be different).