### PR TITLE
Fix imports and formatting according to Quarkus codestyle

### DIFF
--- a/amqp-quickstart/src/main/java/org/acme/quarkus/sample/PriceConverter.java
+++ b/amqp-quickstart/src/main/java/org/acme/quarkus/sample/PriceConverter.java
@@ -1,10 +1,11 @@
 package org.acme.quarkus.sample;
 
-import io.smallrye.reactive.messaging.annotations.Broadcast;
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
-import javax.enterprise.context.ApplicationScoped;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
 
 /**
  * A bean consuming data from the "prices" AMQP queue and applying some conversion.

--- a/amqp-quickstart/src/main/java/org/acme/quarkus/sample/PriceGenerator.java
+++ b/amqp-quickstart/src/main/java/org/acme/quarkus/sample/PriceGenerator.java
@@ -1,11 +1,13 @@
 package org.acme.quarkus.sample;
 
-import io.reactivex.Flowable;
-import org.eclipse.microprofile.reactive.messaging.Outgoing;
-
-import javax.enterprise.context.ApplicationScoped;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.reactivex.Flowable;
 
 /**
  * A bean producing random prices every 5 seconds.

--- a/amqp-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
+++ b/amqp-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
@@ -1,13 +1,14 @@
 package org.acme.quarkus.sample;
 
-import io.smallrye.reactive.messaging.annotations.Channel;
-import org.reactivestreams.Publisher;
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.reactive.messaging.annotations.Channel;
 
 /**
  * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
@@ -16,14 +17,14 @@ import javax.ws.rs.core.MediaType;
 public class PriceResource {
 
     @Inject
-    @Channel("my-data-stream") Publisher<Double> prices;
+    @Channel("my-data-stream")
+    Publisher<Double> prices;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
         return "hello";
     }
-
 
     @GET
     @Path("/stream")

--- a/cache-quickstart/src/main/java/org/acme/caching/WeatherForecastResource.java
+++ b/cache-quickstart/src/main/java/org/acme/caching/WeatherForecastResource.java
@@ -25,8 +25,7 @@ public class WeatherForecastResource {
         List<String> dailyForecasts = Arrays.asList(
                 service.getDailyForecast(LocalDate.now().plusDays(daysInFuture), city),
                 service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 1L), city),
-                service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 2L), city)
-        );
+                service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 2L), city));
         long executionEnd = System.currentTimeMillis();
         return new WeatherForecast(dailyForecasts, executionEnd - executionStart);
     }

--- a/cache-quickstart/src/test/java/org/acme/caching/WeatherForecastResourceTest.java
+++ b/cache-quickstart/src/test/java/org/acme/caching/WeatherForecastResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.caching;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class WeatherForecastResourceTest {
@@ -12,10 +13,10 @@ public class WeatherForecastResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/weather")
-          .then()
-             .statusCode(200)
-             .body(containsString("dailyForecasts"));
+                .when().get("/weather")
+                .then()
+                .statusCode(200)
+                .body(containsString("dailyForecasts"));
     }
 
 }

--- a/config-quickstart/src/main/java/org/acme/config/GreetingResource.java
+++ b/config-quickstart/src/main/java/org/acme/config/GreetingResource.java
@@ -15,12 +15,11 @@ public class GreetingResource {
     @ConfigProperty(name = "greeting.message")
     String message;
 
-    @ConfigProperty(name = "greeting.suffix", defaultValue="!")
+    @ConfigProperty(name = "greeting.suffix", defaultValue = "!")
     String suffix;
 
     @ConfigProperty(name = "greeting.name")
     Optional<String> name;
-
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/config-quickstart/src/test/java/org/acme/config/GreetingResourceTest.java
+++ b/config-quickstart/src/test/java/org/acme/config/GreetingResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.config;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingResourceTest {
@@ -12,10 +13,10 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/greeting")
-          .then()
-             .statusCode(200)
-             .body(is("hello quarkus!"));
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("hello quarkus!"));
     }
 
 }

--- a/getting-started-async/src/test/java/org/acme/quickstart/GreetingResourceTest.java
+++ b/getting-started-async/src/test/java/org/acme/quickstart/GreetingResourceTest.java
@@ -1,12 +1,13 @@
 package org.acme.quickstart;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.util.UUID;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingResourceTest {
@@ -14,21 +15,21 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Test
     public void testGreetingEndpoint() {
         String uuid = UUID.randomUUID().toString();
         given()
-          .pathParam("name", uuid)
-          .when().get("/hello/greeting/{name}")
-          .then()
-            .statusCode(200)
-            .body(is("hello " + uuid));
+                .pathParam("name", uuid)
+                .when().get("/hello/greeting/{name}")
+                .then()
+                .statusCode(200)
+                .body(is("hello " + uuid));
     }
 
 }

--- a/getting-started-knative/src/test/java/org/acme/quickstart/GreetingResourceTest.java
+++ b/getting-started-knative/src/test/java/org/acme/quickstart/GreetingResourceTest.java
@@ -1,12 +1,13 @@
 package org.acme.quickstart;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.util.UUID;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingResourceTest {
@@ -14,21 +15,21 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/")
-          .then()
-             .statusCode(200)  
-             .body(is("hello"));
+                .when().get("/")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Test
     public void testGreetingEndpoint() {
         String uuid = UUID.randomUUID().toString();
         given()
-          .pathParam("name", uuid)
-          .when().get("/greeting/{name}")
-          .then()
-            .statusCode(200)
-            .body(is("hello " + uuid));
+                .pathParam("name", uuid)
+                .when().get("/greeting/{name}")
+                .then()
+                .statusCode(200)
+                .body(is("hello " + uuid));
     }
 
 }

--- a/getting-started-testing/src/test/java/org/acme/quickstart/GreetingResourceTest.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/GreetingResourceTest.java
@@ -1,12 +1,13 @@
 package org.acme.quickstart;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.util.UUID;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingResourceTest {
@@ -14,20 +15,20 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)  
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Test
     public void testGreetingEndpoint() {
         String uuid = UUID.randomUUID().toString();
         given()
-          .pathParam("name", uuid)
-          .when().get("/hello/greeting/{name}")
-          .then()
-            .statusCode(200)
-            .body(is("hello " + uuid));
+                .pathParam("name", uuid)
+                .when().get("/hello/greeting/{name}")
+                .then()
+                .statusCode(200)
+                .body(is("hello " + uuid));
     }
 }

--- a/getting-started-testing/src/test/java/org/acme/quickstart/GreetingServiceTest.java
+++ b/getting-started-testing/src/test/java/org/acme/quickstart/GreetingServiceTest.java
@@ -2,10 +2,10 @@ package org.acme.quickstart;
 
 import javax.inject.Inject;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest

--- a/getting-started/src/main/java/org/acme/quickstart/GreetingResource.java
+++ b/getting-started/src/main/java/org/acme/quickstart/GreetingResource.java
@@ -1,6 +1,5 @@
 package org.acme.quickstart;
 
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/getting-started/src/test/java/org/acme/quickstart/GreetingResourceTest.java
+++ b/getting-started/src/test/java/org/acme/quickstart/GreetingResourceTest.java
@@ -1,12 +1,13 @@
 package org.acme.quickstart;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.util.UUID;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingResourceTest {
@@ -14,10 +15,10 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Test

--- a/hibernate-orm-panache-quickstart/src/test/java/org/acme/hibernate/orm/panache/FruitsEndpointTest.java
+++ b/hibernate-orm-panache-quickstart/src/test/java/org/acme/hibernate/orm/panache/FruitsEndpointTest.java
@@ -4,8 +4,9 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsNot.not;
 
-import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class FruitsEndpointTest {
@@ -14,32 +15,29 @@ public class FruitsEndpointTest {
     public void testListAllFruits() {
         //List all, should have all 3 fruits the database has initially:
         given()
-              .when().get("/fruits")
-              .then()
-              .statusCode(200)
-              .body(
-                    containsString("Cherry"),
-                    containsString("Apple"),
-                    containsString("Banana")
-                    );
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Cherry"),
+                        containsString("Apple"),
+                        containsString("Banana"));
 
         //Delete the Cherry:
         given()
-              .when().delete("/fruits/1")
-              .then()
-              .statusCode(204)
-              ;
+                .when().delete("/fruits/1")
+                .then()
+                .statusCode(204);
 
         //List all, cherry should be missing now:
         given()
-              .when().get("/fruits")
-              .then()
-              .statusCode(200)
-              .body(
-                    not( containsString("Cherry") ),
-                    containsString("Apple"),
-                    containsString("Banana")
-              );
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        not(containsString("Cherry")),
+                        containsString("Apple"),
+                        containsString("Banana"));
     }
 
 }

--- a/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
+++ b/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
@@ -13,18 +13,12 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "known_fruits")
-@NamedQuery(name = "Fruits.findAll",
-      query = "SELECT f FROM Fruit f ORDER BY f.name",
-      hints = @QueryHint(name = "org.hibernate.cacheable", value = "true") )
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
 @Cacheable
 public class Fruit {
 
     @Id
-    @SequenceGenerator(
-            name = "fruitsSequence",
-            sequenceName = "known_fruits_id_seq",
-            allocationSize = 1,
-            initialValue = 10)
+    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fruitsSequence")
     private Integer id;
 

--- a/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/FruitResource.java
+++ b/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/FruitResource.java
@@ -35,7 +35,7 @@ public class FruitResource {
     @GET
     public Fruit[] get() {
         return entityManager.createNamedQuery("Fruits.findAll", Fruit.class)
-              .getResultList().toArray(new Fruit[0]);
+                .getResultList().toArray(new Fruit[0]);
     }
 
     @GET
@@ -107,7 +107,7 @@ public class FruitResource {
                     .add("code", code);
 
             if (exception.getMessage() != null) {
-                    entityBuilder.add("error", exception.getMessage());
+                entityBuilder.add("error", exception.getMessage());
             }
 
             return Response.status(code)

--- a/hibernate-orm-quickstart/src/test/java/org/acme/hibernate/orm/FruitsEndpointTest.java
+++ b/hibernate-orm-quickstart/src/test/java/org/acme/hibernate/orm/FruitsEndpointTest.java
@@ -15,54 +15,49 @@ public class FruitsEndpointTest {
     public void testListAllFruits() {
         //List all, should have all 3 fruits the database has initially:
         given()
-              .when().get("/fruits")
-              .then()
-              .statusCode(200)
-              .body(
-                    containsString("Cherry"),
-                    containsString("Apple"),
-                    containsString("Banana")
-                    );
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Cherry"),
+                        containsString("Apple"),
+                        containsString("Banana"));
 
         //Delete the Cherry:
         given()
-              .when().delete("/fruits/1")
-              .then()
-              .statusCode(204)
-              ;
+                .when().delete("/fruits/1")
+                .then()
+                .statusCode(204);
 
         //List all, cherry should be missing now:
         given()
-              .when().get("/fruits")
-              .then()
-              .statusCode(200)
-              .body(
-                    not( containsString("Cherry") ),
-                    containsString("Apple"),
-                    containsString("Banana")
-              );
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        not(containsString("Cherry")),
+                        containsString("Apple"),
+                        containsString("Banana"));
 
         //Create the Pear:
         given()
-              .when()
-                  .body("{\"name\" : \"Pear\"}")
-                  .contentType("application/json")
-                  .post("/fruits")
-              .then()
-                  .statusCode(201)
-              ;
+                .when()
+                .body("{\"name\" : \"Pear\"}")
+                .contentType("application/json")
+                .post("/fruits")
+                .then()
+                .statusCode(201);
 
         //List all, cherry should be missing now:
         given()
-              .when().get("/fruits")
-              .then()
-              .statusCode(200)
-              .body(
-                    not( containsString("Cherry") ),
-                    containsString("Apple"),
-                    containsString("Banana"),
-                    containsString("Pear")
-              );
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        not(containsString("Cherry")),
+                        containsString("Apple"),
+                        containsString("Banana"),
+                        containsString("Pear"));
     }
 
 }

--- a/hibernate-search-elasticsearch-quickstart/src/main/java/org/acme/hibernate/search/elasticsearch/LibraryResource.java
+++ b/hibernate-search-elasticsearch-quickstart/src/main/java/org/acme/hibernate/search/elasticsearch/LibraryResource.java
@@ -115,12 +115,9 @@ public class LibraryResource {
             @QueryParam Optional<Integer> size) {
         List<Author> authors = Search.session(em)
                 .search(Author.class)
-                .predicate(f ->
-                    pattern == null || pattern.trim().isEmpty() ?
-                            f.matchAll() :
-                            f.simpleQueryString()
-                                .fields("firstName", "lastName", "books.title").matching(pattern)
-                )
+                .predicate(f -> pattern == null || pattern.trim().isEmpty() ? f.matchAll()
+                        : f.simpleQueryString()
+                                .fields("firstName", "lastName", "books.title").matching(pattern))
                 .sort(f -> f.field("lastName_sort").then().field("firstName_sort"))
                 .fetchHits(size.orElse(20));
         return authors;

--- a/hibernate-search-elasticsearch-quickstart/src/test/java/org/acme/hibernate/search/elasticsearch/service/LibraryResourceInGraalIT.java
+++ b/hibernate-search-elasticsearch-quickstart/src/test/java/org/acme/hibernate/search/elasticsearch/service/LibraryResourceInGraalIT.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.acme.hibernate.search.elasticsearch.service;
+
 /*
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +29,6 @@ package org.acme.hibernate.search.elasticsearch.service;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest

--- a/infinispan-client-quickstart/src/main/java/org/acme/infinispanclient/InfinispanClientApp.java
+++ b/infinispan-client-quickstart/src/main/java/org/acme/infinispanclient/InfinispanClientApp.java
@@ -6,7 +6,6 @@ import javax.inject.Inject;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.commons.api.CacheContainerAdmin;
 import org.infinispan.commons.configuration.XMLStringConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,19 +15,19 @@ import io.quarkus.runtime.StartupEvent;
 @ApplicationScoped
 public class InfinispanClientApp {
 
-   private static final Logger LOGGER = LoggerFactory.getLogger("InfinispanClientApp");
+    private static final Logger LOGGER = LoggerFactory.getLogger("InfinispanClientApp");
 
-   @Inject
-   RemoteCacheManager cacheManager;
+    @Inject
+    RemoteCacheManager cacheManager;
 
-   private static final String CACHE_CONFIG =
-         "<infinispan><cache-container>" +
-               "<distributed-cache name=\"%s\"></distributed-cache>" +
-               "</cache-container></infinispan>";
+    private static final String CACHE_CONFIG = "<infinispan><cache-container>" +
+            "<distributed-cache name=\"%s\"></distributed-cache>" +
+            "</cache-container></infinispan>";
 
-   void onStart(@Observes StartupEvent ev) {
-      LOGGER.info("Create or get cache named mycache with the default configuration");
-      RemoteCache<Object, Object> cache = cacheManager.administration().getOrCreateCache("mycache", new XMLStringConfiguration(String.format(CACHE_CONFIG, "mycache")));
-      cache.put("hello", "Hello World, Infinispan is up!");
-   }
+    void onStart(@Observes StartupEvent ev) {
+        LOGGER.info("Create or get cache named mycache with the default configuration");
+        RemoteCache<Object, Object> cache = cacheManager.administration().getOrCreateCache("mycache",
+                new XMLStringConfiguration(String.format(CACHE_CONFIG, "mycache")));
+        cache.put("hello", "Hello World, Infinispan is up!");
+    }
 }

--- a/infinispan-client-quickstart/src/main/java/org/acme/infinispanclient/InfinispanGreetingResource.java
+++ b/infinispan-client-quickstart/src/main/java/org/acme/infinispanclient/InfinispanGreetingResource.java
@@ -13,13 +13,13 @@ import io.quarkus.infinispan.client.Remote;
 @Path("/infinispan")
 public class InfinispanGreetingResource {
 
-   @Inject
-   @Remote("mycache")
-   RemoteCache<String, String> cache;
+    @Inject
+    @Remote("mycache")
+    RemoteCache<String, String> cache;
 
-   @GET
-   @Produces(MediaType.TEXT_PLAIN)
-   public String hello() {
-      return cache.get("hello");
-   }
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return cache.get("hello");
+    }
 }

--- a/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceConverter.java
+++ b/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceConverter.java
@@ -1,10 +1,11 @@
 package org.acme.quarkus.sample;
 
-import io.smallrye.reactive.messaging.annotations.Broadcast;
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
-import javax.enterprise.context.ApplicationScoped;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
 
 /**
  * A bean consuming data from the "prices" Kafka topic and applying some conversion.

--- a/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceGenerator.java
+++ b/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceGenerator.java
@@ -1,11 +1,13 @@
 package org.acme.quarkus.sample;
 
-import io.reactivex.Flowable;
-import org.eclipse.microprofile.reactive.messaging.Outgoing;
-
-import javax.enterprise.context.ApplicationScoped;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.reactivex.Flowable;
 
 /**
  * A bean producing random prices every 5 seconds.

--- a/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
+++ b/kafka-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
@@ -1,14 +1,15 @@
 package org.acme.quarkus.sample;
 
-import io.smallrye.reactive.messaging.annotations.Channel;
-import org.jboss.resteasy.annotations.SseElementType;
-import org.reactivestreams.Publisher;
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.SseElementType;
+import org.reactivestreams.Publisher;
+
+import io.smallrye.reactive.messaging.annotations.Channel;
 
 /**
  * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
@@ -17,7 +18,8 @@ import javax.ws.rs.core.MediaType;
 public class PriceResource {
 
     @Inject
-    @Channel("my-data-stream") Publisher<Double> prices;
+    @Channel("my-data-stream")
+    Publisher<Double> prices;
 
     @GET
     @Path("/stream")

--- a/kafka-streams-quickstart/aggregator/src/main/java/org/acme/quarkus/sample/kafkastreams/rest/WeatherStationEndpoint.java
+++ b/kafka-streams-quickstart/aggregator/src/main/java/org/acme/quarkus/sample/kafkastreams/rest/WeatherStationEndpoint.java
@@ -35,12 +35,10 @@ public class WeatherStationEndpoint {
 
         if (result.getResult().isPresent()) {
             return Response.ok(result.getResult().get()).build();
-        }
-        else if (result.getHost().isPresent()) {
+        } else if (result.getHost().isPresent()) {
             URI otherUri = getOtherUri(result.getHost().get(), result.getPort().getAsInt(), id);
             return Response.seeOther(otherUri).build();
-        }
-        else {
+        } else {
             return Response.status(Status.NOT_FOUND.getStatusCode(), "No data found for weather station " + id).build();
         }
     }
@@ -55,8 +53,7 @@ public class WeatherStationEndpoint {
     private URI getOtherUri(String host, int port, int id) {
         try {
             return new URI("http://" + host + ":" + port + "/weather-stations/data/" + id);
-        }
-        catch (URISyntaxException e) {
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }

--- a/kafka-streams-quickstart/aggregator/src/main/java/org/acme/quarkus/sample/kafkastreams/streams/InteractiveQueries.java
+++ b/kafka-streams-quickstart/aggregator/src/main/java/org/acme/quarkus/sample/kafkastreams/streams/InteractiveQueries.java
@@ -24,7 +24,7 @@ public class InteractiveQueries {
 
     private static final Logger LOG = LoggerFactory.getLogger(InteractiveQueries.class);
 
-    @ConfigProperty(name="hostname")
+    @ConfigProperty(name = "hostname")
     String host;
 
     @Inject
@@ -36,10 +36,9 @@ public class InteractiveQueries {
                 .map(m -> new PipelineMetadata(
                         m.hostInfo().host() + ":" + m.hostInfo().port(),
                         m.topicPartitions()
-                            .stream()
-                            .map(TopicPartition::toString)
-                            .collect(Collectors.toSet()))
-                )
+                                .stream()
+                                .map(TopicPartition::toString)
+                                .collect(Collectors.toSet())))
                 .collect(Collectors.toList());
     }
 
@@ -47,25 +46,21 @@ public class InteractiveQueries {
         StreamsMetadata metadata = streams.metadataForKey(
                 TopologyProducer.WEATHER_STATIONS_STORE,
                 id,
-                Serdes.Integer().serializer()
-        );
+                Serdes.Integer().serializer());
 
         if (metadata == null || metadata == StreamsMetadata.NOT_AVAILABLE) {
             LOG.warn("Found no metadata for key {}", id);
             return GetWeatherStationDataResult.notFound();
-        }
-        else if (metadata.host().equals(host)) {
+        } else if (metadata.host().equals(host)) {
             LOG.info("Found data for key {} locally", id);
             Aggregation result = getWeatherStationStore().get(id);
 
             if (result != null) {
                 return GetWeatherStationDataResult.found(WeatherStationData.from(result));
-            }
-            else {
+            } else {
                 return GetWeatherStationDataResult.notFound();
             }
-        }
-        else {
+        } else {
             LOG.info("Found data for key {} on remote host {}:{}", id, metadata.host(), metadata.port());
             return GetWeatherStationDataResult.foundRemotely(metadata.host(), metadata.port());
         }

--- a/kafka-streams-quickstart/aggregator/src/main/java/org/acme/quarkus/sample/kafkastreams/streams/TopologyProducer.java
+++ b/kafka-streams-quickstart/aggregator/src/main/java/org/acme/quarkus/sample/kafkastreams/streams/TopologyProducer.java
@@ -43,30 +43,27 @@ public class TopologyProducer {
                 Consumed.with(Serdes.Integer(), weatherStationSerde));
 
         builder.stream(
-                        TEMPERATURE_VALUES_TOPIC,
-                        Consumed.with(Serdes.Integer(), Serdes.String())
-                )
+                TEMPERATURE_VALUES_TOPIC,
+                Consumed.with(Serdes.Integer(), Serdes.String()))
                 .join(
                         stations,
                         (stationId, timestampAndValue) -> stationId,
                         (timestampAndValue, station) -> {
                             String[] parts = timestampAndValue.split(";");
-                            return new TemperatureMeasurement(station.id, station.name, Instant.parse(parts[0]), Double.valueOf(parts[1]));
-                        }
-                )
+                            return new TemperatureMeasurement(station.id, station.name, Instant.parse(parts[0]),
+                                    Double.valueOf(parts[1]));
+                        })
                 .groupByKey()
                 .aggregate(
                         Aggregation::new,
                         (stationId, value, aggregation) -> aggregation.updateFrom(value),
                         Materialized.<Integer, Aggregation> as(storeSupplier)
-                            .withKeySerde(Serdes.Integer())
-                            .withValueSerde(aggregationSerde)
-                )
+                                .withKeySerde(Serdes.Integer())
+                                .withValueSerde(aggregationSerde))
                 .toStream()
                 .to(
                         TEMPERATURES_AGGREGATED_TOPIC,
-                        Produced.with(Serdes.Integer(), aggregationSerde)
-                );
+                        Produced.with(Serdes.Integer(), aggregationSerde));
 
         return builder.build();
     }

--- a/kafka-streams-quickstart/producer/src/main/java/org/acme/quarkus/sample/generator/ValuesGenerator.java
+++ b/kafka-streams-quickstart/producer/src/main/java/org/acme/quarkus/sample/generator/ValuesGenerator.java
@@ -42,9 +42,7 @@ public class ValuesGenerator {
                     new WeatherStation(6, "Svalbard", -7),
                     new WeatherStation(7, "Porthsmouth", 11),
                     new WeatherStation(8, "Oslo", 7),
-                    new WeatherStation(9, "Marrakesh", 20)
-            ));
-
+                    new WeatherStation(9, "Marrakesh", 20)));
 
     @Outgoing("temperature-values")
     public Flowable<KafkaMessage<Integer, String>> generate() {
@@ -65,8 +63,8 @@ public class ValuesGenerator {
     @Outgoing("weather-stations")
     public Flowable<KafkaMessage<Integer, String>> weatherStations() {
         List<KafkaMessage<Integer, String>> stationsAsJson = stations.stream()
-            .map(s -> KafkaMessage.of(s.id, "{ \"id\" : " + s.id + ", \"name\" : \"" + s.name + "\" }"))
-            .collect(Collectors.toList());
+                .map(s -> KafkaMessage.of(s.id, "{ \"id\" : " + s.id + ", \"name\" : \"" + s.name + "\" }"))
+                .collect(Collectors.toList());
 
         return Flowable.fromIterable(stationsAsJson);
     };

--- a/kogito-quickstart/src/main/java/org/acme/kogito/model/Person.java
+++ b/kogito-quickstart/src/main/java/org/acme/kogito/model/Person.java
@@ -1,40 +1,38 @@
 package org.acme.kogito.model;
 
-import java.io.Serializable;
-
 public class Person {
 
-	private String name;
-	private int age;
-	private boolean adult;
+    private String name;
+    private int age;
+    private boolean adult;
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public int getAge() {
-		return age;
-	}
+    public int getAge() {
+        return age;
+    }
 
-	public void setAge(int age) {
-		this.age = age;
-	}
+    public void setAge(int age) {
+        this.age = age;
+    }
 
-	public boolean isAdult() {
-		return adult;
-	}
+    public boolean isAdult() {
+        return adult;
+    }
 
-	public void setAdult(boolean adult) {
-		this.adult = adult;
-	}
+    public void setAdult(boolean adult) {
+        this.adult = adult;
+    }
 
-	@Override
-	public String toString() {
-		return "Person [name=" + name + ", age=" + age + ", adult=" + adult + "]";
-	}
+    @Override
+    public String toString() {
+        return "Person [name=" + name + ", age=" + age + ", adult=" + adult + "]";
+    }
 
 }

--- a/kogito-quickstart/src/test/java/org/acme/kogito/PersonProcessTest.java
+++ b/kogito-quickstart/src/test/java/org/acme/kogito/PersonProcessTest.java
@@ -20,24 +20,24 @@ public class PersonProcessTest {
     @Test
     public void testAdult() {
         given()
-               .body("{\"person\": {\"name\":\"John Quark\", \"age\": 20}}")
-               .contentType(ContentType.JSON)
-          .when()
-               .post("/persons")
-          .then()
-             .statusCode(200)
-             .body("person.adult", is(true));
+                .body("{\"person\": {\"name\":\"John Quark\", \"age\": 20}}")
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/persons")
+                .then()
+                .statusCode(200)
+                .body("person.adult", is(true));
     }
 
     @Test
     public void testChild() {
         given()
-               .body("{\"person\": {\"name\":\"Jenny Quark\", \"age\": 15}}")
-               .contentType(ContentType.JSON)
-          .when()
-               .post("/persons")
-          .then()
-             .statusCode(200)
-             .body("person.adult", is(false));
+                .body("{\"person\": {\"name\":\"Jenny Quark\", \"age\": 15}}")
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/persons")
+                .then()
+                .statusCode(200)
+                .body("person.adult", is(false));
     }
 }

--- a/lifecycle-quickstart/src/main/java/org/acme/events/AppLifecycleBean.java
+++ b/lifecycle-quickstart/src/main/java/org/acme/events/AppLifecycleBean.java
@@ -4,10 +4,11 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import io.quarkus.runtime.ShutdownEvent;
-import io.quarkus.runtime.StartupEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
 
 @ApplicationScoped
 public class AppLifecycleBean {

--- a/lifecycle-quickstart/src/test/java/org/acme/events/GreetingResourceTest.java
+++ b/lifecycle-quickstart/src/test/java/org/acme/events/GreetingResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.events;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingResourceTest {
@@ -12,10 +13,10 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
 }

--- a/microprofile-fault-tolerance-quickstart/src/main/java/org/acme/faulttolerance/CoffeeRepositoryService.java
+++ b/microprofile-fault-tolerance-quickstart/src/main/java/org/acme/faulttolerance/CoffeeRepositoryService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
@@ -22,7 +23,6 @@ public class CoffeeRepositoryService {
     private Map<Integer, Integer> availability = new HashMap<>();
 
     private AtomicLong counter = new AtomicLong(0);
-
 
     public CoffeeRepositoryService() {
         coffeeList.put(1, new Coffee(1, "Fernandez Espresso", "Colombia", 23));

--- a/microprofile-fault-tolerance-quickstart/src/main/java/org/acme/faulttolerance/CoffeeResource.java
+++ b/microprofile-fault-tolerance-quickstart/src/main/java/org/acme/faulttolerance/CoffeeResource.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -138,7 +139,6 @@ public class CoffeeResource {
         // safe bet, return something that everybody likes
         return Collections.singletonList(coffeeRepository.getCoffeeById(1));
     }
-
 
     private void maybeFail(String failureLogMessage) {
         // introduce some artificial failures

--- a/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/faulttolerance/CoffeeResourceTest.java
+++ b/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/faulttolerance/CoffeeResourceTest.java
@@ -8,10 +8,11 @@ import static org.hamcrest.core.StringContains.containsString;
 
 import javax.inject.Inject;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
-import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class CoffeeResourceTest {

--- a/microprofile-health-quickstart/src/main/java/org/acme/health/DataHealthCheck.java
+++ b/microprofile-health-quickstart/src/main/java/org/acme/health/DataHealthCheck.java
@@ -1,10 +1,10 @@
 package org.acme.health;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
-
-import javax.enterprise.context.ApplicationScoped;
 
 @Liveness
 @ApplicationScoped
@@ -13,9 +13,9 @@ public class DataHealthCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         return HealthCheckResponse.named("Health check with data")
-            .up()
-            .withData("foo", "fooValue")
-            .withData("bar", "barValue")
-            .build();
+                .up()
+                .withData("foo", "fooValue")
+                .withData("bar", "barValue")
+                .build();
     }
 }

--- a/microprofile-health-quickstart/src/main/java/org/acme/health/DatabaseConnectionHealthCheck.java
+++ b/microprofile-health-quickstart/src/main/java/org/acme/health/DatabaseConnectionHealthCheck.java
@@ -1,12 +1,12 @@
 package org.acme.health;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
-
-import javax.enterprise.context.ApplicationScoped;
 
 @Readiness
 @ApplicationScoped
@@ -26,7 +26,7 @@ public class DatabaseConnectionHealthCheck implements HealthCheck {
         } catch (IllegalStateException e) {
             // cannot access the database
             responseBuilder.down()
-                .withData("error", e.getMessage()); // pass the exception message
+                    .withData("error", e.getMessage()); // pass the exception message
         }
 
         return responseBuilder.build();

--- a/microprofile-health-quickstart/src/main/java/org/acme/health/SimpleHealthCheck.java
+++ b/microprofile-health-quickstart/src/main/java/org/acme/health/SimpleHealthCheck.java
@@ -1,10 +1,10 @@
 package org.acme.health;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
-
-import javax.enterprise.context.ApplicationScoped;
 
 @Liveness
 @ApplicationScoped

--- a/microprofile-health-quickstart/src/test/java/org/acme/health/HealthCheckTest.java
+++ b/microprofile-health-quickstart/src/test/java/org/acme/health/HealthCheckTest.java
@@ -1,12 +1,13 @@
 package org.acme.health;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class HealthCheckTest {
@@ -14,17 +15,17 @@ public class HealthCheckTest {
     @Test
     public void testHealthCheck() {
         given()
-        .when()
-            .get("/health/live")
-        .then()
-            .statusCode(200)
-            .body("status", is("UP"))
-            .body("checks.size()", is(2))
+                .when()
+                .get("/health/live")
+                .then()
+                .statusCode(200)
+                .body("status", is("UP"))
+                .body("checks.size()", is(2))
                 .body("checks.name", everyItem(anyOf(
-                    is("Simple health check"),
-                    is("Health check with data"))))
+                        is("Simple health check"),
+                        is("Health check with data"))))
                 .body("checks.status", everyItem(is("UP")))
-                    .body("checks.data.foo[0]", is("fooValue"))
-                    .body("checks.data.bar[0]", is("barValue"));
+                .body("checks.data.foo[0]", is("fooValue"))
+                .body("checks.data.bar[0]", is("barValue"));
     }
 }

--- a/microprofile-metrics-quickstart/src/main/java/org/acme/metrics/PrimeNumberChecker.java
+++ b/microprofile-metrics-quickstart/src/main/java/org/acme/metrics/PrimeNumberChecker.java
@@ -1,14 +1,14 @@
 package org.acme.metrics;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 
 @Path("/")
 public class PrimeNumberChecker {

--- a/microprofile-metrics-quickstart/src/test/java/org/acme/metrics/PrimeNumberCheckerTest.java
+++ b/microprofile-metrics-quickstart/src/test/java/org/acme/metrics/PrimeNumberCheckerTest.java
@@ -1,12 +1,13 @@
 package org.acme.metrics;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.http.Header;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.Header;
 
 @QuarkusTest
 public class PrimeNumberCheckerTest {
@@ -22,7 +23,6 @@ public class PrimeNumberCheckerTest {
         get("/900");
         assertMetricValue("org.acme.metrics.PrimeNumberChecker.highestPrimeNumberSoFar", 887);
     }
-
 
     private void assertMetricValue(String metric, Object value) {
         given().header(new Header("Accept", "application/json"))

--- a/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/Person.java
+++ b/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/Person.java
@@ -1,13 +1,14 @@
 package org.acme.mongodb.panache;
 
-import io.quarkus.mongodb.panache.MongoEntity;
-import io.quarkus.mongodb.panache.PanacheMongoEntity;
-import org.bson.codecs.pojo.annotations.BsonProperty;
-
 import java.time.LocalDate;
 import java.util.List;
 
-@MongoEntity(collection="ThePerson")
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+import io.quarkus.mongodb.panache.MongoEntity;
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+
+@MongoEntity(collection = "ThePerson")
 public class Person extends PanacheMongoEntity {
     public String name;
 
@@ -18,25 +19,25 @@ public class Person extends PanacheMongoEntity {
     public Status status;
 
     // return name as uppercase in the model
-    public String getName(){
+    public String getName() {
         return name.toUpperCase();
     }
 
     // store all names in lowercase in the DB
-    public void setName(String name){
+    public void setName(String name) {
         this.name = name.toLowerCase();
     }
 
     // entity methods
-    public static Person findByName(String name){
+    public static Person findByName(String name) {
         return find("name", name).firstResult();
     }
 
-    public static List<Person> findAlive(){
+    public static List<Person> findAlive() {
         return list("status", Status.LIVING);
     }
 
-    public static void deleteLoics(){
+    public static void deleteLoics() {
         delete("name", "Loïc");
     }
 }

--- a/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/PersonResource.java
+++ b/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/PersonResource.java
@@ -1,5 +1,7 @@
 package org.acme.mongodb.panache;
 
+import java.util.List;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -9,51 +11,50 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.List;
 
 @Path("/persons")
 @Consumes("application/json")
 @Produces("application/json")
 public class PersonResource {
     @GET
-    public List<Person> list(){
+    public List<Person> list() {
         return Person.listAll();
     }
 
     @GET
     @Path("/{id}")
-    public Person get(String id){
+    public Person get(String id) {
         return Person.findById(id);
     }
 
     @POST
-    public Response create(Person person){
+    public Response create(Person person) {
         person.persist();
         return Response.status(201).build();
     }
 
     @PUT
     @Path("/{id}")
-    public void update(@PathParam("id") String id, Person person){
+    public void update(@PathParam("id") String id, Person person) {
         person.update();
     }
 
     @DELETE
     @Path("/{id}")
-    public void delete(String id){
+    public void delete(String id) {
         Person person = Person.findById(id);
         person.delete();
     }
 
     @GET
     @Path("/search/{name}")
-    public Person search(String name){
+    public Person search(String name) {
         return Person.findByName(name);
     }
 
     @GET
     @Path("/count")
-    public Long count(){
+    public Long count() {
         return Person.count();
     }
 }

--- a/mongodb-quickstart/src/main/java/org/acme/rest/json/CodecFruitService.java
+++ b/mongodb-quickstart/src/main/java/org/acme/rest/json/CodecFruitService.java
@@ -1,20 +1,22 @@
 package org.acme.rest.json;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
-
 @ApplicationScoped
 public class CodecFruitService {
 
-    @Inject MongoClient mongoClient;
+    @Inject
+    MongoClient mongoClient;
 
-    public List<Fruit> list(){
+    public List<Fruit> list() {
         List<Fruit> list = new ArrayList<>();
         MongoCursor<Fruit> cursor = getCollection().find().iterator();
 
@@ -28,11 +30,11 @@ public class CodecFruitService {
         return list;
     }
 
-    public void add(Fruit fruit){
+    public void add(Fruit fruit) {
         getCollection().insertOne(fruit);
     }
 
-    private MongoCollection<Fruit> getCollection(){
+    private MongoCollection<Fruit> getCollection() {
         return mongoClient.getDatabase("fruit").getCollection("fruit", Fruit.class);
     }
 }

--- a/mongodb-quickstart/src/main/java/org/acme/rest/json/Fruit.java
+++ b/mongodb-quickstart/src/main/java/org/acme/rest/json/Fruit.java
@@ -48,11 +48,11 @@ public class Fruit {
         return Objects.hash(this.name);
     }
 
-	public void setId(String id) {
+    public void setId(String id) {
         this.id = id;
-	}
+    }
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 }

--- a/mongodb-quickstart/src/main/java/org/acme/rest/json/FruitResource.java
+++ b/mongodb-quickstart/src/main/java/org/acme/rest/json/FruitResource.java
@@ -15,7 +15,8 @@ import javax.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public class FruitResource {
 
-    @Inject FruitService fruitService;
+    @Inject
+    FruitService fruitService;
 
     @GET
     public List<Fruit> list() {

--- a/mongodb-quickstart/src/main/java/org/acme/rest/json/FruitService.java
+++ b/mongodb-quickstart/src/main/java/org/acme/rest/json/FruitService.java
@@ -1,21 +1,24 @@
 package org.acme.rest.json;
 
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
-import org.bson.Document;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
+
+import org.bson.Document;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 
 @ApplicationScoped
 public class FruitService {
 
-    @Inject MongoClient mongoClient;
+    @Inject
+    MongoClient mongoClient;
 
-    public List<Fruit> list(){
+    public List<Fruit> list() {
         List<Fruit> list = new ArrayList<>();
         MongoCursor<Document> cursor = getCollection().find().iterator();
 
@@ -33,14 +36,14 @@ public class FruitService {
         return list;
     }
 
-    public void add(Fruit fruit){
+    public void add(Fruit fruit) {
         Document document = new Document()
                 .append("name", fruit.getName())
                 .append("description", fruit.getDescription());
         getCollection().insertOne(document);
     }
 
-    private MongoCollection getCollection(){
+    private MongoCollection getCollection() {
         return mongoClient.getDatabase("fruit").getCollection("fruit");
     }
 }

--- a/mongodb-quickstart/src/main/java/org/acme/rest/json/ReactiveFruitResource.java
+++ b/mongodb-quickstart/src/main/java/org/acme/rest/json/ReactiveFruitResource.java
@@ -1,19 +1,19 @@
 package org.acme.rest.json;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 @Path("/reactive_fruits")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ReactiveFruitResource {
 
-    @Inject ReactiveFruitService fruitService;
-
+    @Inject
+    ReactiveFruitService fruitService;
 
     @GET
     public CompletionStage<List<Fruit>> list() {
@@ -21,7 +21,7 @@ public class ReactiveFruitResource {
     }
 
     @POST
-    public CompletionStage<List<Fruit>>  add(Fruit fruit) {
+    public CompletionStage<List<Fruit>> add(Fruit fruit) {
         return fruitService.add(fruit).thenCompose(x -> list());
     }
 }

--- a/mongodb-quickstart/src/main/java/org/acme/rest/json/ReactiveFruitService.java
+++ b/mongodb-quickstart/src/main/java/org/acme/rest/json/ReactiveFruitService.java
@@ -1,13 +1,15 @@
 package org.acme.rest.json;
 
-import io.quarkus.mongodb.ReactiveMongoClient;
-import io.quarkus.mongodb.ReactiveMongoCollection;
-import org.bson.Document;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
+
+import org.bson.Document;
+
+import io.quarkus.mongodb.ReactiveMongoClient;
+import io.quarkus.mongodb.ReactiveMongoCollection;
 
 @ApplicationScoped
 public class ReactiveFruitService {
@@ -15,7 +17,7 @@ public class ReactiveFruitService {
     @Inject
     ReactiveMongoClient mongoClient;
 
-    public CompletionStage<List<Fruit>> list(){
+    public CompletionStage<List<Fruit>> list() {
         return getCollection().find().map(doc -> {
             Fruit fruit = new Fruit();
             fruit.setName(doc.getString("name"));
@@ -24,14 +26,14 @@ public class ReactiveFruitService {
         }).toList().run();
     }
 
-    public CompletionStage<Void> add(Fruit fruit){
+    public CompletionStage<Void> add(Fruit fruit) {
         Document document = new Document()
                 .append("name", fruit.getName())
                 .append("description", fruit.getDescription());
         return getCollection().insertOne(document);
     }
 
-    private ReactiveMongoCollection<Document> getCollection(){
+    private ReactiveMongoCollection<Document> getCollection() {
         return mongoClient.getDatabase("fruit").getCollection("fruit");
     }
 }

--- a/mongodb-quickstart/src/main/java/org/acme/rest/json/codec/FruitCodec.java
+++ b/mongodb-quickstart/src/main/java/org/acme/rest/json/codec/FruitCodec.java
@@ -1,6 +1,7 @@
 package org.acme.rest.json.codec;
 
-import com.mongodb.MongoClientSettings;
+import java.util.UUID;
+
 import org.acme.rest.json.Fruit;
 import org.bson.*;
 import org.bson.codecs.Codec;
@@ -8,7 +9,7 @@ import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
-import java.util.UUID;
+import com.mongodb.MongoClientSettings;
 
 public class FruitCodec implements CollectibleCodec<Fruit> {
 

--- a/mqtt-quickstart/src/main/java/org/acme/quarkus/sample/PriceConverter.java
+++ b/mqtt-quickstart/src/main/java/org/acme/quarkus/sample/PriceConverter.java
@@ -1,10 +1,11 @@
 package org.acme.quarkus.sample;
 
-import io.smallrye.reactive.messaging.annotations.Broadcast;
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
-import javax.enterprise.context.ApplicationScoped;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
 
 /**
  * A bean consuming data from the "prices" MQTT topic and applying some conversion.

--- a/mqtt-quickstart/src/main/java/org/acme/quarkus/sample/PriceGenerator.java
+++ b/mqtt-quickstart/src/main/java/org/acme/quarkus/sample/PriceGenerator.java
@@ -1,11 +1,13 @@
 package org.acme.quarkus.sample;
 
-import io.reactivex.Flowable;
-import org.eclipse.microprofile.reactive.messaging.Outgoing;
-
-import javax.enterprise.context.ApplicationScoped;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.reactivex.Flowable;
 
 /**
  * A bean producing random prices every 5 seconds.

--- a/mqtt-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
+++ b/mqtt-quickstart/src/main/java/org/acme/quarkus/sample/PriceResource.java
@@ -1,13 +1,14 @@
 package org.acme.quarkus.sample;
 
-import io.smallrye.reactive.messaging.annotations.Channel;
-import org.reactivestreams.Publisher;
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.reactive.messaging.annotations.Channel;
 
 /**
  * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
@@ -16,7 +17,8 @@ import javax.ws.rs.core.MediaType;
 public class PriceResource {
 
     @Inject
-    @Channel("my-data-stream") Publisher<Double> prices;
+    @Channel("my-data-stream")
+    Publisher<Double> prices;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/mqtt-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
+++ b/mqtt-quickstart/src/test/java/org/acme/quarkus/sample/PriceResourceTest.java
@@ -1,19 +1,21 @@
 package org.acme.quarkus.sample;
 
-import io.quarkus.test.common.http.TestHTTPResource;
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.sse.SseEventSource;
-import java.net.URI;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class PriceResourceTest {
@@ -24,10 +26,10 @@ public class PriceResourceTest {
     @Test
     public void shouldGetHello() {
         given()
-              .when().get("/prices")
-              .then()
-              .statusCode(200)
-              .body(is("hello"));
+                .when().get("/prices")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Test
@@ -44,7 +46,7 @@ public class PriceResourceTest {
                 priceCount.incrementAndGet();
             });
             source.open();
-            Thread.sleep(15*1000L);
+            Thread.sleep(15 * 1000L);
         } catch (InterruptedException ignored) {
         }
 

--- a/neo4j-quickstart/src/main/java/org/acme/neo4j/Fruit.java
+++ b/neo4j-quickstart/src/main/java/org/acme/neo4j/Fruit.java
@@ -8,7 +8,7 @@ public class Fruit {
 
     public String name;
 
-    public static Fruit from(Node node) {        
+    public static Fruit from(Node node) {
         return new Fruit(node.id(), node.get("name").asString());
     }
 

--- a/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
+++ b/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
@@ -25,7 +25,7 @@ public class ReactiveFruitResource {
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public Publisher<String> get() {
-        return Flux.using(driver::rxSession, session -> session.readTransaction(tx -> {            
+        return Flux.using(driver::rxSession, session -> session.readTransaction(tx -> {
             RxResult result = tx.run("MATCH (f:Fruit) RETURN f.name as name ORDER BY f.name");
             return Flux.from(result.records()).map(record -> record.get("name").asString());
         }), RxSession::close);

--- a/openapi-swaggerui-quickstart/src/main/java/org/acme/openapi/swaggerui/FruitResource.java
+++ b/openapi-swaggerui-quickstart/src/main/java/org/acme/openapi/swaggerui/FruitResource.java
@@ -1,10 +1,11 @@
 package org.acme.openapi.swaggerui;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Set;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 
 @Path("/fruits")
 @Produces(MediaType.APPLICATION_JSON)

--- a/openapi-swaggerui-quickstart/src/test/java/org/acme/openapi/swaggerui/FruitResourceTest.java
+++ b/openapi-swaggerui-quickstart/src/test/java/org/acme/openapi/swaggerui/FruitResourceTest.java
@@ -1,13 +1,14 @@
 package org.acme.openapi.swaggerui;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
-import javax.ws.rs.core.MediaType;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import javax.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class FruitResourceTest {

--- a/openapi-swaggerui-quickstart/src/test/java/org/acme/openapi/swaggerui/OpenApiTest.java
+++ b/openapi-swaggerui-quickstart/src/test/java/org/acme/openapi/swaggerui/OpenApiTest.java
@@ -1,10 +1,11 @@
 package org.acme.openapi.swaggerui;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class OpenApiTest {

--- a/openapi-swaggerui-quickstart/src/test/java/org/acme/openapi/swaggerui/SwaggerUiTest.java
+++ b/openapi-swaggerui-quickstart/src/test/java/org/acme/openapi/swaggerui/SwaggerUiTest.java
@@ -1,10 +1,11 @@
 package org.acme.openapi.swaggerui;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class SwaggerUiTest {

--- a/opentracing-quickstart/src/main/java/org/acme/opentracing/FrancophoneService.java
+++ b/opentracing-quickstart/src/main/java/org/acme/opentracing/FrancophoneService.java
@@ -1,14 +1,14 @@
 package org.acme.opentracing;
 
-
 import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.opentracing.Traced;
 
 @Traced
 @ApplicationScoped
 public class FrancophoneService {
 
-  public String bonjour() {
-    return "bonjour";
-  }
+    public String bonjour() {
+        return "bonjour";
+    }
 }

--- a/opentracing-quickstart/src/main/java/org/acme/opentracing/TracedResource.java
+++ b/opentracing-quickstart/src/main/java/org/acme/opentracing/TracedResource.java
@@ -1,7 +1,5 @@
 package org.acme.opentracing;
 
-import java.net.URI;
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -9,6 +7,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
+
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
 @Path("/")
@@ -32,8 +31,8 @@ public class TracedResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String chain() {
         ResourceClient resourceClient = RestClientBuilder.newBuilder()
-            .baseUri(uriInfo.getBaseUri())
-            .build(ResourceClient.class);
+                .baseUri(uriInfo.getBaseUri())
+                .build(ResourceClient.class);
         return "chain -> " + exampleBean.bonjour() + " -> " + resourceClient.hello();
     }
 }

--- a/opentracing-quickstart/src/test/java/org/acme/opentracing/TracedResourceTest.java
+++ b/opentracing-quickstart/src/test/java/org/acme/opentracing/TracedResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.opentracing;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class TracedResourceTest {
@@ -12,10 +13,10 @@ public class TracedResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
 }

--- a/quartz-quickstart/src/main/java/org/acme/quartz/Task.java
+++ b/quartz-quickstart/src/main/java/org/acme/quartz/Task.java
@@ -1,13 +1,14 @@
 package org.acme.quartz;
 
-import javax.persistence.Entity;
 import java.time.Instant;
+
+import javax.persistence.Entity;
 import javax.persistence.Table;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 
 @Entity
-@Table(name="TASKS")
+@Table(name = "TASKS")
 public class Task extends PanacheEntity {
     public Instant createdAt;
 

--- a/quartz-quickstart/src/main/java/org/acme/quartz/TaskBean.java
+++ b/quartz-quickstart/src/main/java/org/acme/quartz/TaskBean.java
@@ -1,7 +1,6 @@
 package org.acme.quartz;
 
 import javax.enterprise.context.ApplicationScoped;
-
 import javax.transaction.Transactional;
 
 import io.quarkus.scheduler.Scheduled;

--- a/quartz-quickstart/src/test/java/org/acme/quartz/TaskResourceTest.java
+++ b/quartz-quickstart/src/test/java/org/acme/quartz/TaskResourceTest.java
@@ -1,13 +1,12 @@
 package org.acme.quartz;
 
-import io.quarkus.test.junit.QuarkusTest;
-
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class TaskResourceTest {

--- a/reactive-routes-quickstart/src/main/java/org/acme/quarkus/sample/MyDeclarativeRoutes.java
+++ b/reactive-routes-quickstart/src/main/java/org/acme/quarkus/sample/MyDeclarativeRoutes.java
@@ -1,15 +1,13 @@
 package org.acme.quarkus.sample;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import io.quarkus.vertx.web.Route;
-import io.quarkus.vertx.web.RoutingExchange;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 
-import javax.enterprise.context.ApplicationScoped;
-
 @ApplicationScoped
 public class MyDeclarativeRoutes {
-
 
     @Route(path = "/", methods = HttpMethod.GET)
     public void handle(RoutingContext rc) {

--- a/reactive-routes-quickstart/src/main/java/org/acme/quarkus/sample/MyFilter.java
+++ b/reactive-routes-quickstart/src/main/java/org/acme/quarkus/sample/MyFilter.java
@@ -1,9 +1,9 @@
 package org.acme.quarkus.sample;
 
-import io.quarkus.vertx.http.runtime.filters.Filters;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
+
+import io.quarkus.vertx.http.runtime.filters.Filters;
 
 @ApplicationScoped
 public class MyFilter {

--- a/reactive-routes-quickstart/src/main/java/org/acme/quarkus/sample/MyRouteRegistar.java
+++ b/reactive-routes-quickstart/src/main/java/org/acme/quarkus/sample/MyRouteRegistar.java
@@ -1,9 +1,9 @@
 package org.acme.quarkus.sample;
 
-import io.vertx.ext.web.Router;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
+
+import io.vertx.ext.web.Router;
 
 @ApplicationScoped
 public class MyRouteRegistar {
@@ -11,6 +11,5 @@ public class MyRouteRegistar {
     public void init(@Observes Router router) {
         router.get("/my-route").handler(rc -> rc.response().end("Hello from my route"));
     }
-
 
 }

--- a/reactive-routes-quickstart/src/test/java/org/acme/quarkus/sample/RouteTest.java
+++ b/reactive-routes-quickstart/src/test/java/org/acme/quarkus/sample/RouteTest.java
@@ -1,10 +1,11 @@
 package org.acme.quarkus.sample;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
+import static org.hamcrest.core.Is.is;
+
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 
 @QuarkusTest
 public class RouteTest {
@@ -34,6 +35,5 @@ public class RouteTest {
                 .statusCode(200)
                 .body(is("Hello from my route"));
     }
-
 
 }

--- a/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceIT.java
+++ b/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceIT.java
@@ -3,5 +3,5 @@ package org.acme.restclient.multipart;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-public class MultipartResourceIT extends MultipartResourceTest{
+public class MultipartResourceIT extends MultipartResourceTest {
 }

--- a/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceTest.java
+++ b/rest-client-multipart-quickstart/src/test/java/org/acme/restclient/multipart/MultipartResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.restclient.multipart;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class MultipartResourceTest {
@@ -15,7 +16,7 @@ public class MultipartResourceTest {
                 .when().post("/client/multipart")
                 .then()
                 .statusCode(200)
-                .body( containsString("Content-Disposition: form-data; name=\"file\""),
+                .body(containsString("Content-Disposition: form-data; name=\"file\""),
                         containsString("HELLO WORLD"),
                         containsString("Content-Disposition: form-data; name=\"fileName\""),
                         containsString("greeting.txt"));

--- a/rest-client-quickstart/src/main/java/org/acme/restclient/CountriesResource.java
+++ b/rest-client-quickstart/src/main/java/org/acme/restclient/CountriesResource.java
@@ -1,15 +1,16 @@
 package org.acme.restclient;
 
-import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.Set;
-import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 @Path("/country")
 public class CountriesResource {
@@ -17,7 +18,6 @@ public class CountriesResource {
     @Inject
     @RestClient
     CountriesService countriesService;
-
 
     @GET
     @Path("/name/{name}")

--- a/rest-client-quickstart/src/main/java/org/acme/restclient/CountriesService.java
+++ b/rest-client-quickstart/src/main/java/org/acme/restclient/CountriesService.java
@@ -1,13 +1,14 @@
 package org.acme.restclient;
 
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import java.util.Set;
-import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 @Path("/v2")
 @RegisterRestClient

--- a/rest-client-quickstart/src/test/java/org/acme/restclient/CountriesResourceTest.java
+++ b/rest-client-quickstart/src/test/java/org/acme/restclient/CountriesResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.restclient;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class CountriesResourceTest {
@@ -12,28 +13,26 @@ public class CountriesResourceTest {
     @Test
     public void testCountryNameEndpoint() {
         given()
-          .when().get("/country/name/greece")
-          .then()
-             .statusCode(200)
-             .body("$.size()", is(1),
-                     "[0].alpha2Code", is("GR"),
-                     "[0].capital", is("Athens"),
-                     "[0].currencies.size()", is(1),
-                     "[0].currencies[0].name", is("Euro")
-             );
+                .when().get("/country/name/greece")
+                .then()
+                .statusCode(200)
+                .body("$.size()", is(1),
+                        "[0].alpha2Code", is("GR"),
+                        "[0].capital", is("Athens"),
+                        "[0].currencies.size()", is(1),
+                        "[0].currencies[0].name", is("Euro"));
     }
 
     @Test
     public void testCountryNameAsyncEndpoint() {
         given()
-          .when().get("/country/name-async/greece")
-          .then()
-             .statusCode(200)
-             .body("$.size()", is(1),
-                     "[0].alpha2Code", is("GR"),
-                     "[0].capital", is("Athens"),
-                     "[0].currencies.size()", is(1),
-                     "[0].currencies[0].name", is("Euro")
-             );
+                .when().get("/country/name-async/greece")
+                .then()
+                .statusCode(200)
+                .body("$.size()", is(1),
+                        "[0].alpha2Code", is("GR"),
+                        "[0].capital", is("Athens"),
+                        "[0].currencies.size()", is(1),
+                        "[0].currencies[0].name", is("Euro"));
     }
 }

--- a/rest-json-quickstart/src/main/java/org/acme/rest/json/Fruit.java
+++ b/rest-json-quickstart/src/main/java/org/acme/rest/json/Fruit.java
@@ -1,7 +1,5 @@
 package org.acme.rest.json;
 
-import java.util.Objects;
-
 public class Fruit {
 
     public String name;

--- a/rest-json-quickstart/src/main/java/org/acme/rest/json/Legume.java
+++ b/rest-json-quickstart/src/main/java/org/acme/rest/json/Legume.java
@@ -1,7 +1,5 @@
 package org.acme.rest.json;
 
-import java.util.Objects;
-
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection

--- a/rest-json-quickstart/src/main/java/org/acme/rest/json/LoggingFilter.java
+++ b/rest-json-quickstart/src/main/java/org/acme/rest/json/LoggingFilter.java
@@ -1,13 +1,14 @@
 package org.acme.rest.json;
 
-import io.vertx.core.http.HttpServerRequest;
-import org.jboss.logging.Logger;
-
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.http.HttpServerRequest;
 
 @Provider
 public class LoggingFilter implements ContainerRequestFilter {

--- a/rest-json-quickstart/src/test/java/org/acme/rest/json/FruitResourceTest.java
+++ b/rest-json-quickstart/src/test/java/org/acme/rest/json/FruitResourceTest.java
@@ -16,36 +16,36 @@ public class FruitResourceTest {
     @Test
     public void testList() {
         given()
-          .when().get("/fruits")
-          .then()
-             .statusCode(200)
-             .body("$.size()", is(2),
-                     "name", containsInAnyOrder("Apple", "Pineapple"),
-                     "description", containsInAnyOrder("Winter fruit", "Tropical fruit"));
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body("$.size()", is(2),
+                        "name", containsInAnyOrder("Apple", "Pineapple"),
+                        "description", containsInAnyOrder("Winter fruit", "Tropical fruit"));
     }
 
     @Test
     public void testAdd() {
         given()
-            .body("{\"name\": \"Pear\", \"description\": \"Winter fruit\"}")
-            .header("Content-Type", MediaType.APPLICATION_JSON)
-        .when()
-            .post("/fruits")
-        .then()
-            .statusCode(200)
-            .body("$.size()", is(3),
-                    "name", containsInAnyOrder("Apple", "Pineapple", "Pear"),
-                    "description", containsInAnyOrder("Winter fruit", "Tropical fruit", "Winter fruit"));
+                .body("{\"name\": \"Pear\", \"description\": \"Winter fruit\"}")
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("/fruits")
+                .then()
+                .statusCode(200)
+                .body("$.size()", is(3),
+                        "name", containsInAnyOrder("Apple", "Pineapple", "Pear"),
+                        "description", containsInAnyOrder("Winter fruit", "Tropical fruit", "Winter fruit"));
 
         given()
-            .body("{\"name\": \"Pear\", \"description\": \"Winter fruit\"}")
-            .header("Content-Type", MediaType.APPLICATION_JSON)
-        .when()
-            .delete("/fruits")
-        .then()
-            .statusCode(200)
-            .body("$.size()", is(2),
-                    "name", containsInAnyOrder("Apple", "Pineapple"),
-                    "description", containsInAnyOrder("Winter fruit", "Tropical fruit"));
+                .body("{\"name\": \"Pear\", \"description\": \"Winter fruit\"}")
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .delete("/fruits")
+                .then()
+                .statusCode(200)
+                .body("$.size()", is(2),
+                        "name", containsInAnyOrder("Apple", "Pineapple"),
+                        "description", containsInAnyOrder("Winter fruit", "Tropical fruit"));
     }
 }

--- a/rest-json-quickstart/src/test/java/org/acme/rest/json/LegumeResourceTest.java
+++ b/rest-json-quickstart/src/test/java/org/acme/rest/json/LegumeResourceTest.java
@@ -14,11 +14,11 @@ public class LegumeResourceTest {
     @Test
     public void testList() {
         given()
-          .when().get("/legumes")
-          .then()
-             .statusCode(200)
-             .body("$.size()", is(2),
-                     "name", containsInAnyOrder("Carrot", "Zucchini"),
-                     "description", containsInAnyOrder("Root vegetable, usually orange", "Summer squash"));
+                .when().get("/legumes")
+                .then()
+                .statusCode(200)
+                .body("$.size()", is(2),
+                        "name", containsInAnyOrder("Carrot", "Zucchini"),
+                        "description", containsInAnyOrder("Root vegetable, usually orange", "Summer squash"));
     }
 }

--- a/scheduler-quickstart/src/main/java/org/acme/scheduling/CountResource.java
+++ b/scheduler-quickstart/src/main/java/org/acme/scheduling/CountResource.java
@@ -12,7 +12,6 @@ public class CountResource {
     @Inject
     CounterBean counter;
 
-
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {

--- a/scheduler-quickstart/src/main/java/org/acme/scheduling/CounterBean.java
+++ b/scheduler-quickstart/src/main/java/org/acme/scheduling/CounterBean.java
@@ -16,12 +16,12 @@ public class CounterBean {
         return counter.get();
     }
 
-    @Scheduled(every="10s")
+    @Scheduled(every = "10s")
     void increment() {
         counter.incrementAndGet();
     }
-    
-    @Scheduled(cron="0 15 10 * * ?")
+
+    @Scheduled(cron = "0 15 10 * * ?")
     void cronJob(ScheduledExecution execution) {
         counter.incrementAndGet();
         System.out.println(execution.getScheduledFireTime());

--- a/scheduler-quickstart/src/test/java/org/acme/scheduling/CountResourceIT.java
+++ b/scheduler-quickstart/src/test/java/org/acme/scheduling/CountResourceIT.java
@@ -5,4 +5,4 @@ import io.quarkus.test.junit.NativeImageTest;
 @NativeImageTest
 public class CountResourceIT extends CountResourceTest {
 
-}                    
+}

--- a/scheduler-quickstart/src/test/java/org/acme/scheduling/CountResourceTest.java
+++ b/scheduler-quickstart/src/test/java/org/acme/scheduling/CountResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.scheduling;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class CountResourceTest {
@@ -12,10 +13,10 @@ public class CountResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/count")
-          .then()
-             .statusCode(200)
-             .body(containsString("count"));
+                .when().get("/count")
+                .then()
+                .statusCode(200)
+                .body(containsString("count"));
     }
 
 }

--- a/security-jdbc-quickstart/src/test/java/org/acme/elytron/security/jdbc/JdbcSecurityRealmTest.java
+++ b/security-jdbc-quickstart/src/test/java/org/acme/elytron/security/jdbc/JdbcSecurityRealmTest.java
@@ -1,9 +1,8 @@
 package org.acme.elytron.security.jdbc;
 
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
-import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.core.Is.is;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -13,8 +12,11 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static io.restassured.RestAssured.*;
-import static org.hamcrest.core.Is.is;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @Testcontainers
 @QuarkusTest
@@ -27,11 +29,9 @@ public class JdbcSecurityRealmTest {
             .withUsername("quarkus")
             .withPassword("quarkus")
             .withExposedPorts(5432)
-            .withCreateContainerCmdModifier(cmd ->
-                    cmd
-                            .withHostName("localhost")
-                            .withPortBindings(new PortBinding(Ports.Binding.bindPort(5432), new ExposedPort(5432)))
-            )
+            .withCreateContainerCmdModifier(cmd -> cmd
+                    .withHostName("localhost")
+                    .withPortBindings(new PortBinding(Ports.Binding.bindPort(5432), new ExposedPort(5432))))
             .withInitScript("test_user.sql");
 
     @Test

--- a/security-jwt-quickstart/src/main/java/org/acme/jwt/LottoNumbersResource.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/jwt/LottoNumbersResource.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.jwt.Claim;
 import org.eclipse.microprofile.jwt.Claims;
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 @Dependent
 public class LottoNumbersResource {
@@ -35,12 +34,12 @@ public class LottoNumbersResource {
             JsonString bdayString = birthdate.get();
             LocalDate bday = LocalDate.parse(bdayString.getString());
             numbers.add(bday.getDayOfMonth());
-            remaining --;
+            remaining--;
         }
-        while(remaining > 0) {
+        while (remaining > 0) {
             int pick = (int) Math.rint(64 * Math.random());
             numbers.add(pick);
-            remaining --;
+            remaining--;
         }
         LottoNumbers winners = new LottoNumbers();
         winners.numbers = numbers;

--- a/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResource.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResource.java
@@ -29,7 +29,7 @@ public class TokenSecuredResource {
 
     @Context
     ResourceContext resourceContext;
-    
+
     @Inject
     JsonWebToken jwt;
     @Inject
@@ -41,22 +41,24 @@ public class TokenSecuredResource {
     @PermitAll
     @Produces(MediaType.TEXT_PLAIN)
     public String hello(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT);
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme(), hasJWT);
         return helloReply;
     }
 
     @GET()
     @Path("roles-allowed")
-    @RolesAllowed({"Echoer", "Subscriber"})
+    @RolesAllowed({ "Echoer", "Subscriber" })
     @Produces(MediaType.TEXT_PLAIN)
     public String helloRolesAllowed(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT);
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme(), hasJWT);
         return helloReply;
     }
 
@@ -65,7 +67,7 @@ public class TokenSecuredResource {
     @DenyAll
     @Produces(MediaType.TEXT_PLAIN)
     public String helloShouldDeny(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
         return "hello + " + name;
     }
@@ -83,13 +85,13 @@ public class TokenSecuredResource {
             String bdayString = jwt.getClaim(Claims.birthdate.name());
             LocalDate bday = LocalDate.parse(bdayString);
             numbers.add(bday.getDayOfMonth());
-            remaining --;
+            remaining--;
         }
         // Fill remaining picks with random numbers
-        while(remaining > 0) {
+        while (remaining > 0) {
             int pick = (int) Math.rint(64 * Math.random() + 1);
             numbers.add(pick);
-            remaining --;
+            remaining--;
         }
         return numbers.toString();
     }
@@ -107,19 +109,20 @@ public class TokenSecuredResource {
             String bdayString = birthdate.get().getString();
             LocalDate bday = LocalDate.parse(bdayString);
             numbers.add(bday.getDayOfMonth());
-            remaining --;
+            remaining--;
         }
         // Fill remaining picks with random numbers
-        while(remaining > 0) {
+        while (remaining > 0) {
             int pick = (int) Math.rint(64 * Math.random() + 1);
             numbers.add(pick);
-            remaining --;
+            remaining--;
         }
         return numbers.toString();
     }
 
     /**
      * Illustrate the same functionality as the winners endpoint using a sub-resource that has injected JsonWebToken and
+     * 
      * @Claim values using the {@linkplain CDI#current()} API.
      *
      * @return LottoNumbersResource

--- a/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV1.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV1.java
@@ -29,10 +29,11 @@ public class TokenSecuredResourceV1 {
     @PermitAll
     @Produces(MediaType.TEXT_PLAIN)
     public String hello(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT);
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme(), hasJWT);
         return helloReply;
     }
 }

--- a/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV2.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV2.java
@@ -30,21 +30,23 @@ public class TokenSecuredResourceV2 {
     @PermitAll
     @Produces(MediaType.TEXT_PLAIN)
     public String hello(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme());
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme());
         return helloReply;
     }
 
     @GET()
     @Path("roles-allowed")
-    @RolesAllowed({"Echoer", "Subscriber"})
+    @RolesAllowed({ "Echoer", "Subscriber" })
     @Produces(MediaType.TEXT_PLAIN)
     public String helloRolesAllowed(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT);
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme(), hasJWT);
         return helloReply;
     }
 }

--- a/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV3.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV3.java
@@ -8,7 +8,6 @@ import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.json.JsonString;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -34,21 +33,23 @@ public class TokenSecuredResourceV3 {
     @PermitAll
     @Produces(MediaType.TEXT_PLAIN)
     public String hello(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme());
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme());
         return helloReply;
     }
 
     @GET()
     @Path("roles-allowed")
-    @RolesAllowed({"Echoer", "Subscriber"})
+    @RolesAllowed({ "Echoer", "Subscriber" })
     @Produces(MediaType.TEXT_PLAIN)
     public String helloRolesAllowed(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT);
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme(), hasJWT);
         return helloReply;
     }
 
@@ -65,13 +66,13 @@ public class TokenSecuredResourceV3 {
             String bdayString = jwt.getClaim(Claims.birthdate.name());
             LocalDate bday = LocalDate.parse(bdayString);
             numbers.add(bday.getDayOfMonth());
-            remaining --;
+            remaining--;
         }
         // Fill remaining picks with random numbers
-        while(remaining > 0) {
+        while (remaining > 0) {
             int pick = (int) Math.rint(64 * Math.random() + 1);
             numbers.add(pick);
-            remaining --;
+            remaining--;
         }
         return numbers.toString();
     }

--- a/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV4.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResourceV4.java
@@ -39,21 +39,23 @@ public class TokenSecuredResourceV4 {
     @PermitAll
     @Produces(MediaType.TEXT_PLAIN)
     public String hello(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme());
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme());
         return helloReply;
     }
 
     @GET()
     @Path("roles-allowed")
-    @RolesAllowed({"Echoer", "Subscriber"})
+    @RolesAllowed({ "Echoer", "Subscriber" })
     @Produces(MediaType.TEXT_PLAIN)
     public String helloRolesAllowed(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT);
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme(), hasJWT);
         return helloReply;
     }
 
@@ -70,13 +72,13 @@ public class TokenSecuredResourceV4 {
             String bdayString = birthdate.get().getString();
             LocalDate bday = LocalDate.parse(bdayString);
             numbers.add(bday.getDayOfMonth());
-            remaining --;
+            remaining--;
         }
         // Fill remaining picks with random numbers
-        while(remaining > 0) {
+        while (remaining > 0) {
             int pick = (int) Math.rint(64 * Math.random() + 1);
             numbers.add(pick);
-            remaining --;
+            remaining--;
         }
         return numbers.toString();
     }

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/GenerateToken.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/GenerateToken.java
@@ -12,7 +12,7 @@ public class GenerateToken {
     /**
      *
      * @param args - [0]: optional name of classpath resource for json document of claims to add; defaults to "/JwtClaims.json"
-     *             [1]: optional time in seconds for expiration of generated token; defaults to 300
+     *        [1]: optional time in seconds for expiration of generated token; defaults to 300
      * @throws Exception
      */
     public static void main(String[] args) throws Exception {

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceIT.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceIT.java
@@ -5,5 +5,5 @@ import io.quarkus.test.junit.NativeImageTest;
 @NativeImageTest
 public class TokenSecuredResourceIT extends TokenSecuredResourceTest {
 
-   // Execute the same tests but in native mode.
+    // Execute the same tests but in native mode.
 }

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceTest.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenSecuredResourceTest.java
@@ -1,21 +1,22 @@
 package org.acme.jwt;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
 import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
 
 import javax.json.Json;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
+import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
 
 /**
  * Tests of the TokenSecuredResource REST endpoints
@@ -37,13 +38,13 @@ public class TokenSecuredResourceTest {
     @Test
     public void testHelloEndpoint() {
         Response response = given()
-          .when()
-          .get("/secured/permit-all")
-          .andReturn();
+                .when()
+                .get("/secured/permit-all")
+                .andReturn();
 
         response.then()
-          .statusCode(200)
-          .body(containsString("hello + anonymous, isSecure: false, authScheme: null, hasJWT: false"));
+                .statusCode(200)
+                .body(containsString("hello + anonymous, isSecure: false, authScheme: null, hasJWT: false"));
     }
 
     @Test
@@ -54,8 +55,8 @@ public class TokenSecuredResourceTest {
                 .get("/secured/roles-allowed").andReturn();
 
         response.then()
-          .statusCode(200)
-          .body(containsString("hello + jdoe@quarkus.io, isSecure: false, authScheme: Bearer, hasJWT: true"));
+                .statusCode(200)
+                .body(containsString("hello + jdoe@quarkus.io, isSecure: false, authScheme: Bearer, hasJWT: true"));
     }
 
     @Test
@@ -74,7 +75,7 @@ public class TokenSecuredResourceTest {
                 .oauth2(token)
                 .when()
                 .get("/secured/winners").andReturn();
-        
+
         Assertions.assertFalse(response.body().asString().isEmpty());
     }
 

--- a/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenUtils.java
+++ b/security-jwt-quickstart/src/test/java/org/acme/jwt/TokenUtils.java
@@ -41,22 +41,23 @@ public class TokenUtils {
         PrivateKey pk = readPrivateKey("/privateKey.pem");
         return generateTokenString(pk, "/privateKey.pem", jsonResName, timeClaims);
     }
-    
-    public static String generateTokenString(PrivateKey privateKey, String kid, 
-    		String jsonResName, Map<String, Long> timeClaims) throws Exception {
-        
-    	JwtClaimsBuilder claims = Jwt.claims(jsonResName);
+
+    public static String generateTokenString(PrivateKey privateKey, String kid,
+            String jsonResName, Map<String, Long> timeClaims) throws Exception {
+
+        JwtClaimsBuilder claims = Jwt.claims(jsonResName);
         long currentTimeInSecs = currentTimeInSecs();
-        long exp = timeClaims != null && timeClaims.containsKey(Claims.exp.name()) 
-        		? timeClaims.get(Claims.exp.name()) : currentTimeInSecs + 300;
-        
+        long exp = timeClaims != null && timeClaims.containsKey(Claims.exp.name())
+                ? timeClaims.get(Claims.exp.name())
+                : currentTimeInSecs + 300;
+
         claims.issuedAt(currentTimeInSecs);
         claims.claim(Claims.auth_time.name(), currentTimeInSecs);
         claims.expiresAt(exp);
-        
+
         return claims.jws().signatureKeyId(kid).sign(privateKey);
     }
-    
+
     /**
      * Read a PEM encoded private key from the classpath
      *

--- a/security-oauth2-quickstart/src/main/java/org/acme/oauth2/TokenSecuredResource.java
+++ b/security-oauth2-quickstart/src/main/java/org/acme/oauth2/TokenSecuredResource.java
@@ -1,5 +1,7 @@
 package org.acme.oauth2;
 
+import java.security.Principal;
+
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
@@ -8,7 +10,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
-import java.security.Principal;
 
 @Path("/secured")
 public class TokenSecuredResource {
@@ -18,20 +19,22 @@ public class TokenSecuredResource {
     @Produces(MediaType.TEXT_PLAIN)
     @PermitAll
     public String hello(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme());
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme());
         return helloReply;
     }
 
     @GET()
     @Path("roles-allowed")
-    @RolesAllowed({"READER", "WRITER"})
+    @RolesAllowed({ "READER", "WRITER" })
     @Produces(MediaType.TEXT_PLAIN)
     public String helloRolesAllowed(@Context SecurityContext ctx) {
-        Principal caller =  ctx.getUserPrincipal();
+        Principal caller = ctx.getUserPrincipal();
         String name = caller == null ? "anonymous" : caller.getName();
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme());
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s", name, ctx.isSecure(),
+                ctx.getAuthenticationScheme());
         return helloReply;
     }
 }

--- a/security-openid-connect-quickstart/src/main/java/org/acme/keycloak/AdminResource.java
+++ b/security-openid-connect-quickstart/src/main/java/org/acme/keycloak/AdminResource.java
@@ -15,13 +15,13 @@
  */
 package org.acme.keycloak;
 
-import io.quarkus.security.Authenticated;
-
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import io.quarkus.security.Authenticated;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>

--- a/security-openid-connect-quickstart/src/main/java/org/acme/keycloak/UsersResource.java
+++ b/security-openid-connect-quickstart/src/main/java/org/acme/keycloak/UsersResource.java
@@ -15,15 +15,16 @@
  */
 package org.acme.keycloak;
 
-import io.quarkus.security.identity.SecurityIdentity;
-import org.jboss.resteasy.annotations.cache.NoCache;
-
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.cache.NoCache;
+
+import io.quarkus.security.identity.SecurityIdentity;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>

--- a/security-openid-connect-web-authentication-quickstart/src/main/java/org/acme/quickstart/oidc/TokenResource.java
+++ b/security-openid-connect-web-authentication-quickstart/src/main/java/org/acme/quickstart/oidc/TokenResource.java
@@ -3,11 +3,6 @@ package org.acme.quickstart.oidc;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -18,20 +13,20 @@ import io.quarkus.oidc.RefreshToken;
 public class TokenResource {
 
     /**
-     * Injection point for the ID Token issued by the OpenID Connect Provider 
+     * Injection point for the ID Token issued by the OpenID Connect Provider
      */
     @Inject
     @IdToken
     JsonWebToken idToken;
 
     /**
-     * Injection point for the Access Token issued by the OpenID Connect Provider 
+     * Injection point for the Access Token issued by the OpenID Connect Provider
      */
     @Inject
     JsonWebToken accessToken;
 
     /**
-     * Injection point for the Refresh Token issued by the OpenID Connect Provider 
+     * Injection point for the Refresh Token issued by the OpenID Connect Provider
      */
     @Inject
     RefreshToken refreshToken;
@@ -49,19 +44,19 @@ public class TokenResource {
                 .append("<ul>");
 
         Object userName = this.idToken.getClaim("preferred_username");
-        
+
         if (userName != null) {
             response.append("<li>username: ").append(userName.toString()).append("</li>");
         }
 
         Object scopes = this.accessToken.getClaim("scope");
-        
+
         if (scopes != null) {
             response.append("<li>scopes: ").append(scopes.toString()).append("</li>");
         }
-        
+
         response.append("<li>refresh_token: ").append(refreshToken.getToken() != null).append("</li>");
-        
+
         return response.append("</ul>").append("</body>").append("</html>").toString();
     }
 }

--- a/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
+++ b/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
 import com.gargoylesoftware.htmlunit.WebClient;
@@ -110,6 +109,5 @@ public class CodeFlowTest {
 
         return webClient;
     }
-
 
 }

