### PR TITLE
Use HTTP test port if set in MP RestClient URL

### DIFF
--- a/rest-client-multipart-quickstart/src/main/resources/application.properties
+++ b/rest-client-multipart-quickstart/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-org.acme.restclient.multipart.MultipartService/mp-rest/url=http://localhost:8080/
-%test.org.acme.restclient.multipart.MultipartService/mp-rest/url=http://localhost:8081/
+org.acme.restclient.multipart.MultipartService/mp-rest/url=http://localhost:${quarkus.http.test-port:8080}/

--- a/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceTest.java
+++ b/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceTest.java
@@ -1,6 +1,5 @@
 package org.acme.restclient.multipart;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
@@ -8,7 +7,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
 @QuarkusTest
-@DisabledOnNativeImage("Because native port test does not use 8081 for tests")
 public class MultipartResourceTest {
 
     @Test


### PR DESCRIPTION
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


