### PR TITLE
Using quay.io based graalvm image

### DIFF
--- a/getting-started-knative/Dockerfile
+++ b/getting-started-knative/Dockerfile
@@ -3,7 +3,7 @@ COPY . /project
 WORKDIR /project
 RUN mvn -Duser.home=/builder/home -B install
 
-FROM swd847/centos-graal-native-image-rc12 as nativebuilder
+FROM quay.io/quarkus/centos-quarkus-native-image:graalvm-1.0.0-rc15 as nativebuilder
 COPY --from=builder /project/target /project/
 WORKDIR /project
 RUN  /opt/graalvm/bin/native-image -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager \
@@ -14,7 +14,7 @@ RUN  /opt/graalvm/bin/native-image -J-Djava.util.logging.manager=org.jboss.logma
      -H:-SpawnIsolates -H:-JNI --no-server -H:-UseServiceLoaderFeature -H:+StackTrace \
      && cp  -v quarkus-quickstart-knative-runner /tmp/quarkus-knative-runner
 
-FROM  registry.fedoraproject.org/fedora-minimal
+FROM registry.fedoraproject.org/fedora-minimal
 RUN mkdir -p /work
 COPY --from=nativebuilder /tmp/quarkus-knative-runner /work/application
 RUN chmod -R 775 /work


### PR DESCRIPTION
Using quay.io based graalvm image instead of swd847/centos-graal-native-image-rc12

Fixes knative part of https://github.com/quarkusio/quarkus-quickstarts/issues/144

Using rc15 intentionally as it works for this example and we are moving towards this version.

Checked via:
```
docker build -t quarkus/knative .
docker run -i --rm -p 8080:8080 quarkus/knative
curl http://0.0.0.0:8080/
```