### PR TITLE
Implement a periodic workflow verifying the QS against the Quarkus master

### DIFF
--- a/.github/NativeBuildReport.kts
+++ b/.github/NativeBuildReport.kts
@@ -1,7 +1,7 @@
 #!/usr/bin/env kscript
 
 @file:MavenRepository("jcenter","https://jcenter.bintray.com/")
-@file:MavenRepository("maven-central","https://repo1.maven.org/maven2/")
+@file:MavenRepository("maven-central","https://repo.maven.apache.org/maven2/")
 @file:DependsOn("org.kohsuke:github-api:1.101")
 
 
@@ -13,6 +13,8 @@ import java.util.concurrent.TimeUnit
 val token = args[0]; 
 val status = args[1];
 
+val ISSUE_NUMBER=6588
+val REPO = "quarkusio/quarkus"
 
 // Handle status. Possible values are success, failure, or cancelled.
 val succeed = status == "success";
@@ -21,14 +23,17 @@ if (status == "cancelled") {
     System.exit(0)
 }
 
-val ISSUE_TITLE = "[CI] - Quickstarts Native Build failed against Quarkus Master"
-val REPO = "quarkusio/quarkus-quickstarts"
-
 val github = GitHubBuilder().withOAuthToken(token).build()
-val repository = github.getRepository("quarkusio/quarkus")
-val issues = repository.getIssues(GHIssueState.ALL)
+val repository = github.getRepository(REPO)
 
-val issue = issues.firstOrNull { i -> i.getTitle() == ISSUE_TITLE}
+val issue = repository.getIssue(ISSUE_NUMBER)
+if (issue == null) {
+    println("Unable to find the issue ${ISSUE_NUMBER} in project ${REPO}")
+    System.exit(-1)
+} else {
+    println("Report issue found: ${issue.getTitle()} - ${issue.getHtmlUrl()}")
+    println("The issue is currently ${issue.getState()}")
+}
 
 val quickstartsCommit = getRepositoryCommit(".")
 val quarkusCommit = getRepositoryCommit("quarkus")
