### PR TITLE
Fixup #146 camel-java quickstart has no test coverage

### DIFF
--- a/camel-java/src/test/java/org/acme/camel/java/CamelRouteTest.java
+++ b/camel-java/src/test/java/org/acme/camel/java/CamelRouteTest.java
@@ -29,11 +29,13 @@ public class CamelRouteTest {
         try (BufferedReader r = Files.newBufferedReader(logPath, StandardCharsets.UTF_8)) {
             while (System.currentTimeMillis() <= deadline) {
                 final String line = r.readLine();
-                if (line != null && line.contains(CamelRoute.I_AM_ALIVE_MESSAGE)) {
+                if (line == null) {
+                    /* More lines may appear later */
+                    Thread.sleep(100);
+                } else if (line.contains(CamelRoute.I_AM_ALIVE_MESSAGE)) {
                     /* test passed */
                     return;
                 }
-                Thread.sleep(100);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
@rsvoboda I just found out that I have messed up the timeout loop in https://github.com/quarkusio/quarkus-quickstarts/pull/167 . In the original version, the 100ms sleep is there for each and every attempt to read a log line, which just makes the test run longer. The sleep makes sense only if readLine() returns null (i.e. when there are no more lines there at the given point in time). Here is a fix. Sorry to bother you again.