### PR TITLE
Quarkus version fix for tests-with-coverage-quickstart

### DIFF
--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>0.19.1</quarkus.version>
+        <quarkus.version>999-SNAPSHOT</quarkus.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Quarkus version fix for tests-with-coverage-quickstart

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
