### PR TITLE
Fix wrong annotation import

### DIFF
--- a/amqp-quickstart/pom.xml
+++ b/amqp-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>config-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/dynamodb-quickstart/pom.xml
+++ b/dynamodb-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/src/main/java/org/acme/quickstart/GreetingResource.java
+++ b/getting-started/src/main/java/org/acme/quickstart/GreetingResource.java
@@ -4,21 +4,20 @@ package org.acme.quickstart;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 @Path("/hello")
 public class GreetingResource {
 
     @Inject
     GreetingService service;
-
+    
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/greeting/{name}")
-    public String greeting(@PathParam String name) {
+    public String greeting(@PathParam("name") String name) {
         return service.greeting(name);
     }
 

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-search-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-elasticsearch-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -9,7 +9,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/kafka-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
+++ b/kafka-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
@@ -10,13 +10,11 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.sse.SseEventSource;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
 
 @QuarkusTest
 class PriceResourceTest {

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -13,7 +13,7 @@
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -15,7 +15,7 @@
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>lifecycle-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>mqtt-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>opentracing-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>rest-client-multipart-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>rest-client-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>rest-json-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/rest-json-quickstart/src/main/java/org/acme/rest/json/Fruit.java
+++ b/rest-json-quickstart/src/main/java/org/acme/rest/json/Fruit.java
@@ -1,7 +1,5 @@
 package org.acme.rest.json;
 
-import java.util.Objects;
-
 public class Fruit {
 
     public String name;

--- a/rest-json-quickstart/src/main/java/org/acme/rest/json/Legume.java
+++ b/rest-json-quickstart/src/main/java/org/acme/rest/json/Legume.java
@@ -1,7 +1,5 @@
 package org.acme.rest.json;
 
-import java.util.Objects;
-
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>scheduler-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <testcontainers.version>1.12.3</testcontainers.version>
         <surefire.version>2.22.0</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <surefire.version>2.22.0</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <keycloak.version>7.0.1</keycloak.version>
         <surefire.version>2.22.0</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>spring-data-jpa-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>spring-di-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>spring-web-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>0.19.1</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>validation-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.0.0.CR1</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>websockets-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>1.0.0.CR1</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
import javax.ws.rs.PathParam instead org.jboss.resteasy.annotations.jaxrs.PathParam


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


