### PR TITLE
Replace use of env vars with application properties

### DIFF
--- a/using-opentracing/src/main/resources/application.properties
+++ b/using-opentracing/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.jaeger.service-name=myservice
+quarkus.jaeger.sampler-type=const
+quarkus.jaeger.sampler-param=1
+quarkus.jaeger.endpoint=http://localhost:14268/api/traces


### PR DESCRIPTION
Currently the documentation for the `using-opentracing` quickstart passes the Jaeger config via environment variables using the `jvmArgs` command line parameter. Although this is an option, to enable config to be specified outside the app, the quickstart should probably use the MP-config (application.properties) approach.

This PR provides the equivalent configuration values in an `application.properties` file.

A PR will be prepared to update the documentation to accompany this change.