### PR TITLE
Build minimal docker image by ldd and scratch.

### DIFF
--- a/getting-started-knative/Dockerfile
+++ b/getting-started-knative/Dockerfile
@@ -3,7 +3,7 @@ COPY . /project
 WORKDIR /project
 RUN mvn -Duser.home=/builder/home -B install
 
-FROM quay.io/quarkus/centos-quarkus-native-image:graalvm-1.0.0-rc15 as nativebuilder
+FROM swd847/centos-graal-native-image-rc12 as nativebuilder
 COPY --from=builder /project/target /project/
 WORKDIR /project
 RUN  /opt/graalvm/bin/native-image -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager \
@@ -14,10 +14,12 @@ RUN  /opt/graalvm/bin/native-image -J-Djava.util.logging.manager=org.jboss.logma
      -H:-SpawnIsolates -H:-JNI --no-server -H:-UseServiceLoaderFeature -H:+StackTrace \
      && cp  -v quarkus-quickstart-knative-runner /tmp/quarkus-knative-runner
 
-FROM registry.fedoraproject.org/fedora-minimal
+FROM  registry.fedoraproject.org/fedora-minimal as lddpackage
 RUN mkdir -p /work
 COPY --from=nativebuilder /tmp/quarkus-knative-runner /work/application
-RUN chmod -R 775 /work
-EXPOSE 8080
-WORKDIR /work/
-ENTRYPOINT ["./application","-Dquarkus.http.host=0.0.0.0"]
+COPY ./copy_ldd.sh /work
+RUN chmod -R 775 /work && cd work && ./copy_ldd.sh application build
+
+FROM scratch
+COPY --from=lddpackage /work/build /
+CMD ["/app/application","-Dquarkus.http.host=0.0.0.0"]

--- a/getting-started-knative/Dockerfile
+++ b/getting-started-knative/Dockerfile
@@ -3,7 +3,7 @@ COPY . /project
 WORKDIR /project
 RUN mvn -Duser.home=/builder/home -B install
 
-FROM swd847/centos-graal-native-image-rc12 as nativebuilder
+FROM quay.io/quarkus/centos-quarkus-native-image:graalvm-1.0.0-rc15 as nativebuilder
 COPY --from=builder /project/target /project/
 WORKDIR /project
 RUN  /opt/graalvm/bin/native-image -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager \
@@ -14,7 +14,7 @@ RUN  /opt/graalvm/bin/native-image -J-Djava.util.logging.manager=org.jboss.logma
      -H:-SpawnIsolates -H:-JNI --no-server -H:-UseServiceLoaderFeature -H:+StackTrace \
      && cp  -v quarkus-quickstart-knative-runner /tmp/quarkus-knative-runner
 
-FROM  registry.fedoraproject.org/fedora-minimal as lddpackage
+FROM registry.fedoraproject.org/fedora-minimal as lddpackage
 RUN mkdir -p /work
 COPY --from=nativebuilder /tmp/quarkus-knative-runner /work/application
 COPY ./copy_ldd.sh /work

--- a/getting-started-knative/copy_ldd.sh
+++ b/getting-started-knative/copy_ldd.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ $# != 2 ] ; then
+    echo "usage $0 PATH_TO_BINARY TARGET_FOLDER"
+    exit 1
+fi
+
+PATH_TO_BINARY="$1"
+TARGET_FOLDER="$2"
+
+# if we cannot find the the binary we have to abort
+if [ ! -f "$PATH_TO_BINARY" ] ; then
+    echo "The file '$PATH_TO_BINARY' was not found. Aborting!"
+    exit 1
+fi
+
+# copy the binary to the target folder
+# create directories if required
+echo "---> copy binary itself"
+mkdir -p "$TARGET_FOLDER"/app
+cp --parents -v "$PATH_TO_BINARY" "$TARGET_FOLDER"/app
+
+
+# copy the required shared libs to the target folder
+# create directories if required
+echo "---> copy libraries"
+for lib in `ldd "$PATH_TO_BINARY" | cut -d'>' -f2 | awk '{print $1}' | grep "/"` ; do
+   if [ -f "$lib" ] ; then
+        cp -v --parents "$lib" "$TARGET_FOLDER"
+   fi  
+done
+echo "Done!!!"


### PR DESCRIPTION
Using ldd to parse the java native execute file that needs those dependency of os library files, "copy_ldd.sh". Then building only execute file and os library files from Docker scratch image, and it just only 24MB.