### PR TITLE
Native build should use Graal 19.3.1

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           mvn -B clean install -Pnative \
             -Dquarkus.native.container-build=true \
-            -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8
+            -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8 \
+            -pl '!rest-client-quickstart'
       - name: Report
         if: always()
         env:


### PR DESCRIPTION
This is done because SSL doesn't work from docker
builds of the native image

Fixes: https://github.com/quarkusio/quarkus/issues/6588#issuecomment-575648918