### PR TITLE
WIP: Add opentracing support (depends upon protean 0.6.0)

### DIFF
--- a/getting-started-native/pom.xml
+++ b/getting-started-native/pom.xml
@@ -102,6 +102,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>opentracing</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.shamrock</groupId>
+                    <artifactId>shamrock-opentracing-deployment</artifactId>
+                    <scope>provided</scope>
+                    <version>${shamrock.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <!-- This should go away as soon as we publish the artifacts publicly. -->


### PR DESCRIPTION
This PR shows how opentracing (with default Jaeger tracer) can be added to a protean app. This could be used as the basis for adding tracing details to the docs.

For example, building app:
```
mvn package -Pnative -Popentracing
```
If the app is then run with no system properties (or env vars) for Jaeger, we get:
```
$ target/shamrock-quickstart-runner
2019-01-14 15:02:34,757 localhost shamrock-quickstart-runner[21366] WARN  [o.j.s.j.r.JaegerDeploymentTemplate] (main) Property 'JAEGER_SERVICE_NAME' has not been defined
2019-01-14 15:02:34,759 localhost shamrock-quickstart-runner[21366] INFO  [o.j.shamrock] (main) Shamrock 1.0.0.Alpha1-SNAPSHOT started in 0.002s. Listening on: http://localhost:8080
2019-01-14 15:02:34,759 localhost shamrock-quickstart-runner[21366] INFO  [o.j.shamrock] (main) Installed features: [mp-opentracing, cdi, jax-rs]
```
As the relevant properties have not been provided, a `NoopTracer` is instantiated so no tracing data is created or reported.

If we include the relevant properties:
```
$ target/shamrock-quickstart-runner -DJAEGER_SERVICE_NAME=myservice -DJAEGER_SAMPLER_TYPE=const -DJAEGER_SAMPLER_PARAM=1 -DJAEGER_ENDPOINT=http://localhost:14268/api/traces
2019-01-14 15:03:15,523 localhost shamrock-quickstart-runner[21497] INFO  [o.j.shamrock] (main) Shamrock 1.0.0.Alpha1-SNAPSHOT started in 0.005s. Listening on: http://localhost:8080
2019-01-14 15:03:15,529 localhost shamrock-quickstart-runner[21497] INFO  [o.j.shamrock] (main) Installed features: [mp-opentracing, cdi, jax-rs]
2019-01-14 15:03:21,227 localhost shamrock-quickstart-runner[21497] INFO  [i.j.Configuration] (XNIO-1 task-1) Initialized tracer=JaegerTracer(version=, serviceName=myservice, reporter=RemoteReporter(sender=HttpSender(), closeEnqueueTimeout=1000), sampler=ConstSampler(decision=true, tags={sampler.type=const, sampler.param=true}), tags={hostname=localhost.localdomain, jaeger.version=, ip=127.0.0.1}, zipkinSharedRpcSpan=false, expandExceptionLogs=false, useTraceId128Bit=false)
```
The final line in the logs is created when the first request is received by the app - and after that point no further log statements appear.

Note: for testing purposes, startup an all-in-one Jaeger server on localhost:
```
docker run -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 -p 9411:9411 jaegertracing/all-in-one:1.8
```

Questions:
* Should this profile be added to the other quickstarts?
* Would like to add a more comprehensive tracing example - if ok, where should it be located in this repo?
