### PR TITLE
#170 Dockerfile.jvm sync with template

### DIFF
--- a/application-configuration/src/main/docker/Dockerfile.jvm
+++ b/application-configuration/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/application-configuration .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/application-configuration-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/application-configuration
+# docker run -i --rm -p 8080:8080 quarkus/application-configuration-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/application-lifecycle-events/src/main/docker/Dockerfile.jvm
+++ b/application-lifecycle-events/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/application-lifecycle-events .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/application-lifecycle-events-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/application-lifecycle-events
+# docker run -i --rm -p 8080:8080 quarkus/application-lifecycle-events-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/camel-java/src/main/docker/Dockerfile.jvm
+++ b/camel-java/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/camel-java .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/camel-java-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/camel-java
+# docker run -i --rm -p 8080:8080 quarkus/camel-java-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/getting-started-async/src/main/docker/Dockerfile.jvm
+++ b/getting-started-async/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/quarkus-quickstart-async .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/quarkus-quickstart-async-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-async
+# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-async-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/getting-started-testing/src/main/docker/Dockerfile.jvm
+++ b/getting-started-testing/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/quarkus-quickstart-testing .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/quarkus-quickstart-testing-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-testing
+# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-testing-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/getting-started/src/main/docker/Dockerfile.jvm
+++ b/getting-started/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/getting-started .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/getting-started-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/hibernate-orm-panache-resteasy/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-resteasy/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/hibernate-orm-panache-resteasy .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/hibernate-orm-panache-resteasy-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-panache-resteasy
+# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-panache-resteasy-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/hibernate-orm-resteasy/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-resteasy/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/hibernate-orm-resteasy .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/hibernate-orm-resteasy-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-resteasy
+# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-resteasy-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/infinispan-client/src/main/docker/Dockerfile.jvm
+++ b/infinispan-client/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/infinispan-client .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/infinispan-client-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/infinispan-client
+# docker run -i --rm -p 8080:8080 quarkus/infinispan-client-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/kafka-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-quickstart/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/kafka-quickstart .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/kafka-quickstart-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/kafka-quickstart
+# docker run -i --rm -p 8080:8080 quarkus/kafka-quickstart-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/microprofile-fault-tolerance/src/main/docker/Dockerfile.jvm
+++ b/microprofile-fault-tolerance/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/microprofile-fault-tolerance .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/microprofile-fault-tolerance-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/microprofile-fault-tolerance
+# docker run -i --rm -p 8080:8080 quarkus/microprofile-fault-tolerance-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/microprofile-health/src/main/docker/Dockerfile.jvm
+++ b/microprofile-health/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/microprofile-health .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/microprofile-health-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/microprofile-health
+# docker run -i --rm -p 8080:8080 quarkus/microprofile-health-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/microprofile-metrics/src/main/docker/Dockerfile.jvm
+++ b/microprofile-metrics/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/microprofile-metrics .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/microprofile-metrics-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/microprofile-metrics
+# docker run -i --rm -p 8080:8080 quarkus/microprofile-metrics-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/rest-client/src/main/docker/Dockerfile.jvm
+++ b/rest-client/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/rest-client .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/rest-client-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/rest-client
+# docker run -i --rm -p 8080:8080 quarkus/rest-client-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/rest-json/src/main/docker/Dockerfile.jvm
+++ b/rest-json/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/rest-json .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/rest-json-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/rest-json
+# docker run -i --rm -p 8080:8080 quarkus/rest-json-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/scheduling-periodic-tasks/src/main/docker/Dockerfile.jvm
+++ b/scheduling-periodic-tasks/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/scheduling-periodic-tasks .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/scheduling-periodic-tasks-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/scheduling-periodic-tasks
+# docker run -i --rm -p 8080:8080 quarkus/scheduling-periodic-tasks-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/using-jwt-rbac/src/main/docker/Dockerfile.jvm
+++ b/using-jwt-rbac/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-jwt-rbac .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-jwt-rbac-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/using-jwt-rbac
+# docker run -i --rm -p 8080:8080 quarkus/using-jwt-rbac-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/using-openapi-swaggerui/src/main/docker/Dockerfile.jvm
+++ b/using-openapi-swaggerui/src/main/docker/Dockerfile.jvm
@@ -14,8 +14,9 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-openapi-swaggerui-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/using-opentracing/src/main/docker/Dockerfile.jvm
+++ b/using-opentracing/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-opentracing .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-opentracing-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/using-opentracing
+# docker run -i --rm -p 8080:8080 quarkus/using-opentracing-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/using-spring-di/src/main/docker/Dockerfile.jvm
+++ b/using-spring-di/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-spring-di .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-spring-di-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/using-spring-di
+# docker run -i --rm -p 8080:8080 quarkus/using-spring-di-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/using-vertx/src/main/docker/Dockerfile.jvm
+++ b/using-vertx/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-vertx .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-vertx-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/using-vertx
+# docker run -i --rm -p 8080:8080 quarkus/using-vertx-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/using-websockets/src/main/docker/Dockerfile.jvm
+++ b/using-websockets/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-websockets .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/using-websockets-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/using-websockets
+# docker run -i --rm -p 8080:8080 quarkus/using-websockets-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/validation/src/main/docker/Dockerfile.jvm
+++ b/validation/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,16 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/validation .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/validation-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/validation
+# docker run -i --rm -p 8080:8080 quarkus/validation-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus-quickstarts/issues/170

 - switch to fabric8/java-alpine-openjdk8-jre
 - `-jvm` suffix for docker tag in build command 
 - forcing org.jboss.logmanager.LogManager
 - disabling Jolokia