### PR TITLE
Move mapper configuration out of the "elasticsearch" section in the Hibernate Search extension config

### DIFF
--- a/hibernate-search-elasticsearch-quickstart/src/main/resources/application.properties
+++ b/hibernate-search-elasticsearch-quickstart/src/main/resources/application.properties
@@ -27,6 +27,6 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 
 quarkus.hibernate-search.elasticsearch.version=7
 quarkus.hibernate-search.elasticsearch.analysis.configurer=org.acme.hibernate.search.elasticsearch.config.AnalysisConfigurer
-quarkus.hibernate-search.elasticsearch.automatic-indexing.synchronization.strategy=searchable
 quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create
 quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.required-status=yellow
+quarkus.hibernate-search.automatic-indexing.synchronization.strategy=searchable


### PR DESCRIPTION
Related to this PR in quarkus: https://github.com/quarkusio/quarkus/pull/5203

**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [X] makes sure the documentation must not be updated
- [X] links the documentation update pull request (if needed)
- [X] updates or creates the `README.md` file (with build and run instructions)
- [X] For new quickstart, is located in the directory _component-quickstart_
- [X] For new quickstart, is added to the root `pom.xml` and `README.md`