### PR TITLE
Remove jaeger.endpoint property as UDPSender now works and that shoul…

### DIFF
--- a/using-opentracing/src/main/resources/application.properties
+++ b/using-opentracing/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 quarkus.jaeger.service-name=myservice
 quarkus.jaeger.sampler-type=const
 quarkus.jaeger.sampler-param=1
-quarkus.jaeger.endpoint=http://localhost:14268/api/traces


### PR DESCRIPTION
…d be default

Related to https://github.com/quarkusio/quarkus/pull/2304, it is no longer necessary to force use of the HTTPSender to avoid core dump when using UDPSender in native mode.
