### PR TITLE
Sync docker tag with directory name

### DIFF
--- a/getting-started-async/src/main/docker/Dockerfile.jvm
+++ b/getting-started-async/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/quarkus-quickstart-async-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/getting-started-async-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-async-jvm
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-async-jvm
 #
 ###
 FROM fabric8/java-alpine-openjdk8-jre

--- a/getting-started-async/src/main/docker/Dockerfile.native
+++ b/getting-started-async/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/quarkus-quickstart-async .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/getting-started-async .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-async
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-async
 #
 ###
 FROM registry.fedoraproject.org/fedora-minimal

--- a/getting-started-testing/src/main/docker/Dockerfile.jvm
+++ b/getting-started-testing/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/quarkus-quickstart-testing-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/getting-started-testing-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-testing-jvm
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-testing-jvm
 #
 ###
 FROM fabric8/java-alpine-openjdk8-jre

--- a/getting-started-testing/src/main/docker/Dockerfile.native
+++ b/getting-started-testing/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/quarkus-quickstart-testing .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/getting-started-testing .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/quarkus-quickstart-testing
+# docker run -i --rm -p 8080:8080 quarkus/getting-started-testing
 #
 ###
 FROM registry.fedoraproject.org/fedora-minimal


### PR DESCRIPTION
Sync docker tag with directory name

No reference to tag names in documentation / guides