### PR TITLE
Make Postgresql host explicit

### DIFF
--- a/hibernate-orm-panache-resteasy/README.md
+++ b/hibernate-orm-panache-resteasy/README.md
@@ -109,3 +109,14 @@ Navigate to:
 <http://localhost:8080/index.html>
 
 Have fun, and join the team of contributors!
+
+## Running the demo in Kubernetes
+
+This section provides extra information for running both the database and the demo on Kubernetes.
+As well as running the DB on Kubernetes, a service needs to be exposed for the demo to connect to the DB.
+
+Then, rebuild demo docker image with a system property that points to the DB. 
+
+```bash
+-Dquarkus.datasource.url=jdbc:postgresql://<DB_SERVICE_NAME>/quarkus_test
+```

--- a/hibernate-orm-panache-resteasy/src/main/resources/application.properties
+++ b/hibernate-orm-panache-resteasy/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.datasource.url=jdbc:postgresql:quarkus_test
+quarkus.datasource.url=jdbc:postgresql://localhost/quarkus_test
 quarkus.datasource.driver=org.postgresql.Driver
 quarkus.datasource.username=quarkus_test
 quarkus.datasource.password=quarkus_test

--- a/hibernate-orm-resteasy/README.md
+++ b/hibernate-orm-resteasy/README.md
@@ -109,3 +109,14 @@ Navigate to:
 <http://localhost:8080/index.html>
 
 Have fun, and join the team of contributors!
+
+## Running the demo in Kubernetes
+
+This section provides extra information for running both the database and the demo on Kubernetes.
+As well as running the DB on Kubernetes, a service needs to be exposed for the demo to connect to the DB.
+
+Then, rebuild demo docker image with a system property that points to the DB. 
+
+```bash
+-Dquarkus.datasource.url=jdbc:postgresql://<DB_SERVICE_NAME>/quarkus_test
+```

--- a/hibernate-orm-resteasy/src/main/resources/application.properties
+++ b/hibernate-orm-resteasy/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.datasource.url=jdbc:postgresql:quarkus_test
+quarkus.datasource.url=jdbc:postgresql://localhost/quarkus_test
 quarkus.datasource.driver=org.postgresql.Driver
 quarkus.datasource.username=quarkus_test
 quarkus.datasource.password=quarkus_test

--- a/hibernate-search-elasticsearch/README.md
+++ b/hibernate-search-elasticsearch/README.md
@@ -127,3 +127,14 @@ Navigate to:
 <http://localhost:8080/>
 
 Have fun, and join the team of contributors!
+
+## Running the demo in Kubernetes
+
+This section provides extra information for running both the database and the demo on Kubernetes.
+As well as running the DB on Kubernetes, a service needs to be exposed for the demo to connect to the DB.
+
+Then, rebuild demo docker image with a system property that points to the DB. 
+
+```bash
+-Dquarkus.datasource.url=jdbc:postgresql://<DB_SERVICE_NAME>/quarkus_test
+```

--- a/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -17,7 +17,7 @@
 # we don't need SSL here, let's disable it to have a more compact native executable
 quarkus.ssl.native=false
 
-quarkus.datasource.url=jdbc:postgresql:quarkus_test
+quarkus.datasource.url=jdbc:postgresql://localhost/quarkus_test
 quarkus.datasource.driver=org.postgresql.Driver
 quarkus.datasource.username=quarkus_test
 quarkus.datasource.password=quarkus_test


### PR DESCRIPTION
Aside from this, I was wondering if it'd be useful to explain in the corresponding READMEs how these ORM examples could be run within a Kubernetes environment?

I was trying to run both the quickstart and DB in Minikube, and that's what lead me down this path. In such env the host needs to be aligned to the DB service name, hence the importance of making this explicit.

I ended up creating a Kubernetes specific [Dockerfile](https://github.com/galderz/putcachejpa/blob/master/src/main/docker/Dockerfile.kubernetes#L22) that passed in database URL adjusted to the DB Kubernetes service. Use [this Makefile](https://github.com/galderz/putcachejpa/blob/master/Makefile) to drive building and running app and DB in kubernetess. 

If added, could this be easily tested too?