### PR TITLE
Improve the Neo4j quickstart.

### DIFF
--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -25,7 +25,7 @@
       <dependency>
           <groupId>io.projectreactor</groupId>
           <artifactId>reactor-bom</artifactId>
-          <version>Californium-SR4</version>
+          <version>Dysprosium-RELEASE</version>
           <type>pom</type>
           <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The Neo4j extension has been updated to the 4.0 final release of the
driver lately.
The final version of the driver correctly fails with the previous state
of the getting started guide:

The reading of the transactional result of a transactional function
needs to happen inside the same transaction.
Therefor the guide needs a fix so that the composition of the future
extracting the node happens in the transaction, not outside.

Furthermore the dependency of Project Reactor for the reactive example
has been updated to the one the Neo4j extension itself uses in
integratation tests (which is the same as the driver uses).


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [x] links the documentation update pull request (if needed): https://github.com/quarkusio/quarkus/pull/6409
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


