### PR TITLE
Skip docker and elasticsearch startup on skipTests=true

### DIFF
--- a/hibernate-orm-panache-resteasy/pom.xml
+++ b/hibernate-orm-panache-resteasy/pom.xml
@@ -97,6 +97,7 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>${docker-plugin.version}</version>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <images>
                         <image>
                             <name>postgres:10.5</name>

--- a/hibernate-search-elasticsearch/pom.xml
+++ b/hibernate-search-elasticsearch/pom.xml
@@ -101,6 +101,7 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>${docker-plugin.version}</version>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <images>
                         <image>
                             <name>postgres:11.3</name>
@@ -156,6 +157,7 @@
                 <artifactId>elasticsearch-maven-plugin</artifactId>
                 <version>${elasticsearch-maven-plugin.version}</version>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <version>${elasticsearch-server.version}</version>
                     <timeout>90</timeout>
                     <pathConf>${project.build.directory}/test-classes/elasticsearch-maven-plugin/configuration/</pathConf>

--- a/using-vertx/pom.xml
+++ b/using-vertx/pom.xml
@@ -105,6 +105,7 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>${docker-plugin.version}</version>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <images>
                         <image>
                             <name>postgres:10.5</name>


### PR DESCRIPTION
Hello, this is follow up to https://github.com/quarkusio/quarkus-quickstarts/pull/218. Here I also added skip configuration in `elasticsearch-maven-plugin` because it was downloading elasticsearch binaries and starting it via `bin/elasticsearch` to do some testing `PUT` requests (which took forever).
