### PR TITLE
Set the version of keycloak to 7.0.1

### DIFF
--- a/security-keycloak-authorization-quickstart/README.md
+++ b/security-keycloak-authorization-quickstart/README.md
@@ -47,7 +47,7 @@ Launch the Maven build on the checked out sources of this demo:
 To start a Keycloak Server you can use Docker and just run the following command:
 
 ```bash
-docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak
+docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:7.0.1
 ```
 
 You should be able to access your Keycloak Server at http://localhost:8180/auth[localhost:8180/auth].

--- a/security-keycloak-authorization-quickstart/src/test/java/org.acme.keycloak.authorization/KeycloakServer.java
+++ b/security-keycloak-authorization-quickstart/src/test/java/org.acme.keycloak.authorization/KeycloakServer.java
@@ -13,8 +13,8 @@ public class KeycloakServer implements BeforeAllCallback, AfterAllCallback {
     private GenericContainer keycloak;
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) throws Exception {
-        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak")
+    public void beforeAll(ExtensionContext extensionContext) {
+        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:7.0.1")
                 .withFixedExposedPort(8180, 8080)
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
@@ -25,7 +25,7 @@ public class KeycloakServer implements BeforeAllCallback, AfterAllCallback {
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) throws Exception {
+    public void afterAll(ExtensionContext extensionContext) {
         keycloak.stop();
     }
 }

--- a/security-openid-connect-web-authentication-quickstart/README.md
+++ b/security-openid-connect-web-authentication-quickstart/README.md
@@ -37,7 +37,7 @@ Launch the Maven build on the checked out sources of this demo:
 To start a Keycloak Server you can use Docker and just run the following command:
 
 ```bash
-docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak
+docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:7.0.1
 ```
 
 You should be able to access your Keycloak Server at http://localhost:8180/auth[localhost:8180/auth].

--- a/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
+++ b/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
@@ -14,7 +14,7 @@ public class KeycloakServer implements BeforeAllCallback, AfterAllCallback {
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
-        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak")
+        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:7.0.1")
                 .withFixedExposedPort(8180, 8080)
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")


### PR DESCRIPTION
This PR sets the Keycloak version to 7.0.1 to avoid the issue we have with 8.0.0. 
It needs to be cherry-picked to the 1.0 branch and master branch. 

**Checklist**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] updates or creates the `README.md` file (with build and run instructions)


