### PR TITLE
CoffeeResourceIT fix to extend CoffeeResourceTest

### DIFF
--- a/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/faulttolerance/CoffeeResourceIT.java
+++ b/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/faulttolerance/CoffeeResourceIT.java
@@ -1,35 +1,8 @@
 package org.acme.faulttolerance;
 
-import static io.restassured.RestAssured.get;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-
 import io.quarkus.test.junit.NativeImageTest;
-import org.junit.jupiter.api.Test;
 
 @NativeImageTest
-public class CoffeeResourceIT {
-
-    @Test
-    public void testAvailability() {
-        get("/coffee/1/availability").then()
-                .statusCode(200).body(is("20"));
-        get("/coffee/1/availability").then()
-                .statusCode(200).body(is("20"));
-        get("/coffee/1/availability").then()
-                .statusCode(500).body(is("RuntimeException: Service failed."));
-        get("/coffee/1/availability").then()
-                .statusCode(500).body(is("RuntimeException: Service failed."));
-        get("/coffee/1/availability").then()
-                .statusCode(500).body(is("CircuitBreakerOpenException: getAvailability"));
-    }
-
-    @Test
-    public void testRecommendations() {
-        get("/coffee/2/recommendations").then()
-                .statusCode(200)
-                .body("id", hasItem(1),
-                        "countryOfOrigin", hasItem("Colombia"));
-    }
+public class CoffeeResourceIT extends CoffeeResourceTest {
 
 }

--- a/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/faulttolerance/CoffeeResourceTest.java
+++ b/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/faulttolerance/CoffeeResourceTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import javax.inject.Inject;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ public class CoffeeResourceTest {
     private CoffeeResource coffeeResource;
 
     @Test
+    @DisabledOnNativeImage("@Inject in tests doesn't work for native mode")
     public void testCoffeeList() {
         coffeeResource.resetCounter();
         coffeeResource.setFailRatio(0f);
@@ -37,6 +39,7 @@ public class CoffeeResourceTest {
     }
 
     @Test
+    @DisabledOnNativeImage("@Inject in tests doesn't work for native mode")
     public void testCoffeeDetail() {
         coffeeResource.setFailRatio(0f);
         get("/coffee/1")


### PR DESCRIPTION
CoffeeResourceIT fix to extend CoffeeResourceTest

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
