### PR TITLE
Improving test coverage for native mode

### DIFF
--- a/application-configuration/pom.xml
+++ b/application-configuration/pom.xml
@@ -91,6 +91,23 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemProperties>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/application-configuration/src/test/java/org/acme/config/NativeGreetingResourceIT.java
+++ b/application-configuration/src/test/java/org/acme/config/NativeGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.config;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeGreetingResourceIT extends GreetingResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/application-lifecycle-events/pom.xml
+++ b/application-lifecycle-events/pom.xml
@@ -91,6 +91,23 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemProperties>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/application-lifecycle-events/src/test/java/org/acme/events/NativeGreetingResourceIT.java
+++ b/application-lifecycle-events/src/test/java/org/acme/events/NativeGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.events;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeGreetingResourceIT extends GreetingResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/camel-java/pom.xml
+++ b/camel-java/pom.xml
@@ -91,6 +91,23 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemProperties>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/getting-started-async/src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java
+++ b/getting-started-async/src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.quickstart;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeGreetingResourceIT extends GreetingResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -120,6 +120,23 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemProperties>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/getting-started-knative/src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java
+++ b/getting-started-knative/src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.quickstart;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeGreetingResourceIT extends GreetingResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/getting-started-testing/src/test/java/org/acme/quickstart/GreetingITCase.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/GreetingITCase.java
@@ -1,8 +1,0 @@
-package org.acme.quickstart;
-
-import io.quarkus.test.junit.SubstrateTest;
-
-@SubstrateTest
-public class GreetingITCase extends GreetingResourceTest {
-
-}

--- a/getting-started-testing/src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.quickstart;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeGreetingResourceIT extends GreetingResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/getting-started-testing/src/test/java/org/acme/quickstart/NativeGreetingServiceIT.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/NativeGreetingServiceIT.java
@@ -1,0 +1,11 @@
+package org.acme.quickstart;
+
+import io.quarkus.test.junit.SubstrateTest;
+import org.junit.jupiter.api.Disabled;
+
+@SubstrateTest
+@Disabled("java.lang.NullPointerException in native mode")
+public class NativeGreetingServiceIT extends GreetingServiceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/getting-started-testing/src/test/java/org/acme/quickstart/NativeStaticContentIT.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/NativeStaticContentIT.java
@@ -1,0 +1,9 @@
+package org.acme.quickstart;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeStaticContentIT extends StaticContentTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/using-openapi-swaggerui/src/test/java/org/acme/openapi/swaggerui/NativeOpenApiIT.java
+++ b/using-openapi-swaggerui/src/test/java/org/acme/openapi/swaggerui/NativeOpenApiIT.java
@@ -1,0 +1,9 @@
+package org.acme.openapi.swaggerui;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeOpenApiIT extends OpenApiTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/using-openapi-swaggerui/src/test/java/org/acme/openapi/swaggerui/SwaggerUiTest.java
+++ b/using-openapi-swaggerui/src/test/java/org/acme/openapi/swaggerui/SwaggerUiTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 @QuarkusTest
 public class SwaggerUiTest {
 
+    // Note: Swagger UI is only available when Quarkus is started in dev or test mode
     @Test
     public void testSwaggerUi() {
         given()

--- a/using-opentracing/pom.xml
+++ b/using-opentracing/pom.xml
@@ -93,6 +93,23 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemProperties>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/using-opentracing/src/test/java/org/acme/opentracing/NativeTracedResourceIT.java
+++ b/using-opentracing/src/test/java/org/acme/opentracing/NativeTracedResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.opentracing;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativeTracedResourceIT extends TracedResourceTest {
+
+    // Execute the same tests but in native mode.
+}


### PR DESCRIPTION
Improving test coverage for native mode.

Resolves https://github.com/quarkusio/quarkus-quickstarts/issues/176

 - added missing maven-failsafe-plugin so some quickstarts
 - adding Native**IT variants of JVM mode tests