### PR TITLE
kafka-quickstart - Remove the previous workaround that's no longer necessary

### DIFF
--- a/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
+++ b/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.annotations.SseElementType;
 
 /**
  * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
@@ -19,15 +20,9 @@ public class PriceResource {
     @Stream("my-data-stream") Publisher<Double> prices;
 
     @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    public String hello() {
-        return "hello";
-    }
-
-
-    @GET
     @Path("/stream")
-    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @Produces(MediaType.SERVER_SENT_EVENTS) // denotes that server side events (SSE) will be produced
+    @SseElementType("text/plain") // denotes that the contained data, within this SSE, is just regular text/plain data
     public Publisher<Double> stream() {
         return prices;
     }


### PR DESCRIPTION
Now that the upstream master branch of quarkus has an enhancement to deal with server side events better https://github.com/quarkusio/quarkus/pull/4167, the previous workaround that was added to this quickstart guide (https://github.com/quarkusio/quarkus/issues/2176) is no longer needed.
The commit here removes that workaround and uses the new construct for SSE. Manual testing with this change has gone fine.
