### PR TITLE
#6114 Using UBI base image for Kafka Streams quickstart

### DIFF
--- a/kafka-streams-quickstart/README.md
+++ b/kafka-streams-quickstart/README.md
@@ -44,8 +44,8 @@ docker run --tty --rm -i --network ks debezium/tooling:1.0
 In the tooling container, run _kafkacat_ to examine the results of the streaming pipeline:
 
 ```bash
-kafkacat -b kafka:9092 -C -o beginning -q \
-        -t temperatures-aggregated
+kafkacat -b kafka:9092 -C -o beginning -u -q \
+        -t temperatures-aggregated | jq .
 ```
 
 You also can obtain the current aggregated state for a given weather station using _httpie_,

--- a/kafka-streams-quickstart/aggregator/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/aggregator/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,9 @@
 # docker run -i --rm -p 8080:8080 quarkus/kafka-streams-quickstart-producer-jvm
 #
 ###
-FROM fabric8/java-centos-openjdk8-jdk
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf install java-1.8.0-openjdk-headless && microdnf clean all
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
-ENTRYPOINT [ "/deployments/run-java.sh" ]
+ENTRYPOINT [ "java", "-jar", "/deployments/app.jar", "-Dquarkus.http.host=0.0.0.0", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager" ]


### PR DESCRIPTION
RocksDB (a dependency of Kafka Streams) isn't compatible with Alpine.
Hence Kafka Streams cannot be used with the default Dockerfile.jvm as
generated by Quarkus atm.
The quickstart guide will be updated accordingly and this example is
updated to verify things work with UBI + installed JDK.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [x] links the documentation update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [x] For new quickstart, is located in the directory _component-quickstart_
- [x] For new quickstart, is added to the root `pom.xml` and `README.md`

Docs PR will follow up in a bit.

