### PR TITLE
Fix link to tests-with-coverage document

### DIFF
--- a/tests-with-coverage-quickstart/README.md
+++ b/tests-with-coverage-quickstart/README.md
@@ -27,4 +27,4 @@ It will generate three separate reports:
 
 ## Learn more
 
-For more in-depth information please see [Quarkus - Measuring the coverage of your tests](https://github.com/quarkusio/quarkus/blob/master/docs/src/main/asciidoc/tests-with-coverage-guide.adoc) guide.
+For more in-depth information please see [Quarkus - Measuring the coverage of your tests](https://github.com/quarkusio/quarkus/blob/master/docs/src/main/asciidoc/tests-with-coverage.adoc) guide.


### PR DESCRIPTION
Fix link to tests-with-coverage document

Your pull request:

- [x] targets the `development` branch

Following checks are irrelevant:
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


