### PR TITLE
Add prerequisites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ This repository contains a set of examples about the Shamrock framework.
 * [Validation and JSON](./input-validation): How to consume and produce JSON payloads and how to validate the user input with Bean Validation
 
 There is documentation published at <http://10.8.247.58/nfs/protean/index.html> (docs' [sources are here](https://github.com/jbossas/protean-shamrock/tree/master/docs/src/main/asciidoc)).
+
+## Prerequisites
+
+* [Maven 3.5+](https://maven.apache.org/install.html)
+* [Java - OpenJDK 1.8+](https://adoptopenjdk.net/)


### PR DESCRIPTION
This is basically done in order to call out the minimum Maven version.
When using IntelliJ it's very easy to forget that the it bundles it's
own old Maven version which results in the quickstarts not working