### PR TITLE
Add ObjectStore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ quarkus.log
 
 bin/
 .DS_Store
+ObjectStore


### PR DESCRIPTION
Like we already do in the `quarkus` repository.

Because some people seem to be using Mac OS... I won't point fingers.