### PR TITLE
Rest client URLs in test mode uses a different port

### DIFF
--- a/rest-client-multipart-quickstart/src/main/resources/application.properties
+++ b/rest-client-multipart-quickstart/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-org.acme.restclient.multipart.MultipartService/mp-rest/url=http://localhost:8080/ 
+org.acme.restclient.multipart.MultipartService/mp-rest/url=http://localhost:8080/
+%test.org.acme.restclient.multipart.MultipartService/mp-rest/url=http://localhost:8081/

--- a/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceIT.java
+++ b/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceIT.java
@@ -1,4 +1,7 @@
 package org.acme.restclient.multipart;
 
-public class MultipartResourceIT {
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class MultipartResourceIT extends MultipartResourceTest{
 }

--- a/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceTest.java
+++ b/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceTest.java
@@ -1,5 +1,6 @@
 package org.acme.restclient.multipart;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
@@ -7,6 +8,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
 @QuarkusTest
+@DisabledOnNativeImage("Because native port test does not use 8081 for tests")
 public class MultipartResourceTest {
 
     @Test


### PR DESCRIPTION
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
- [] links the documentation update pull request (if needed)
- [] updates or creates the `README.md` file (with build and run instructions)
- [] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


