### PR TITLE
Pipelines - increase timeoutInMinutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 
 jobs:
 - job: Build
-  timeoutInMinutes: 60
+  timeoutInMinutes: 90
   pool:
     vmImage: 'Ubuntu 16.04'
   variables:


### PR DESCRIPTION
Increase `timeoutInMinutes` for pipelines, build are cancelled after 1 hour.

Number of quickstarts increased a bit and new are coming.