### PR TITLE
use FROM fedora-minimal instead of centos:7

### DIFF
--- a/getting-started-native/Dockerfile
+++ b/getting-started-native/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:7
+FROM registry.fedoraproject.org/fedora-minimal
+# FROM centos:7
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work


### PR DESCRIPTION
as that creates a significantly (100 MB) smaller container image