### PR TITLE
Use DisabledOnNativeImage annotation

### DIFF
--- a/getting-started-testing/src/test/java/org/acme/quickstart/GreetingServiceTest.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/GreetingServiceTest.java
@@ -2,6 +2,7 @@ package org.acme.quickstart;
 
 import javax.inject.Inject;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,7 @@ public class GreetingServiceTest {
     GreetingService service;
 
     @Test
+    @DisabledOnNativeImage("@Inject in tests doesn't work for native mode")
     public void testGreetingService() {
         Assertions.assertEquals("hello Quarkus", service.greeting("Quarkus"));
     }

--- a/getting-started-testing/src/test/java/org/acme/quickstart/NativeGreetingServiceIT.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/NativeGreetingServiceIT.java
@@ -1,10 +1,8 @@
 package org.acme.quickstart;
 
 import io.quarkus.test.junit.NativeImageTest;
-import org.junit.jupiter.api.Disabled;
 
 @NativeImageTest
-@Disabled("java.lang.NullPointerException in native mode")
 public class NativeGreetingServiceIT extends GreetingServiceTest {
 
     // Execute the same tests but in native mode.

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceIT.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceIT.java
@@ -2,16 +2,8 @@ package org.acme.jwt;
 
 import io.quarkus.test.junit.NativeImageTest;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-/**
- * Native tests
- */
 @NativeImageTest
 public class TokenSecuredResourceIT extends TokenSecuredResourceTest {
-   @Test
-   @Override
-   @Disabled("Doesn't work in the native mode due to a subresource issue")
-   public void testLottoWinners() {
-   }
+
+   // Execute the same tests but in native mode.
 }

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceTest.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceTest.java
@@ -8,6 +8,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
@@ -91,6 +92,7 @@ public class TokenSecuredResourceTest {
     }
 
     @Test
+    @DisabledOnNativeImage("Doesn't work in the native mode due to a subresource issue")
     public void testLottoWinners() {
         Response response = RestAssured.given().auth()
                 .oauth2(token)


### PR DESCRIPTION
Use DisabledOnNativeImage annotation

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
