### PR TITLE
Create native "getting started" image without having to install GraalVM

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -72,7 +72,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw package -Pnative -Dquarkus.native.container-build=true
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 


### PR DESCRIPTION
"-Dquarkus.native.container-build=true" can be added to quarkus-maven-plugin for creating a native "getting started" image without the need to install GraalVM locally. Instead, docker image quay.io/quarkus/ubi-quarkus-native-image is used for as build image.
See https://quarkus.io/guides/building-native-image#quarkus-native-pkg-native-config_quarkus.native.container-build for details