### PR TITLE
update s2i environment to work with the latest Java s2i

### DIFF
--- a/getting-started/.s2i/environment
+++ b/getting-started/.s2i/environment
@@ -1,5 +1,4 @@
-# ARTIFACT_COPY_ARGS is deprecated, but S2I_SOURCE_DEPLOYMENTS_FILTER does not actually work, see https://github.com/jboss-container-images/openjdk/issues/75
-
-ARTIFACT_COPY_ARGS=-p -r lib/ *-runner.jar
-
+MAVEN_S2I_ARTIFACT_DIRS=target
+S2I_SOURCE_DEPLOYMENTS_FILTER=*-runner.jar lib
 JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+AB_JOLOKIA_OFF=true


### PR DESCRIPTION
This removes the usage of a deprecated feature to copy the `lib` directory.