@@ -46,55 +51,30 @@ if (succeed) {
         issue.close()
         println("Comment added on issue ${issue.getHtmlUrl()} - ${comment.getHtmlUrl()}, the issue has also been closed")
     } else {
-        println("Nothing to do - the build passed and the issue is already closed or not created")
+        println("Nothing to do - the build passed and the issue is already closed")
     }
 } else  {
-    // Build failed
-    if (issue == null) {
-        // create a new issue
-        val newIssue = repository.createIssue(ISSUE_TITLE)
-            .body("""
-                The build of the  `development` branch of the quickstarts against quarkus `master` has failed.
-                This build verifies the native compilation and executes the native integration tests.
+    if (isOpen(issue)) {
+        val comment = issue.comment("""
+        The build is still failing with:
 
-                The build failed with:
+        * Quarkus commit: ${quarkusCommit}
+        * Quickstarts commit: ${quickstartsCommit}   
+        * Link to build: https://github.com/quarkusio/quarkus-quickstarts/actions
 
-                * Quarkus commit: ${quarkusCommit}
-                * Quickstarts commit: ${quickstartsCommit}     
-                * Link to build: https://github.com/quarkusio/quarkus-quickstarts/actions 
-                         
-                This issue will be closed when the build gets fixed. It will be re-opened if it fails again later.
-                Do not close the issue yourself (it will be re-opened automatically)
-                You can subscribe and monitor the status.
-
-            """.trimIndent())
-                .label("area/infra")
-                .create()
-        println("New issue created: ${newIssue.getTitle()} - ${newIssue.getHtmlUrl()}")    
+    """.trimIndent())
+        println("Comment added on issue ${issue.getHtmlUrl()} - ${comment.getHtmlUrl()}")
     } else {
-        if (isOpen(issue)) {
-            val comment = issue.comment("""
-            Build still failing with:
+        issue.reopen()
+        val comment = issue.comment("""
+        Unfortunately, the build failed:
 
-            * Quarkus commit: ${quarkusCommit}
-            * Quickstarts commit: ${quickstartsCommit}   
-            * Link to build: https://github.com/quarkusio/quarkus-quickstarts/actions
+        * Quarkus commit: ${quarkusCommit}
+        * Quickstarts commit: ${quickstartsCommit}   
+        * Link to build: https://github.com/quarkusio/quarkus-quickstarts/actions
 
-        """.trimIndent())
-            println("Comment added on issue ${issue.getHtmlUrl()} - ${comment.getHtmlUrl()}")
-        } else {
-            issue.reopen()
-            val comment = issue.comment("""
-            Unfortunately, the build fails again:
-
-            * Quarkus commit: ${quarkusCommit}
-            * Quickstarts commit: ${quickstartsCommit}   
-            * Link to build: https://github.com/quarkusio/quarkus-quickstarts/actions
-
-        """.trimIndent())
-            println("Comment added on issue ${issue.getHtmlUrl()} - ${comment.getHtmlUrl()}, the issue has been re-opened.")
-
-        }
+    """.trimIndent())
+        println("Comment added on issue ${issue.getHtmlUrl()} - ${comment.getHtmlUrl()}, the issue has been re-opened.")
 
     }
 }
@@ -113,7 +93,7 @@ fun String.runCommand(workingDir: String): String {
                 .redirectError(ProcessBuilder.Redirect.PIPE)
                 .start()
 
-        proc.waitFor(60, TimeUnit.MINUTES)
+        proc.waitFor(1, TimeUnit.MINUTES)
         return proc.inputStream.bufferedReader().readText()
     } catch(e: IOException) {
         e.printStackTrace()

--- a/.github/NativeBuildReport.kts
+++ b/.github/NativeBuildReport.kts
@@ -1,0 +1,101 @@
+#!/usr/bin/env kscript
+
+@file:MavenRepository("jcenter","https://jcenter.bintray.com/")
+@file:MavenRepository("maven-central","https://repo1.maven.org/maven2/")
+@file:DependsOn("org.kohsuke:github-api:1.101")
+
+
+import org.kohsuke.github.*
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+val token = args[0]; 
+val status = args[1];
+
+
+// Handle status. Possible values are success, failure, or cancelled.
+val succeed = status == "success";
+if (status == "cancelled") {
+    println("Job status is `cancelled` - exiting")
+    System.exit(0)
+}
+
+val ISSUE_TITLE = "Quickstarts Native Build failed against Quarkus Master"
+val REPO = "quarkusio/quarkus-quickstarts"
+
+val github = GitHubBuilder().withOAuthToken(token).build()
+val repository = github.getRepository("quarkusio/quarkus-quickstarts")
+val issues = repository.getIssues(GHIssueState.OPEN)
+val existingIssue = issues.firstOrNull { i -> i.getTitle() == ISSUE_TITLE}
+
+val quickstartsCommit = getRepositoryCommit(".")
+val quarkusCommit = getRepositoryCommit("quarkus")
+if (succeed) {
+    if (existingIssue != null) {
+        // close issue with a comment
+        val comment = existingIssue.comment("""
+            Build fixed with:
+
+            * Quarkus commit: ${quarkusCommit}
+            * Quickstarts commit: ${quickstartsCommit}               
+
+        """.trimIndent())        
+        existingIssue.close()
+        println("Comment added on issue ${existingIssue.getHtmlUrl()} - ${comment.getHtmlUrl()}, the issue has also been closed")
+    } else {
+        println("Nothing to do - the build passed and there are no issue to close")
+    }
+} else  {
+    // Build failed
+    if (existingIssue == null) {
+        // create a new issue
+        val newIssue = repository.createIssue(ISSUE_TITLE)
+            .body("""
+                The build of the  `development` branch of the quickstarts against quarkus `master` has failed.
+                This build verifies the native compilation and executes the native integration tests.
+
+                The build failed with:
+
+                * Quarkus commit: ${quarkusCommit}
+                * Quickstarts commit: ${quickstartsCommit}               
+
+            """.trimIndent())
+            .create()
+        println("New issue created: ${newIssue.getTitle()} - ${newIssue.getHtmlUrl()}")    
+    } else {
+        // comment on issue
+        val comment = existingIssue.comment("""
+            Build still failing with:
+
+            * Quarkus commit: ${quarkusCommit}
+            * Quickstarts commit: ${quickstartsCommit}   
+
+        """.trimIndent())
+        println("Comment added on issue ${existingIssue.getHtmlUrl()} - ${comment.getHtmlUrl()}")
+
+    }
+}
+
+
+fun getRepositoryCommit(workingDir: String) : String {
+    return "git rev-parse HEAD".runCommand(workingDir)
+}
+
+fun String.runCommand(workingDir: String): String {
+    try {
+        val parts = this.split("\\s".toRegex())
+        val proc = ProcessBuilder(*parts.toTypedArray())
+                .directory(File(workingDir))
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
+                .start()
+
+        proc.waitFor(60, TimeUnit.MINUTES)
+        return proc.inputStream.bufferedReader().readText()
+    } catch(e: IOException) {
+        e.printStackTrace()
+        return ""
+    }
+}
+

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -36,9 +36,7 @@ jobs:
       - name: Build Quickstart with native
         run: |
           mvn -B clean install -Pnative \
-            -Dquarkus.native.container-build=true \
-            -pl "!software-transactional-memory-quickstart"
-
+            -Dquarkus.native.container-build=true
       - name: Report
         if: always()
         env:

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -39,7 +39,7 @@ jobs:
             -Dquarkus.native.container-build=true \
             -pl "!software-transactional-memory-quickstart"
 
-      - name: Report Success
+      - name: Report
         if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -1,0 +1,57 @@
+---
+name: "Native Test - development"
+
+# Adding the dispatch event to allow restarting the build on demand
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  repository_dispatch:
+
+jobs:
+  build_with_native:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: development
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Install JDK 8
+        uses: joschi/setup-jdk@v1.0.0
+        with:
+          java-version: 'openjdk8'
+
+      - name: Build Quarkus master
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git \
+          && cd quarkus \
+          && mvn -B clean install -DskipTests -DskipITs
+
+      - name: Build Quickstart with native
+        run: |
+          mvn -B clean install -Pnative \
+            -Dquarkus.native.container-build=true \
+            -pl "!software-transactional-memory-quickstart"
+
+      - name: Report Success
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
+          STATUS: ${{ job.status }}
+        run: |
+          sudo apt-get update -o Dir::Etc::sourcelist="sources.list" \
+            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+          sudo apt-get install -y gnupg2 gnupg-agent
+          echo Installing SDKMAN
+          curl -s "https://get.sdkman.io" | bash
+          source ~/.sdkman/bin/sdkman-init.sh && \
+          sdk install kotlin 1.3.61 && \
+          sdk install kscript 2.9.0
+
+          kscript .github/NativeBuildReport.kts ${GITHUB_TOKEN} ${STATUS}


### PR DESCRIPTION
The implemented workflow runs every 6 hours and verifies the quickstarts against the latest Quarkus (master branch). It builds the native executables using the container policy and runs native ITs.

To ease debugging and to avoid waiting for the next _tick_, the dispatch event is also enabled. So we can trigger the workflow by issuing a curl command as follows:

```
curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
          -H "Accept: application/vnd.github.everest-preview+json"  \
         -H "Content-Type: application/json" \
          https://api.github.com/repos/quarkusio/quarkus-quickstarts/dispatches \
         --data '{"event_type": "internal_event"}'
```

The build reporting uses Github Issues. It creates, closes or adds a comment to an issue named `Quickstarts Native Build failed against Quarkus Master`. If the issue does not exist it creates it at the first failure. It the issue exist and the build passes, the issue is closed (with a comment). If the build still fails, a comment is added. The comment contains the SHAs of the quickstart and quarkus commits.

At the moment the STM quickstart is ignored. An issue has been found yesterday and is currently being reviewed (https://github.com/quarkusio/quarkus/issues/6553). 

**IMPORTANT**: The build takes almost 3h to run...
