### PR TITLE
security-jwt-quickstart code polish

### DIFF
--- a/security-jwt-quickstart/src/main/java/org/acme/jwt/LottoNumbersResource.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/jwt/LottoNumbersResource.java
@@ -20,8 +20,6 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 @Dependent
 public class LottoNumbersResource {
     @Inject
-    JsonWebToken jwt;
-    @Inject
     @Claim(standard = Claims.birthdate)
     Optional<JsonString> birthdate;
 

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceTest.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceTest.java
@@ -5,8 +5,6 @@ import java.net.HttpURLConnection;
 import java.util.HashMap;
 
 import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
 
 import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
@@ -101,8 +99,7 @@ public class TokenSecuredResourceTest {
 
         Assertions.assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode());
         String replyString = response.body().asString();
-        JsonReader jsonReader = Json.createReader(new StringReader(replyString));
-        JsonObject reply = jsonReader.readObject();
+        Json.createReader(new StringReader(replyString)).readObject();
         LottoNumbers numbers = response.as(LottoNumbers.class);
         Assertions.assertFalse(numbers.numbers.isEmpty());
     }

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenUtils.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenUtils.java
@@ -65,10 +65,11 @@ public class TokenUtils {
      * @throws Exception on decode failure
      */
     public static PrivateKey readPrivateKey(final String pemResName) throws Exception {
-        InputStream contentIS = TokenUtils.class.getResourceAsStream(pemResName);
-        byte[] tmp = new byte[4096];
-        int length = contentIS.read(tmp);
-        return decodePrivateKey(new String(tmp, 0, length, "UTF-8"));
+        try (InputStream contentIS = TokenUtils.class.getResourceAsStream(pemResName)) {
+            byte[] tmp = new byte[4096];
+            int length = contentIS.read(tmp);
+            return decodePrivateKey(new String(tmp, 0, length, "UTF-8"));
+        }
     }
 
     /**


### PR DESCRIPTION
security-jwt-quickstart code polish

 - removal of dead local store
 - auto-close of the stream

Checks:
- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
the rest of checkboxes is not applicable to this change