### PR TITLE
Change platform version to 1.2.0.Final

### DIFF
--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <quarkus-plugin.version>1.2.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.2.0.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Change platform version to 1.2.0.Final for spring-security-quickstart

Targets `master` on purpose

@gsmet / @cescoffier release procedure needs to be adjusted to cover version rewrite of Quarkus platform property