### PR TITLE
Use GraalVM 19.3.1 when checking native image build in CI

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Build Quickstart with native
         run: |
           mvn -B clean install -Pnative \
-            -Dquarkus.native.container-build=true
+            -Dquarkus.native.container-build=true \
+            -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8
       - name: Report
         if: always()
         env:


### PR DESCRIPTION
This is just a cherry-pick of my same commit which was merged in `development`.

We need it in master otherwise the cron job doesn't use the proper settings