### PR TITLE
Ignore case when testing the job status

### DIFF
--- a/.github/NativeBuildReport.kts
+++ b/.github/NativeBuildReport.kts
@@ -17,8 +17,8 @@ val ISSUE_NUMBER=6588
 val REPO = "quarkusio/quarkus"
 
 // Handle status. Possible values are success, failure, or cancelled.
-val succeed = status == "success";
-if (status == "cancelled") {
+val succeed = status.equals("success", ignoreCase = true);
+if (status.equals("cancelled", ignoreCase = true)) {
     println("Job status is `cancelled` - exiting")
     System.exit(0)
 }


### PR DESCRIPTION
This PR targets `master` on purpose. We would need to cherry-pick the commit on the development branch too.

Note that the Github action documentation is a bit misleading as it says: "The current status of the job. Possible values are success, failure, or cancelled." (https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#job-status-check-functions), while it gets "Success".

Related to https://github.com/quarkusio/quarkus/issues/6588.
