### PR TITLE
RSS Regression: Upload pmap output to cloud storage, compare between runs

### DIFF
--- a/.github/RssRegression.java
+++ b/.github/RssRegression.java
@@ -73,7 +73,6 @@ public class RssRegression {
             rssRegression = newRss > (oldRss * 1.1);
             System.out.println("Regression: " + rssRegression);
 
-            System.out.println("Uploading new pmap file to storage: " + bucketFile + " from local: " + oldPmapFile);
         }
         _cosClient.shutdown();
 
@@ -81,6 +80,7 @@ public class RssRegression {
             exit(1);
         }
         else {
+            System.out.println("Uploading new pmap file to storage: " + bucketFile + " from local: " + oldPmapFile);
             uploadObject(_cosClient, BUCKET_NAME, bucketFile, newPmapFile);
             exit(0);
         }

--- a/.github/RssRegression.java
+++ b/.github/RssRegression.java
@@ -1,0 +1,182 @@
+//usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS com.ibm.cos:ibm-cos-java-sdk:2.1.0
+//DEPS javax.xml.bind:jaxb-api:2.4.0-b180830.0359
+
+package io.quarkus;
+
+import com.ibm.cloud.objectstorage.ClientConfiguration;
+import com.ibm.cloud.objectstorage.SDKGlobalConfiguration;
+import com.ibm.cloud.objectstorage.auth.AWSCredentials;
+import com.ibm.cloud.objectstorage.auth.AWSStaticCredentialsProvider;
+import com.ibm.cloud.objectstorage.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.ibm.cloud.objectstorage.oauth.BasicIBMOAuthCredentials;
+import com.ibm.cloud.objectstorage.services.s3.AmazonS3;
+import com.ibm.cloud.objectstorage.services.s3.AmazonS3ClientBuilder;
+import com.ibm.cloud.objectstorage.services.s3.model.AmazonS3Exception;
+import com.ibm.cloud.objectstorage.services.s3.model.GetObjectRequest;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import static java.lang.System.exit;
+
+public class RssRegression {
+
+    private static AmazonS3 _cosClient;
+    private static String ENDPOINT_URL;
+    private static String LOCATION;
+
+    static {
+        ENDPOINT_URL = "https://s3.eu-gb.cloud-object-storage.appdomain.cloud";
+        SDKGlobalConfiguration.IAM_ENDPOINT = "https://iam.cloud.ibm.com/identity/token";
+        LOCATION = "eu-gb";
+    }
+
+    /**
+     * @param args
+     */
+    public static void main(String[] args) {
+
+        if(args.length != 6){
+            System.out.println(args.length);
+            printUsage();
+            exit(1);
+        }
+        String BUCKET_NAME = args[0];
+        String API_KEY = args[1];
+        String SERVICE_INSTANCE_ID = args[2];
+        String bucketFile = args[3];
+        String oldPmapFile = args[4];
+        String newPmapFile = args[5];
+
+        _cosClient = createClient(API_KEY, SERVICE_INSTANCE_ID, ENDPOINT_URL, LOCATION);
+
+        System.out.println("Downloading file from storage: " + bucketFile + " to local: " + oldPmapFile);
+        try{
+            downloadFile(_cosClient, BUCKET_NAME, bucketFile, oldPmapFile);
+        } catch (AmazonS3Exception s3Execpetion){
+            System.out.println("Download failed with: " + s3Execpetion.getMessage());
+            _cosClient.shutdown();
+            exit(1);
+        }
+
+        int oldRss = getRssFromFile(oldPmapFile);
+        int newRss = getRssFromFile(newPmapFile);
+        boolean rssRegression = false;
+
+        if( oldRss != -1 && newRss != -1) {
+            System.out.println("Old RSS: " + oldRss);
+            System.out.println("New RSS: " + newRss);
+
+            rssRegression = newRss > (oldRss * 1.1);
+            System.out.println("Regression: " + rssRegression);
+
+            System.out.println("Uploading new pmap file to storage: " + bucketFile + " from local: " + oldPmapFile);
+            uploadObject(_cosClient, BUCKET_NAME, bucketFile, newPmapFile);
+        }
+        _cosClient.shutdown();
+
+        if(rssRegression) {
+            exit(1);
+        }
+        else {
+            exit(0);
+        }
+    }
+
+    private static void printUsage() {
+        System.out.println("Usage: jbang RssRegression BUCKET_NAME API_KEY SERVICE_INSTANCE_ID REMOTE_OBJECT_NAME OLD_PMAP_FILENAME NEW_PMAP_FILENAME");
+        System.out.println("");
+        System.out.println("   Where;");
+        System.out.println("      BUCKET_NAME - name of S3 bucket to contain pmap object");
+        System.out.println("      API_KEY - Private API key");
+        System.out.println("      SERVICE_INSTANCE_ID - Cloud Resource Name (CRN) id of S3 bucket");
+        System.out.println("      REMOTE_OBJECT_NAME - name of S3 object stored in S3 bucket");
+        System.out.println("      OLD_PMAP_FILENAME - local filename of to download previous run pmap file");
+        System.out.println("      NEW_PMAP_FILENAME - name of filename for current run pmap file");
+    }
+
+    /**
+     * @param api_key
+     * @param service_instance_id
+     * @param endpoint_url
+     * @param location
+     * @return AmazonS3
+     */
+    public static AmazonS3 createClient(String api_key, String service_instance_id, String endpoint_url, String
+            location) {
+        AWSCredentials credentials;
+        credentials = new BasicIBMOAuthCredentials(api_key, service_instance_id);
+
+        ClientConfiguration clientConfig = new ClientConfiguration().withRequestTimeout(5000);
+        clientConfig.setUseTcpKeepAlive(true);
+
+        AmazonS3 cosClient = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withEndpointConfiguration(new EndpointConfiguration(endpoint_url, location)).withPathStyleAccessEnabled(true)
+                .withClientConfiguration(clientConfig).build();
+        return cosClient;
+    }
+
+    /**
+     * @param cosClient
+     * @param BUCKET_NAME
+     * @param bucketFile
+     * @param inputFile
+     */
+    public static void uploadObject(AmazonS3 cosClient, String BUCKET_NAME, String bucketFile, String inputFile){
+        cosClient.putObject(
+                BUCKET_NAME, // the name of the destination bucket
+                bucketFile, // the object key
+                new File(inputFile) // the file name and path of the object to be uploaded
+        );
+    }
+
+    /**
+     * @param cosClient
+     * @param BUCKET_NAME
+     * @param bucketFile
+     * @param outputFile
+     */    public static void downloadFile(AmazonS3 cosClient, String BUCKET_NAME, String bucketFile, String outputFile) throws AmazonS3Exception {
+        GetObjectRequest request = new // create a new request to get an object
+                GetObjectRequest( // request the new object by identifying
+                BUCKET_NAME, // the name of the bucket
+                bucketFile // the name of the object
+        );
+
+        cosClient.getObject( // write the contents of the object
+                request, // using the request that was just created
+                new File(outputFile) // to write to a new file
+        );
+    }
+
+    public static int getRssFromFile(String filename){
+        int rss = -1;
+        try {
+            String lastLine = readLastLine(filename);
+            if (!lastLine.equals("")){
+                while(lastLine.length() != (lastLine = lastLine.replaceAll("  ", " ")).length()){}
+                rss = Integer.parseInt(lastLine.split(" ")[3]);
+            } else {
+                System.out.println("File was empty: " + filename);;
+            }
+        } catch (IOException e) {
+            System.out.println("Read file failed with: " + e.getMessage());
+        }
+        return rss;
+
+    }
+
+    public static String readLastLine(String filename) throws IOException {
+        String sCurrentLine, lastLine = "";
+
+        try(BufferedReader br = new BufferedReader(new FileReader(filename))){
+            while ((sCurrentLine = br.readLine()) != null) {
+                lastLine = sCurrentLine;
+            }
+        }
+
+        return lastLine;
+    }
+}

