### PR TITLE
Upgrade to Elasticsearch 7.5

### DIFF
--- a/hibernate-search-elasticsearch-quickstart/README.md
+++ b/hibernate-search-elasticsearch-quickstart/README.md
@@ -48,7 +48,7 @@ You can launch a test instance easily from the project directory:
 
 If you prefer using Docker:
 
-> docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.0.1
+> docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.5.0
 
 Alternatively you can setup an Elasticsearch instance in any another way.
 

--- a/hibernate-search-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-elasticsearch-quickstart/pom.xml
@@ -12,8 +12,8 @@
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>
-        <elasticsearch-maven-plugin.version>6.14</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.4.0</elasticsearch-server.version>
+        <elasticsearch-maven-plugin.version>6.15</elasticsearch-maven-plugin.version>
+        <elasticsearch-server.version>7.5.0</elasticsearch-server.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Following the upgrade to Hibernate Search 6.0.0.Beta3 [here](https://github.com/quarkusio/quarkus/pull/6204).
