### PR TITLE
chore: remove jQuery from Kafka quickstart

### DIFF
--- a/kafka-quickstart/src/main/resources/META-INF/resources/prices.html
+++ b/kafka-quickstart/src/main/resources/META-INF/resources/prices.html
@@ -18,7 +18,6 @@
     </div>
 </div>
 </body>
-<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script>
     var source = new EventSource("/prices/stream");
     source.onmessage = function (event) {


### PR DESCRIPTION
Linked to https://github.com/quarkusio/quarkus/pull/2137

JQuery doesn't seem to be used anywhere, so it's pointless to include it