### PR TITLE
Make sure the cron job runs all the tests

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Quickstart with native
         run: |
-          mvn -B clean install -Pnative \
+          mvn -B clean install --fail-at-end -Pnative \
             -Dquarkus.native.container-build=true \
             -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8 \
             -pl '!rest-client-quickstart'


### PR DESCRIPTION
We do this so the log output can tell us all the failing
quickstarts instead of just seeing the first failure