### PR TITLE
Apply changes from PR  #154

### DIFF
--- a/hibernate-orm-panache-resteasy/pom.xml
+++ b/hibernate-orm-panache-resteasy/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.version>999-SNAPSHOT</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
-        <docker-plugin.version>0.28.0</docker-plugin.version>
+        <testcontainers.version>1.11.3</testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -53,6 +53,18 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -91,61 +103,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <!-- Automatically start PostgreSQL for integration testing - requires Docker -->
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>${docker-plugin.version}</version>
-                <configuration>
-                    <images>
-                        <image>
-                            <name>postgres:10.5</name>
-                            <alias>postgresql</alias>
-                            <run>
-                                <env>
-                                    <POSTGRES_USER>quarkus_test</POSTGRES_USER>
-                                    <POSTGRES_PASSWORD>quarkus_test</POSTGRES_PASSWORD>
-                                    <POSTGRES_DB>quarkus_test</POSTGRES_DB>
-                                </env>
-                                <ports>
-                                    <port>5432:5432</port>
-                                </ports>
-                                <log>
-                                    <prefix>PostgreSQL: </prefix>
-                                    <date>default</date>
-                                    <color>cyan</color>
-                                </log>
-                                <wait>
-                                    <tcp>
-                                        <mode>mapped</mode>
-                                        <ports>
-                                            <port>5432</port>
-                                        </ports>
-                                    </tcp>
-                                    <time>10000</time>
-                                </wait>
-                            </run>
-                        </image>
-                    </images>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>docker-start</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>stop</goal>
-                            <goal>start</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>docker-stop</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            
         </plugins>
     </build>
 

--- a/hibernate-orm-panache-resteasy/src/test/java/org/acme/hibernate/orm/panache/FruitsEndpointTest.java
+++ b/hibernate-orm-panache-resteasy/src/test/java/org/acme/hibernate/orm/panache/FruitsEndpointTest.java
@@ -4,14 +4,32 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsNot.not;
 
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @QuarkusTest
-public class FruitsEndpointTest {
+@Testcontainers
+class FruitsEndpointTest {
+
+    @Container
+    static PostgreSQLContainer DATABASE = new PostgreSQLContainer<>("postgres:10.5")
+            .withDatabaseName("quarkus_test")
+            .withUsername("quarkus_test")
+            .withPassword("quarkus_test")
+            .withExposedPorts(5432)
+            .withCreateContainerCmdModifier(cmd ->
+                    cmd
+                    .withHostName("localhost")
+                    .withPortBindings(new PortBinding(Ports.Binding.bindPort(5432), new ExposedPort(5432))));
 
     @Test
-    public void testListAllFruits() {
+    void testListAllFruits() {
         //List all, should have all 3 fruits the database has initially:
         given()
               .when().get("/fruits")

--- a/hibernate-orm-resteasy/pom.xml
+++ b/hibernate-orm-resteasy/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.version>999-SNAPSHOT</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
-        <docker-plugin.version>0.28.0</docker-plugin.version>
+        <testcontainers.version>1.11.3</testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -61,6 +61,18 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -95,61 +107,6 @@
                     <execution>
                         <goals>
                             <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <!-- Automatically start PostgreSQL for integration testing - requires Docker -->
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>${docker-plugin.version}</version>
-                <configuration>
-                    <images>
-                        <image>
-                            <name>postgres:10.5</name>
-                            <alias>postgresql</alias>
-                            <run>
-                                <env>
-                                    <POSTGRES_USER>quarkus_test</POSTGRES_USER>
-                                    <POSTGRES_PASSWORD>quarkus_test</POSTGRES_PASSWORD>
-                                    <POSTGRES_DB>quarkus_test</POSTGRES_DB>
-                                </env>
-                                <ports>
-                                    <port>5432:5432</port>
-                                </ports>
-                                <log>
-                                    <prefix>PostgreSQL: </prefix>
-                                    <date>default</date>
-                                    <color>cyan</color>
-                                </log>
-                                <wait>
-                                    <tcp>
-                                        <mode>mapped</mode>
-                                        <ports>
-                                            <port>5432</port>
-                                        </ports>
-                                    </tcp>
-                                    <time>10000</time>
-                                </wait>
-                            </run>
-                        </image>
-                    </images>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>docker-start</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>stop</goal>
-                            <goal>start</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>docker-stop</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/hibernate-orm-resteasy/src/test/java/org/acme/hibernate/orm/FruitsEndpointTest.java
+++ b/hibernate-orm-resteasy/src/test/java/org/acme/hibernate/orm/FruitsEndpointTest.java
@@ -4,14 +4,32 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsNot.not;
 
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @QuarkusTest
-public class FruitsEndpointTest {
+@Testcontainers
+class FruitsEndpointTest {
+
+    @Container
+    static PostgreSQLContainer DATABASE = new PostgreSQLContainer<>("postgres:10.5")
+            .withDatabaseName("quarkus_test")
+            .withUsername("quarkus_test")
+            .withPassword("quarkus_test")
+            .withExposedPorts(5432)
+            .withCreateContainerCmdModifier(cmd ->
+                    cmd
+                    .withHostName("localhost")
+                    .withPortBindings(new PortBinding(Ports.Binding.bindPort(5432), new ExposedPort(5432))));
 
     @Test
-    public void testListAllFruits() {
+    void testListAllFruits() {
         //List all, should have all 3 fruits the database has initially:
         given()
               .when().get("/fruits")


### PR DESCRIPTION
Follow up of #154.

@lordofthejars has proposed to switch from the maven docker plugin to test containers, which is more in line with the deep-dive content. The PR was pending for a few weeks, and well, you can imagine what happened... 

This PR:

* apply the same changes
* update the test containers version
* remove modifiers when not requires