### PR TITLE
Added missing README.md files with a link to the guides

### DIFF
--- a/cache-quickstart/README.md
+++ b/cache-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/cache

--- a/config-quickstart/README.md
+++ b/config-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/config

--- a/getting-started-async/README.md
+++ b/getting-started-async/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/getting-started

--- a/getting-started-knative/README.md
+++ b/getting-started-knative/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/getting-started-knative

--- a/getting-started-testing/README.md
+++ b/getting-started-testing/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/getting-started-testing

--- a/kafka-streams-quickstart/aggregator/README.md
+++ b/kafka-streams-quickstart/aggregator/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/kafka-streams

--- a/kafka-streams-quickstart/producer/README.md
+++ b/kafka-streams-quickstart/producer/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/kafka-streams

--- a/kogito-quickstart/README.md
+++ b/kogito-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/kogito

--- a/lifecycle-quickstart/README.md
+++ b/lifecycle-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/lifecycle

--- a/microprofile-fault-tolerance-quickstart/README.md
+++ b/microprofile-fault-tolerance-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/microprofile-fault-tolerance

--- a/microprofile-health-quickstart/README.md
+++ b/microprofile-health-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/microprofile-health

--- a/microprofile-metrics-quickstart/README.md
+++ b/microprofile-metrics-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/microprofile-metrics

--- a/mongodb-panache-quickstart/README.md
+++ b/mongodb-panache-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/mongodb-panache

--- a/mongodb-quickstart/README.md
+++ b/mongodb-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/mongodb

--- a/neo4j-quickstart/README.md
+++ b/neo4j-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/neo4j

--- a/openapi-swaggerui-quickstart/README.md
+++ b/openapi-swaggerui-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/openapi-swaggerui

--- a/opentracing-quickstart/README.md
+++ b/opentracing-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/opentracing

--- a/qute-quickstart/README.md
+++ b/qute-quickstart/README.md
@@ -1,0 +1,3 @@
+Quarkus guide: https://quarkus.io/guides/qute
+
+Reference guide: https://quarkus.io/guides/qute-reference

--- a/reactive-routes-quickstart/README.md
+++ b/reactive-routes-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/reactive-routes

--- a/rest-client-multipart-quickstart/README.md
+++ b/rest-client-multipart-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/rest-client-multipart

--- a/rest-client-quickstart/README.md
+++ b/rest-client-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/rest-client

--- a/rest-json-quickstart/README.md
+++ b/rest-json-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/rest-json

--- a/scheduler-quickstart/README.md
+++ b/scheduler-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/scheduler

--- a/security-jwt-quickstart/README.adoc
+++ b/security-jwt-quickstart/README.adoc
@@ -3,3 +3,5 @@
 This quickstart project is the code part of the Quarkus Smallrye-JWT guide. It contains
 the final solution as well as the incremental versions leading up to the final solution
 and some additional features beyond that.
+
+Quarkus guide: https://quarkus.io/guides/security-jwt

--- a/security-oauth2-quickstart/README.md
+++ b/security-oauth2-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/security-oauth2

--- a/security-openid-connect-quickstart/README.md
+++ b/security-openid-connect-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/security-openid-connect

--- a/software-transactional-memory-quickstart/README.md
+++ b/software-transactional-memory-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/software-transactional-memory

--- a/spring-di-quickstart/README.md
+++ b/spring-di-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/spring-di

--- a/spring-security-quickstart/README.md
+++ b/spring-security-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/spring-security

--- a/spring-web-quickstart/README.md
+++ b/spring-web-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/spring-web

--- a/tika-quickstart/README.adoc
+++ b/tika-quickstart/README.adoc
@@ -12,3 +12,4 @@ OpenDocument Format:
 curl -v -X POST -H "Content-type: application/vnd.oasis.opendocument.text" --data-binary @target/classes/quarkus.odt http://localhost:8080/parse/text
 
 
+Quarkus guide: https://quarkus.io/guides/tika

--- a/validation-quickstart/README.md
+++ b/validation-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/validation

--- a/vertx-quickstart/README.md
+++ b/vertx-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/vertx

--- a/websockets-quickstart/README.md
+++ b/websockets-quickstart/README.md
@@ -1,0 +1,1 @@
+Quarkus guide: https://quarkus.io/guides/websockets


### PR DESCRIPTION
To all quickstarts without README.md files were added readme with a link to the right guide.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


