### PR TITLE
Remove now unnecessary @Inject on @ConfigProperty

### DIFF
--- a/application-configuration/src/main/java/org/acme/config/GreetingResource.java
+++ b/application-configuration/src/main/java/org/acme/config/GreetingResource.java
@@ -2,7 +2,6 @@ package org.acme.config;
 
 import java.util.Optional;
 
-import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -13,15 +12,12 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("/greeting")
 public class GreetingResource {
 
-    @Inject
     @ConfigProperty(name = "greeting.message")
     String message;
 
-    @Inject
     @ConfigProperty(name = "greeting.suffix", defaultValue="!")
     String suffix;
 
-    @Inject
     @ConfigProperty(name = "greeting.name")
     Optional<String> name;
 

--- a/microprofile-health/src/main/java/org/acme/health/DatabaseConnectionHealthCheck.java
+++ b/microprofile-health/src/main/java/org/acme/health/DatabaseConnectionHealthCheck.java
@@ -7,13 +7,11 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 @Health
 @ApplicationScoped
 public class DatabaseConnectionHealthCheck implements HealthCheck {
 
-    @Inject
     @ConfigProperty(name = "database.up", defaultValue = "false")
     private boolean databaseUp;
 


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/1554 made it redundant to have
`@Inject` on a `@ConfigProperty` annotated field