--- a/.github/RssRegression.java
+++ b/.github/RssRegression.java
@@ -74,7 +74,6 @@ public class RssRegression {
             System.out.println("Regression: " + rssRegression);
 
             System.out.println("Uploading new pmap file to storage: " + bucketFile + " from local: " + oldPmapFile);
-            uploadObject(_cosClient, BUCKET_NAME, bucketFile, newPmapFile);
         }
         _cosClient.shutdown();
 
@@ -82,6 +81,7 @@ public class RssRegression {
             exit(1);
         }
         else {
+            uploadObject(_cosClient, BUCKET_NAME, bucketFile, newPmapFile);
             exit(0);
         }
     }

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -43,20 +43,39 @@ jobs:
       - name: Check RSS
         env:
           QUICKSTART_VERSION: "1.0-SNAPSHOT"
-          RSS_THRESHOLD: "25000"
+          RSS_THRESHOLD: "40000"
           START_TIME_THRESHOLD: "1000"
+          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+          REMOTE_OBJECT_NAME: "pmap.out"
+          API_KEY: ${{ secrets.API_KEY }}
+          SERVICE_INSTANCE_ID: ${{ secrets.SERVICE_INSTANCE_ID }}
+
         run: |
-          getting-started/target/getting-started-${QUICKSTART_VERSION}-runner -Xmx2m > server.log &
+          sudo apt-get update -o Dir::Etc::sourcelist="sources.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+          sudo apt-get install -y gnupg2 gnupg-agent
+          echo Installing SDKMAN
+          curl -s "https://get.sdkman.io" | bash
+          source ~/.sdkman/bin/sdkman-init.sh
+          sdk install jbang
+          getting-started/target/getting-started-${QUICKSTART_VERSION}-runner -Xmx2m -Dquarkus.http.io-threads=1 -Dquarkus.vertx.worker-pool-size=1 > server.log &
           sleep 2
