### PR TITLE
Remove a duplicate Jackson dependency from oidc web auth quickstart

### DIFF
--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -43,10 +43,6 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Depends on https://github.com/quarkusio/quarkus/pull/5470 and targets 1.1.0 (unless the backport is preferred)