### PR TITLE
DatabaseConnectionHealthCheck private member fix to comply with Q best practice

### DIFF
--- a/microprofile-health/src/main/java/org/acme/health/DatabaseConnectionHealthCheck.java
+++ b/microprofile-health/src/main/java/org/acme/health/DatabaseConnectionHealthCheck.java
@@ -13,7 +13,7 @@ import javax.enterprise.context.ApplicationScoped;
 public class DatabaseConnectionHealthCheck implements HealthCheck {
 
     @ConfigProperty(name = "database.up", defaultValue = "false")
-    private boolean databaseUp;
+    boolean databaseUp;
 
     @Override
     public HealthCheckResponse call() {


### PR DESCRIPTION
DatabaseConnectionHealthCheck private member fix to comply with Q best practice

Avoids "[INFO] [io.quarkus.arc.processor.BeanProcessor] Found unrecommended usage of private members (use package-private instead) in application beans:" message in the console