### PR TITLE
Skip docker startup when skipTests=true

### DIFF
--- a/hibernate-orm-resteasy/pom.xml
+++ b/hibernate-orm-resteasy/pom.xml
@@ -105,6 +105,7 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>${docker-plugin.version}</version>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <images>
                         <image>
                             <name>postgres:10.5</name>


### PR DESCRIPTION
Hello @quarkusio team,

When you do `mvn clean install` in `hibernate-orm-resteasy` then `hibernate-orm-resteasy` tries to communicate with docker host to start container. If docker service is not started then the following error occurs:

```plain
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.036 s
[INFO] Finished at: 2019-06-13T19:19:44+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.fabric8:docker-maven-plugin:0.28.0:stop (docker-start) on project hibernate-orm-resteasy: Execution docker-start of goal io.fabric8:docker-maven-plugin:0.28.0:stop failed: No <dockerHost> given, no DOCKER_HOST environment variable, no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine' and no external provider like Docker machine configured -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```

This is expected. However, if I want to skip tests (docker is used here only for this purpose), and this is usually done by:

```plain
mvn clean install -DskipTests=true
```

By executing above command tests will not be run, but docker is still starting, unfortunately.

This PR is to fix this. With this modification if you do `-DskipTests=true` the `docker-maven-plugin` execution will be skipped as well.