+          appPid=$!
+          pmap -x $appPid > pmap.out
           ps --no-headers  -C getting-started-${QUICKSTART_VERSION}-runner -o rss > rss.out
           rss=$(< rss.out)
-          echo "Threshold (kB): ${RSS_THRESHOLD}"
+          echo "Max RSS Threshold (kB): ${RSS_THRESHOLD}"
           echo "RSS (kB): $rss"
           startTime=$(grep -oP "started in \K([0-9]*\.[0-9]*)" server.log)
           startTimeMs=$(echo "$startTime*1000/1" | bc)
           echo "Start time Threshold (ms): ${START_TIME_THRESHOLD}"
           echo "Start time (ms): $startTimeMs"
+          jbang .github/RssRegression.java ${BUCKET_NAME} ${API_KEY} ${SERVICE_INSTANCE_ID} ${REMOTE_OBJECT_NAME} pmap.old.out pmap.out
           [ "$rss" -lt "${RSS_THRESHOLD}" ] && [ "$startTimeMs" -lt "${START_TIME_THRESHOLD}" ] && exit 0 || exit 1
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: pmap
+          path: pmap.out
 
       - name: Report
         if: always()

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -45,10 +45,10 @@ jobs:
           QUICKSTART_VERSION: "1.0-SNAPSHOT"
           RSS_THRESHOLD: "40000"
           START_TIME_THRESHOLD: "1000"
-          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
           REMOTE_OBJECT_NAME: "pmap.out"
-          API_KEY: ${{ secrets.API_KEY }}
-          SERVICE_INSTANCE_ID: ${{ secrets.SERVICE_INSTANCE_ID }}
+          BUCKET_NAME: ${{ secrets.IBM_COS_BUCKET_NAME }}
+          API_KEY: ${{ secrets.IBM_COS_SERVICE_CREDENTIAL_API_KEY }}
+          SERVICE_INSTANCE_ID: ${{ secrets.IBM_COS_SERVICE_CREDENTIAL_RESOURCE_INSTANCE_ID }}
 
         run: |
           sudo apt-get update -o Dir::Etc::sourcelist="sources.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"


### PR DESCRIPTION
The PR aims to make the RSS regression check more robust for the native image cron job by;

1. Capturing pmap output from getting-started native binary
2. Downloading pmap output from previous build from IBM cloud storage
3. Comparing RSS from current build to previous build. If the RSS has grown more than 10%, then the run fails the RSS regression test
4. An upper limit of 40MB is defined to stop unbounded RSS growth by less than 10% each run
5. Current run pmap output is uploaded to IBM cloud storage for comparison against subsequent test

**In order for this PR to function, the following secrets needs to be defined for the repo before this PR is merged**;

- BUCKET_NAME
- API_KEY
- SERVICE_INSTANCE_ID