### PR TITLE
ubi8 based container for native mode application

### DIFF
--- a/application-configuration/src/main/docker/Dockerfile.native
+++ b/application-configuration/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/application-configuration
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/application-lifecycle-events/src/main/docker/Dockerfile.native
+++ b/application-lifecycle-events/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/application-lifecycle-events
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/camel-java/src/main/docker/Dockerfile.native
+++ b/camel-java/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/camel-java
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/getting-started-async/src/main/docker/Dockerfile.native
+++ b/getting-started-async/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-async
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/getting-started-knative/Dockerfile
+++ b/getting-started-knative/Dockerfile
@@ -14,7 +14,7 @@ RUN  /opt/graalvm/bin/native-image -J-Djava.util.logging.manager=org.jboss.logma
      -H:-SpawnIsolates -H:-JNI --no-server -H:-UseServiceLoaderFeature -H:+StackTrace \
      && cp  -v quarkus-quickstart-knative-runner /tmp/quarkus-knative-runner
 
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 RUN mkdir -p /work
 COPY --from=nativebuilder /tmp/quarkus-knative-runner /work/application
 RUN chmod -R 775 /work

--- a/getting-started-testing/src/main/docker/Dockerfile.native
+++ b/getting-started-testing/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-testing
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/getting-started/src/main/docker/Dockerfile.native
+++ b/getting-started/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/hibernate-orm-panache-resteasy/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-panache-resteasy/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-panache-resteasy
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/hibernate-orm-resteasy/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-resteasy/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-resteasy
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/infinispan-client/src/main/docker/Dockerfile.native
+++ b/infinispan-client/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8081:8081 quarkus/infinispan-client
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/kafka-quickstart/src/main/docker/Dockerfile.native
+++ b/kafka-quickstart/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8081:8081 quarkus/kafka-quickstart
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/microprofile-fault-tolerance/src/main/docker/Dockerfile.native
+++ b/microprofile-fault-tolerance/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8081:8081 quarkus/microprofile-fault-tolerance
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/microprofile-health/src/main/docker/Dockerfile.native
+++ b/microprofile-health/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-health
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/microprofile-messaging-mqtt/src/main/docker/Dockerfile.native
+++ b/microprofile-messaging-mqtt/src/main/docker/Dockerfile.native
@@ -12,7 +12,7 @@
 # docker run -i --rm -p 8081:8081 quarkus/mqtt-quickstart
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/microprofile-metrics/src/main/docker/Dockerfile.native
+++ b/microprofile-metrics/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-metrics
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/rest-client/src/main/docker/Dockerfile.native
+++ b/rest-client/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/rest-client
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/rest-json/src/main/docker/Dockerfile.native
+++ b/rest-json/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/rest-json
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/scheduling-periodic-tasks/src/main/docker/Dockerfile.native
+++ b/scheduling-periodic-tasks/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/scheduling-periodic-tasks
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/using-jwt-rbac/src/main/docker/Dockerfile.native
+++ b/using-jwt-rbac/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-jwt-rbac
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/using-openapi-swaggerui/src/main/docker/Dockerfile.native
+++ b/using-openapi-swaggerui/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-openapi-swaggerui
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/using-opentracing/src/main/docker/Dockerfile.native
+++ b/using-opentracing/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-opentracing
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/using-spring-di/src/main/docker/Dockerfile.native
+++ b/using-spring-di/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-spring-di
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/using-vertx/src/main/docker/Dockerfile.native
+++ b/using-vertx/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-vertx
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/using-websockets/src/main/docker/Dockerfile.native
+++ b/using-websockets/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-websockets
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/validation/src/main/docker/Dockerfile.native
+++ b/validation/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/validation
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work


### PR DESCRIPTION
ubi8 based container for native mode application

Followup of https://github.com/quarkusio/quarkus/pull/2723

Used command: `git grep -l fedora-minimal | xargs sed -i '' "s,registry.fedoraproject.org/fedora-minimal,registry.access.redhat.com/ubi8/ubi-minimal,g"`