### PR TITLE
Upgrade to Hibernate Search 6.0.0.Beta2

### DIFF
--- a/hibernate-search-elasticsearch/pom.xml
+++ b/hibernate-search-elasticsearch/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>
         <elasticsearch-maven-plugin.version>6.14</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.3.1</elasticsearch-server.version>
+        <elasticsearch-server.version>7.4.0</elasticsearch-server.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
No change i necessary, just upgrading the Elasticsearch version for consistency with the documentation.

Related: https://github.com/quarkusio/quarkus/pull/4921