### PR TITLE
Use the Strimzi docker images in the docker-compose descriptor in the…

### DIFF
--- a/kafka-quickstart/docker-compose.yaml
+++ b/kafka-quickstart/docker-compose.yaml
@@ -3,17 +3,28 @@ version: '2'
 services:
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
-    expose:
-    - "2181"
+    image: strimzi/kafka:0.11.3-kafka-2.1.0
+    command: [
+      "sh", "-c",
+      "bin/zookeeper-server-start.sh config/zookeeper.properties"
+    ]
+    ports:
+      - "2181:2181"
+    environment:
+      LOG_DIR: /tmp/logs
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: strimzi/kafka:0.11.3-kafka-2.1.0
+    command: [
+      "sh", "-c",
+      "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
+    ]
     depends_on:
-    - zookeeper
+      - zookeeper
     ports:
-    - "9092:9092"
+      - "9092:9092"
     environment:
+      LOG_DIR: "/tmp/logs"
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181


### PR DESCRIPTION
This PR replaces the docker images used in the `docker-compose` descriptor in the Kafka quickstart.

To be more homogenous between "bare metal" and Kubernetes, we switch to Strimzi images.  The work has been done by @scholzj, so a big THANK YOU for this! 

This fixes https://github.com/quarkusio/quarkus/issues/2184