--- a/software-transactional-memory-quickstart/src/main/java/org/acme/quickstart/stm/FlightResource.java
+++ b/software-transactional-memory-quickstart/src/main/java/org/acme/quickstart/stm/FlightResource.java
@@ -1,6 +1,9 @@
 package org.acme.quickstart.stm;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -11,10 +14,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Path("/stm")
 @RequestScoped
@@ -42,8 +43,7 @@ public class FlightResource {
     public CompletionStage<String> bookingCount() {
         return CompletableFuture.supplyAsync(
                 () -> getInfo(factory.getInstance()),
-                executor
-        );
+                executor);
     }
 
     @POST

--- a/software-transactional-memory-quickstart/src/main/java/org/acme/quickstart/stm/FlightService.java
+++ b/software-transactional-memory-quickstart/src/main/java/org/acme/quickstart/stm/FlightService.java
@@ -7,5 +7,6 @@ import org.jboss.stm.annotations.Transactional;
 @NestedTopLevel
 public interface FlightService {
     int getNumberOfBookings();
+
     void makeBooking(String details);
 }

--- a/software-transactional-memory-quickstart/src/main/java/org/acme/quickstart/stm/FlightServiceFactory.java
+++ b/software-transactional-memory-quickstart/src/main/java/org/acme/quickstart/stm/FlightServiceFactory.java
@@ -1,8 +1,8 @@
 package org.acme.quickstart.stm;
 
