### PR TITLE
Fix Kafka quickstart dependencies

### DIFF
--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -11,8 +11,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <resteasy.version>4.1.0.Final</resteasy.version>
-    <awaitility.version>3.0.0</awaitility.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -31,17 +29,17 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-      <version>${resteasy.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -52,7 +50,6 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
@cescoffier can you have a look. It's a cleanup and it's necessary to fix a warning with the new Jakarta checking infrastructure.