### PR TITLE
Add test for kafka-quickstart

### DIFF
--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -11,6 +11,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <resteasy.version>4.1.0.Final</resteasy.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -27,6 +28,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${resteasy.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -12,6 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <resteasy.version>4.1.0.Final</resteasy.version>
+    <awaitility.version>3.0.0</awaitility.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -46,6 +47,12 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kafka-quickstart/src/main/resources/application.properties
+++ b/kafka-quickstart/src/main/resources/application.properties
@@ -1,9 +1,21 @@
 # Configure the Kafka sink (we write to it)
-mp.messaging.outgoing.generated-price.connector=smallrye-kafka
-mp.messaging.outgoing.generated-price.topic=prices
-mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+%dev.mp.messaging.outgoing.generated-price.connector=smallrye-kafka
+%dev.mp.messaging.outgoing.generated-price.topic=prices
+%dev.mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
 
 # Configure the Kafka source (we read from it)
-mp.messaging.incoming.prices.connector=smallrye-kafka
-mp.messaging.incoming.prices.topic=prices
-mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+%dev.mp.messaging.incoming.prices.connector=smallrye-kafka
+%dev.mp.messaging.incoming.prices.topic=prices
+%dev.mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+
+
+
+# Configure the Kafka sink (we write to it)
+%prod.mp.messaging.outgoing.generated-price.connector=smallrye-kafka
+%prod.mp.messaging.outgoing.generated-price.topic=prices
+%prod.mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+
+# Configure the Kafka source (we read from it)
+%prod.mp.messaging.incoming.prices.connector=smallrye-kafka
+%prod.mp.messaging.incoming.prices.topic=prices
+%prod.mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer

--- a/kafka-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
+++ b/kafka-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
@@ -1,0 +1,39 @@
+package org.acme.quarkus.sample;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.sse.SseEventSource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class PriceResourceTest {
+
+    private static final String PRICES_SSE_ENDPOINT = "http://localhost:8081/prices/stream";
+
+    @Test
+    void testPricesEventStream() {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(PRICES_SSE_ENDPOINT);
+
+        List<Double> received = new ArrayList<>();
+
+        try (SseEventSource source = SseEventSource.target(target).build()) {
+            source.register(inboundSseEvent -> received.add(Double.valueOf(inboundSseEvent.readData())));
+            source.open();
+            Thread.sleep(500); // Consume events for just 500 ms
+        } catch (InterruptedException e) {
+            System.out.println("Something went wrong!");
+
+        }
+
+        assertEquals(Arrays.asList(0.88, 1.76, 2.64), received);
+    }
+}

--- a/kafka-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
+++ b/kafka-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
@@ -32,7 +32,6 @@ class PriceResourceTest {
         source.open();
         await().atMost(100000, MILLISECONDS).until(() -> received.size() == 3);
 
-
         assertEquals(Arrays.asList(0.88, 1.76, 2.64), received);
     }
 }

--- a/kafka-quickstart/src/test/java/org/acme/quarkus/sample/SourceOfData.java
+++ b/kafka-quickstart/src/test/java/org/acme/quarkus/sample/SourceOfData.java
@@ -1,0 +1,16 @@
+package org.acme.quarkus.sample;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SourceOfData {
+
+    @Outgoing("prices")
+    public PublisherBuilder<Integer> source() {
+        return ReactiveStreams.of(1, 2, 3);
+    }
+}


### PR DESCRIPTION
Hi, 

this PR add test for kafka-quickstart.

Resolves #145 

- avoid to use kafka in test profile
- add resteasy-client
