### PR TITLE
Update JVM dockerfile to use ubi

### DIFF
--- a/amqp-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amqp-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/amqp-quickstart-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/cache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/cache-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,21 +14,33 @@
 # docker run -i --rm -p 8080:8080 quarkus/cache-quickstart-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre:1.6.5
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 
-# Be prepared for running in OpenShift too
-RUN adduser -G root --no-create-home --disabled-password 1001 \
-  && chown -R 1001 /deployments \
-  && chmod -R "g+rwX" /deployments \
-  && chown -R 1001:root /deployments
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
 EXPOSE 8080
-
-# run with user 1001
 USER 1001
-
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/config-quickstart/src/main/docker/Dockerfile.jvm
+++ b/config-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/application-configuration-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/dynamodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/dynamodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/dynamodb-client-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
-ENTRYPOINT [ "/deployments/run-java.sh"]
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/getting-started-async/src/main/docker/Dockerfile.jvm
+++ b/getting-started-async/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-async-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/getting-started-testing/src/main/docker/Dockerfile.jvm
+++ b/getting-started-testing/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-testing-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/getting-started/src/main/docker/Dockerfile.jvm
+++ b/getting-started/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-panache-resteasy-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-resteasy-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/infinispan-client-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
-ENTRYPOINT [ "/deployments/run-java.sh -Dquarkus.infinispan-client.server-list=infinispan:11222"]
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh", "-Dquarkus.infinispan-client.server-list=infinispan:11222"]

--- a/jms-quickstart/src/main/docker/Dockerfile.jvm
+++ b/jms-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/artemis-jms-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/kafka-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/kafka-quickstart-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/kafka-streams-quickstart/aggregator/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/aggregator/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/kafka-streams-quickstart-producer-jvm
 #
 ###
-FROM fabric8/java-centos-openjdk8-jdk
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/kafka-streams-quickstart/producer/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/producer/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/kafka-streams-quickstart-producer-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/kogito-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kogito-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-kogito-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/application-lifecycle-events-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-fault-tolerance-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-health-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/microprofile-metrics-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-metrics-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-metrics-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/mongodb-panache-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/mongodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/mongo-client-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/mqtt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,8 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/mqtt-quickstart
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/neo4j-quickstart/src/main/docker/Dockerfile.jvm
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/neo4j-quickstart-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-openapi-swaggerui-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/opentracing-quickstart/src/main/docker/Dockerfile.jvm
+++ b/opentracing-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-opentracing-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/quartz-quickstart/src/main/docker/Dockerfile.jvm
+++ b/quartz-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/quartz-quickstart
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/qute-quickstart/src/main/docker/Dockerfile.jvm
+++ b/qute-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/application-qute-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/rest-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
+++ b/rest-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/rest-client-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/rest-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/rest-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/rest-client-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/rest-json-quickstart/src/main/docker/Dockerfile.jvm
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/rest-json-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/scheduler-quickstart/src/main/docker/Dockerfile.jvm
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/scheduling-periodic-tasks-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-elytron-security-jdbc-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-jwt-rbac-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-oauth2-rbac-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/spring-di-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-spring-di-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/spring-security-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,18 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/secured-spring-web-quickstart-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
-EXPOSE 8080
 
-# run with user 1001 and be prepared for be running in OpenShift too
-RUN adduser -G root --no-create-home --disabled-password 1001 \
-  && chown -R 1001 /deployments \
-  && chmod -R "g+rwX" /deployments \
-  && chown -R 1001:root /deployments
+EXPOSE 8080
 USER 1001
 
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/spring-web-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-spring-di-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-testing-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/tika-quickstart/src/main/docker/Dockerfile.jvm
+++ b/tika-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-apache-tika-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/validation-quickstart/src/main/docker/Dockerfile.jvm
+++ b/validation-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/validation-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/vertx-quickstart/src/main/docker/Dockerfile.jvm
+++ b/vertx-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-vertx-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/websockets-quickstart/src/main/docker/Dockerfile.jvm
+++ b/websockets-quickstart/src/main/docker/Dockerfile.jvm
@@ -14,9 +14,34 @@
 # docker run -i --rm -p 8080:8080 quarkus/using-websockets-jvm
 #
 ###
-FROM fabric8/java-alpine-openjdk8-jre
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV AB_ENABLED=jmx_exporter
+
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]


### PR DESCRIPTION
This PR updates the docker file of the quickstart (JVM mode) to follow the new template (UBI-based).