### PR TITLE
since vert.x 3.8.0,we should use request instead of send.

### DIFF
--- a/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
@@ -23,7 +23,7 @@ public class EventResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{name}")
     public CompletionStage<String> greeting(@PathParam String name) {
-        return bus.<String>send("greeting", name)
+        return bus.<String>request("greeting", name)
                 .thenApply(Message::body);
     }
 }


### PR DESCRIPTION
method "send" will be remove in version 4,now we should use
`eventBus.request("the-address", body, ar -> ...);`
here is the wiki [https://github.com/vert-x3/wiki/wiki/3.8.0-Deprecations-and-breaking-changes](url "Vert.x wiki")
