### PR TITLE
Cleanup native tests for software-transactional-memory-quickstart

### DIFF
--- a/software-transactional-memory-quickstart/src/test/java/org/acme/quickstart/stm/STMResourceIT.java
+++ b/software-transactional-memory-quickstart/src/test/java/org/acme/quickstart/stm/STMResourceIT.java
@@ -1,40 +1,8 @@
 package org.acme.quickstart.stm;
 
 import io.quarkus.test.junit.NativeImageTest;
-import io.restassured.RestAssured;
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @NativeImageTest
-class STMResourceIT {
+class STMResourceIT extends STMResourceTest {
 
-    @Test
-    void testGet() {
-        given()
-                .when().get("/stm")
-                .then()
-                .statusCode(200);
-    }
-
-    @Test
-    void testPost() {
-        String responseString;
-
-        makeBooking();
-        responseString = makeBooking();
-
-        assertThat(responseString, containsString("Booking Count=2"));
-    }
-
-    private String makeBooking() {
-        return RestAssured.post("/stm").then()
-                .assertThat()
-                .statusCode(200)
-                .extract()
-                .asString();
-    }
 }

--- a/software-transactional-memory-quickstart/src/test/java/org/acme/quickstart/stm/STMResourceTest.java
+++ b/software-transactional-memory-quickstart/src/test/java/org/acme/quickstart/stm/STMResourceTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.restassured.RestAssured;
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;


### PR DESCRIPTION
Native test fix for software-transactional-memory-quickstart

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