-import org.jboss.stm.Container;
-
 import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.stm.Container;
 
 @ApplicationScoped
 class FlightServiceFactory {

--- a/software-transactional-memory-quickstart/src/test/java/org/acme/quickstart/stm/STMResourceTest.java
+++ b/software-transactional-memory-quickstart/src/test/java/org/acme/quickstart/stm/STMResourceTest.java
@@ -4,10 +4,10 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 
 @QuarkusTest
 class STMResourceTest {

--- a/spring-data-jpa-quickstart/src/main/java/org/acme/spring/data/jpa/Fruit.java
+++ b/spring-data-jpa-quickstart/src/main/java/org/acme/spring/data/jpa/Fruit.java
@@ -15,7 +15,6 @@ public class Fruit {
 
     private String color;
 
-
     public Fruit() {
     }
 

--- a/spring-data-jpa-quickstart/src/main/java/org/acme/spring/data/jpa/FruitRepository.java
+++ b/spring-data-jpa-quickstart/src/main/java/org/acme/spring/data/jpa/FruitRepository.java
@@ -1,8 +1,8 @@
 package org.acme.spring.data.jpa;
 
-import org.springframework.data.repository.CrudRepository;
-
 import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
 
 public interface FruitRepository extends CrudRepository<Fruit, Long> {
 

--- a/spring-data-jpa-quickstart/src/main/java/org/acme/spring/data/jpa/FruitResource.java
+++ b/spring-data-jpa-quickstart/src/main/java/org/acme/spring/data/jpa/FruitResource.java
@@ -1,5 +1,8 @@
 package org.acme.spring.data.jpa;
 
+import java.util.List;
+import java.util.Optional;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -8,9 +11,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
-import java.util.List;
-import java.util.Optional;
 
 @Path("/fruits")
 public class FruitResource {
@@ -26,7 +26,6 @@ public class FruitResource {
     public Iterable<Fruit> findAll() {
         return fruitRepository.findAll();
     }
-
 
     @DELETE
     @Path("{id}")

--- a/spring-data-jpa-quickstart/src/test/java/org/acme/spring/data/jpa/FruitResourceIT.java
+++ b/spring-data-jpa-quickstart/src/test/java/org/acme/spring/data/jpa/FruitResourceIT.java
@@ -3,6 +3,6 @@ package org.acme.spring.data.jpa;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-class FruitResourceIT extends FruitResourceTest{
+class FruitResourceIT extends FruitResourceTest {
 
 }

--- a/spring-data-jpa-quickstart/src/test/java/org/acme/spring/data/jpa/FruitResourceTest.java
+++ b/spring-data-jpa-quickstart/src/test/java/org/acme/spring/data/jpa/FruitResourceTest.java
@@ -1,13 +1,14 @@
 package org.acme.spring.data.jpa;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.IsNot.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class FruitResourceTest {
@@ -22,15 +23,13 @@ class FruitResourceTest {
                 .body(
                         containsString("Cherry"),
                         containsString("Apple"),
-                        containsString("Banana")
-                );
+                        containsString("Banana"));
 
         //Delete the Cherry:
         given()
                 .when().delete("/fruits/1")
                 .then()
-                .statusCode(204)
-        ;
+                .statusCode(204);
 
         //List all, cherry should be missing now:
         given()
@@ -40,8 +39,7 @@ class FruitResourceTest {
                 .body(
                         not(containsString("Cherry")),
                         containsString("Apple"),
-                        containsString("Banana")
-                );
+                        containsString("Banana"));
 
         //Create a new Fruit
         given()
@@ -60,8 +58,7 @@ class FruitResourceTest {
                 .body(
                         not(containsString("Cherry")),
                         containsString("Apple"),
-                        containsString("Orange")
-                );
+                        containsString("Orange"));
     }
 
     @Test
@@ -80,8 +77,7 @@ class FruitResourceTest {
                 .statusCode(200)
                 .body(
                         containsString("Apple"),
-                        containsString("Strawberry")
-                );
+                        containsString("Strawberry"));
 
         //Find by color that matches
         given()
@@ -106,8 +102,7 @@ class FruitResourceTest {
                 .body("size()", is(1))
                 .body(
                         containsString("Black"),
-                        containsString("Avocado")
-                );
+                        containsString("Avocado"));
     }
 
 }

--- a/spring-di-quickstart/src/main/java/org/acme/spring/di/GreeterResource.java
+++ b/spring-di-quickstart/src/main/java/org/acme/spring/di/GreeterResource.java
@@ -16,12 +16,12 @@
 
 package org.acme.spring.di;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Path("/greeting")
 public class GreeterResource {

--- a/spring-di-quickstart/src/test/java/org/acme/spring/di/GreetingResourceTest.java
+++ b/spring-di-quickstart/src/test/java/org/acme/spring/di/GreetingResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.spring.di;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingResourceTest {
@@ -12,8 +13,8 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-            .when().get("/greeting")
-            .then()
+                .when().get("/greeting")
+                .then()
                 .statusCode(200)
                 .body(is("HELLO WORLD!"));
     }

--- a/spring-security-quickstart/src/main/java/org/acme/spring/security/GreetingController.java
+++ b/spring-security-quickstart/src/main/java/org/acme/spring/security/GreetingController.java
@@ -4,8 +4,6 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PathVariable;
-
 
 @RestController
 @RequestMapping("/greeting")

--- a/spring-security-quickstart/src/test/java/org/acme/spring/security/GreetingControllerTest.java
+++ b/spring-security-quickstart/src/test/java/org/acme/spring/security/GreetingControllerTest.java
@@ -1,13 +1,11 @@
 package org.acme.spring.security;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingControllerTest {
@@ -15,9 +13,9 @@ public class GreetingControllerTest {
     @Test
     public void testHelloEndpointForbidden() {
         given().auth().preemptive().basic("stuart", "test")
-          .when().get("/greeting")
-          .then()
-             .statusCode(403);
+                .when().get("/greeting")
+                .then()
+                .statusCode(403);
     }
 
     @Test

--- a/spring-web-quickstart/src/test/java/org/acme/spring/web/GreetingControllerTest.java
+++ b/spring-web-quickstart/src/test/java/org/acme/spring/web/GreetingControllerTest.java
@@ -1,10 +1,11 @@
 package org.acme.spring.web;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class GreetingControllerTest {
@@ -12,8 +13,8 @@ public class GreetingControllerTest {
     @Test
     public void testGreeting() {
         given()
-            .when().get("/greeting/world")
-            .then()
+                .when().get("/greeting/world")
+                .then()
                 .statusCode(200)
                 .body("message", is("HELLO WORLD!"));
     }

--- a/tests-with-coverage-quickstart/src/test/java/org/acme/quickstart/GreetingResourceTest.java
+++ b/tests-with-coverage-quickstart/src/test/java/org/acme/quickstart/GreetingResourceTest.java
@@ -1,13 +1,14 @@
 package org.acme.quickstart;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.util.UUID;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @Tag("integration")
@@ -16,20 +17,20 @@ public class GreetingResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)  
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Test
     public void testGreetingEndpoint() {
         String uuid = UUID.randomUUID().toString();
         given()
-          .pathParam("name", uuid)
-          .when().get("/hello/greeting/{name}")
-          .then()
-            .statusCode(200)
-            .body(is("hello " + uuid));
+                .pathParam("name", uuid)
+                .when().get("/hello/greeting/{name}")
+                .then()
+                .statusCode(200)
+                .body(is("hello " + uuid));
     }
 }

--- a/tika-quickstart/src/main/java/org/acme/quickstart/tika/TikaParserResource.java
+++ b/tika-quickstart/src/main/java/org/acme/quickstart/tika/TikaParserResource.java
@@ -11,19 +11,20 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.quarkus.tika.TikaParser;
 import org.jboss.logging.Logger;
+
+import io.quarkus.tika.TikaParser;
 
 @Path("/parse")
 public class TikaParserResource {
     private static final Logger log = Logger.getLogger(TikaParserResource.class);
 
     @Inject
-    TikaParser parser; 
+    TikaParser parser;
 
     @POST
     @Path("/text")
-    @Consumes({"application/pdf", "application/vnd.oasis.opendocument.text"})
+    @Consumes({ "application/pdf", "application/vnd.oasis.opendocument.text" })
     @Produces(MediaType.TEXT_PLAIN)
     public String extractText(InputStream stream) {
         Instant start = Instant.now();
@@ -32,7 +33,7 @@ public class TikaParserResource {
 
         Instant finish = Instant.now();
 
-        log.info(Duration.between(start, finish).toMillis() + " mls have passed"); 
+        log.info(Duration.between(start, finish).toMillis() + " mls have passed");
 
         return text;
     }

--- a/tika-quickstart/src/test/java/org/acme/quickstart/tika/TikaParserResourceTest.java
+++ b/tika-quickstart/src/test/java/org/acme/quickstart/tika/TikaParserResourceTest.java
@@ -2,7 +2,6 @@ package org.acme.quickstart.tika;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -16,27 +15,27 @@ public class TikaParserResourceTest {
 
     @Test
     public void testHelloQuarkusPdfFormat() throws Exception {
-    	checkText("application/pdf", "pdf");
+        checkText("application/pdf", "pdf");
     }
 
     @Test
     public void testHelloQuarkusOdfFormat() throws Exception {
-    	checkText("application/vnd.oasis.opendocument.text", "odt");
+        checkText("application/vnd.oasis.opendocument.text", "odt");
     }
 
     private void checkText(String contentType, String extension) throws Exception {
         given()
-          .when().header("Content-Type", contentType)
-                 .body(readQuarkusFile("quarkus." + extension))
-                 .post("/parse/text")
-          .then()
-             .statusCode(200)
-             .body(is("Hello Quarkus"));
+                .when().header("Content-Type", contentType)
+                .body(readQuarkusFile("quarkus." + extension))
+                .post("/parse/text")
+                .then()
+                .statusCode(200)
+                .body(is("Hello Quarkus"));
     }
-    
+
     private byte[] readQuarkusFile(String fileName) throws Exception {
         try (InputStream is = getClass().getClassLoader().getResourceAsStream(fileName)) {
-            return readBytes(is);    
+            return readBytes(is);
         }
     }
 

--- a/validation-quickstart/src/main/java/org/acme/validation/Book.java
+++ b/validation-quickstart/src/main/java/org/acme/validation/Book.java
@@ -4,12 +4,12 @@ import javax.validation.constraints.*;
 
 public class Book {
 
-    @NotBlank(message="Title cannot be blank")
+    @NotBlank(message = "Title cannot be blank")
     public String title;
 
-    @NotBlank(message="Author cannot be blank")
+    @NotBlank(message = "Author cannot be blank")
     public String author;
 
-    @Min(message="Author has been very lazy", value=1)
+    @Min(message = "Author has been very lazy", value = 1)
     public double pages;
 }

--- a/validation-quickstart/src/main/java/org/acme/validation/BookResource.java
+++ b/validation-quickstart/src/main/java/org/acme/validation/BookResource.java
@@ -1,5 +1,8 @@
 package org.acme.validation;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -7,8 +10,6 @@ import javax.validation.Valid;
 import javax.validation.Validator;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Path("/books")
 public class BookResource {
@@ -58,7 +59,6 @@ public class BookResource {
             return new Result(e.getConstraintViolations());
         }
     }
-
 
     public static class Result {
 

--- a/validation-quickstart/src/test/java/org/acme/validation/BookResourceTest.java
+++ b/validation-quickstart/src/test/java/org/acme/validation/BookResourceTest.java
@@ -1,10 +1,11 @@
 package org.acme.validation;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class BookResourceTest {
@@ -12,104 +13,104 @@ public class BookResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/books")
-          .then()
-             .statusCode(200)
-             .body(is("hello"));
+                .when().get("/books")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Test
     public void testValidBook() {
         given()
-            .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":5}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/manual-validation")
-        .then()
-            .statusCode(200)
-            .body("success", is(true), "message", containsString("Book is valid!"));
+                .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":5}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/manual-validation")
+                .then()
+                .statusCode(200)
+                .body("success", is(true), "message", containsString("Book is valid!"));
     }
 
     @Test
     public void testBookWithoutTitle() {
         given()
-            .body("{\"author\": \"me\", \"pages\":5}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/manual-validation")
-        .then()
-            .statusCode(200)
-            .body("success", is(false), "message", containsString("Title"));
+                .body("{\"author\": \"me\", \"pages\":5}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/manual-validation")
+                .then()
+                .statusCode(200)
+                .body("success", is(false), "message", containsString("Title"));
     }
 
     @Test
     public void testBookWithoutAuthor() {
         given()
-            .body("{\"title\": \"catchy\", \"pages\":5}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/manual-validation")
-        .then()
-            .statusCode(200)
-            .body("success", is(false), "message", containsString("Author"));
+                .body("{\"title\": \"catchy\", \"pages\":5}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/manual-validation")
+                .then()
+                .statusCode(200)
+                .body("success", is(false), "message", containsString("Author"));
     }
 
     @Test
     public void testBookWithNegativePage() {
         given()
-            .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":-25}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/manual-validation")
-        .then()
-            .statusCode(200)
-            .body("success", is(false), "message", containsString("lazy"));
+                .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":-25}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/manual-validation")
+                .then()
+                .statusCode(200)
+                .body("success", is(false), "message", containsString("lazy"));
     }
 
     @Test
     public void testValidBookEndPointValidation() {
         given()
-            .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":5}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/end-point-method-validation")
-        .then()
-            .statusCode(200)
-            .body("success", is(true), "message", containsString("Book is valid!"));
+                .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":5}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/end-point-method-validation")
+                .then()
+                .statusCode(200)
+                .body("success", is(true), "message", containsString("Book is valid!"));
     }
 
     @Test
     public void testBookWithoutTitleEndPointValidation() {
         given()
-            .body("{\"author\": \"me\", \"pages\":5}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/end-point-method-validation")
-        .then()
-            .statusCode(400)
-            .body("parameterViolations.message", hasItem("Title cannot be blank"));
+                .body("{\"author\": \"me\", \"pages\":5}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/end-point-method-validation")
+                .then()
+                .statusCode(400)
+                .body("parameterViolations.message", hasItem("Title cannot be blank"));
     }
 
     @Test
     public void testValidBookServiceValidation() {
         given()
-            .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":5}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/service-method-validation")
-        .then()
-            .statusCode(200)
-            .body("success", is(true), "message", containsString("Book is valid!"));
+                .body("{\"title\": \"some book\", \"author\": \"me\", \"pages\":5}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/service-method-validation")
+                .then()
+                .statusCode(200)
+                .body("success", is(true), "message", containsString("Book is valid!"));
     }
 
     @Test
     public void testBookWithoutTitleServiceValidation() {
         given()
-            .body("{\"author\": \"me\", \"pages\":5}")
-            .header("Content-Type", "application/json")
-        .when()
-            .post("/books/service-method-validation")
-        .then()
-            .body("success", is(false), "message", containsString("Title"));
+                .body("{\"author\": \"me\", \"pages\":5}")
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/books/service-method-validation")
+                .then()
+                .body("success", is(false), "message", containsString("Title"));
     }
 }

--- a/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
@@ -23,7 +23,7 @@ public class EventResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{name}")
     public CompletionStage<String> greeting(@PathParam String name) {
-        return bus.<String>request("greeting", name)
+        return bus.<String> request("greeting", name)
                 .thenApply(Message::body);
     }
 }

--- a/vertx-quickstart/src/main/java/org/acme/vertx/GreetingService.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/GreetingService.java
@@ -1,10 +1,8 @@
 package org.acme.vertx;
 
-import io.quarkus.vertx.ConsumeEvent;
-
 import javax.enterprise.context.ApplicationScoped;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+
+import io.quarkus.vertx.ConsumeEvent;
 
 @ApplicationScoped
 public class GreetingService {

--- a/vertx-quickstart/src/main/java/org/acme/vertx/ResourceUsingWebClient.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/ResourceUsingWebClient.java
@@ -1,10 +1,6 @@
 package org.acme.vertx;
 
-import io.vertx.axle.core.Vertx;
-import io.vertx.axle.ext.web.client.WebClient;
-import io.vertx.axle.ext.web.codec.BodyCodec;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.WebClientOptions;
+import java.util.concurrent.CompletionStage;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -15,11 +11,13 @@ import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
-import java.util.concurrent.CompletionStage;
+import io.vertx.axle.core.Vertx;
+import io.vertx.axle.ext.web.client.WebClient;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
 
 @Path("/fruit-data")
 public class ResourceUsingWebClient {
-
 
     @Inject
     Vertx vertx;

--- a/vertx-quickstart/src/main/java/org/acme/vertx/StreamingResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/StreamingResource.java
@@ -1,16 +1,18 @@
 package org.acme.vertx;
 
-import io.vertx.axle.core.Vertx;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-import org.reactivestreams.Publisher;
+import java.util.Date;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.Date;
+
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import org.reactivestreams.Publisher;
+
+import io.vertx.axle.core.Vertx;
 
 @Path("/hello")
 public class StreamingResource {

--- a/vertx-quickstart/src/test/java/org/acme/vertx/EventResourceTest.java
+++ b/vertx-quickstart/src/test/java/org/acme/vertx/EventResourceTest.java
@@ -1,14 +1,17 @@
 package org.acme.vertx;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.startsWith;
 
-@QuarkusTest class EventResourceTest {
+import org.junit.jupiter.api.Test;
 
-    @Test void testEventBusGreeter() {
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class EventResourceTest {
+
+    @Test
+    void testEventBusGreeter() {
         given()
                 .when().get("/async/Quarkus")
                 .then()

--- a/vertx-quickstart/src/test/java/org/acme/vertx/GreetingResourceTest.java
+++ b/vertx-quickstart/src/test/java/org/acme/vertx/GreetingResourceTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTest class GreetingResourceTest {
+@QuarkusTest
+class GreetingResourceTest {
 
-    @Test void testGreeter() {
+    @Test
+    void testGreeter() {
         given()
                 .when().get("/hello/Quarkus")
                 .then()

--- a/vertx-quickstart/src/test/java/org/acme/vertx/JsonEndpointTest.java
+++ b/vertx-quickstart/src/test/java/org/acme/vertx/JsonEndpointTest.java
@@ -1,13 +1,14 @@
 package org.acme.vertx;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class JsonEndpointTest {

--- a/vertx-quickstart/src/test/java/org/acme/vertx/ResourceUsingWebClientTest.java
+++ b/vertx-quickstart/src/test/java/org/acme/vertx/ResourceUsingWebClientTest.java
@@ -1,10 +1,11 @@
 package org.acme.vertx;
 
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class ResourceUsingWebClientTest {

--- a/websockets-quickstart/src/main/java/org/acme/websocket/ChatSocket.java
+++ b/websockets-quickstart/src/main/java/org/acme/websocket/ChatSocket.java
@@ -51,7 +51,7 @@ public class ChatSocket {
 
     private void broadcast(String message) {
         sessions.values().forEach(s -> {
-            s.getAsyncRemote().sendObject(message, result ->  {
+            s.getAsyncRemote().sendObject(message, result -> {
                 if (result.getException() != null) {
                     System.out.println("Unable to send message: " + result.getException());
                 }

--- a/websockets-quickstart/src/test/java/org/acme/websocket/ChatTestCase.java
+++ b/websockets-quickstart/src/test/java/org/acme/websocket/ChatTestCase.java
@@ -1,14 +1,16 @@
 package org.acme.websocket;
 
-import io.quarkus.test.common.http.TestHTTPResource;
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-import javax.websocket.*;
 import java.net.URI;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+
+import javax.websocket.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class ChatTestCase {


### PR DESCRIPTION
Fix imports and formatting according to Quarkus codestyle

Commands:
 - mvn -Dproject.build.sourceEncoding=UTF-8 net.revelc.code.formatter:formatter-maven-plugin:2.11.0:format -Dconfigfile=/Users/rsvoboda/git/quarkus/ide-config/eclipse-format.xml
 - mvn -Dproject.build.sourceEncoding=UTF-8 net.revelc.code:impsort-maven-plugin:1.3.2:sort -Dimpsort.groups='java.,javax.,org.,com.' -Dimpsort.staticGroups='*' -Dimpsort.removeUnused=true

There is discussion about automating this, no easy way atm.
https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Quickstarts.20and.20formatter-maven-plugin/near/187398949

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)

Not sure about docs part, I don't thing it makes sense to touch it.

- [ ] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


