### PR TITLE
Automatically start PostgreSQL for integration testing

### DIFF
--- a/using-vertx/pom.xml
+++ b/using-vertx/pom.xml
@@ -12,6 +12,7 @@
         <quarkus.version>999-SNAPSHOT</quarkus.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
+        <docker-plugin.version>0.28.0</docker-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -93,6 +94,62 @@
                     <execution>
                         <goals>
                             <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <!-- Automatically start PostgreSQL for integration testing - requires Docker -->
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${docker-plugin.version}</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>postgres:10.5</name>
+                            <alias>postgresql</alias>
+                            <run>
+                                <env>
+                                    <POSTGRES_USER>quarkus_test</POSTGRES_USER>
+                                    <POSTGRES_PASSWORD>quarkus_test</POSTGRES_PASSWORD>
+                                    <POSTGRES_DB>quarkus_test</POSTGRES_DB>
+                                </env>
+                                <ports>
+                                    <port>5432:5432</port>
+                                </ports>
+                                <log>
+                                    <prefix>PostgreSQL: </prefix>
+                                    <date>default</date>
+                                    <color>cyan</color>
+                                </log>
+                                <wait>
+                                    <tcp>
+                                        <mode>mapped</mode>
+                                        <ports>
+                                            <port>5432</port>
+                                        </ports>
+                                    </tcp>
+                                    <time>10000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>docker-start</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>stop</goal>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>docker-stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Automatically start PostgreSQL for integration testing in using-vertx module.

Tests expect db available on localhost:5432 but DB wasn't started automatically so `mvn verify` command failed on using-vertx module