### PR TITLE
Fix neo4j native tests

### DIFF
--- a/neo4j-quickstart/src/test/java/org/acme/neo4j/Neo4jResource.java
+++ b/neo4j-quickstart/src/test/java/org/acme/neo4j/Neo4jResource.java
@@ -2,10 +2,6 @@ package org.acme.neo4j;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
-
 import java.util.Collections;
 import java.util.Map;
 
@@ -13,18 +9,18 @@ import org.testcontainers.containers.Neo4jContainer;
 
 public class Neo4jResource implements QuarkusTestResourceLifecycleManager {
 
-    final Neo4jContainer NEO4J = new Neo4jContainer<>("neo4j:4.0.0").withAdminPassword(null);
+    @SuppressWarnings("rawtypes")
+    private static final Neo4jContainer NEO4J = new Neo4jContainer<>("neo4j:4.0.0")
+            .withAdminPassword(null);
 
     @Override
     public Map<String, String> start() {
         NEO4J.start();
-        System.setProperty("quarkus.neo4j.uri", NEO4J.getBoltUrl());
-        return Collections.emptyMap();
+        return Collections.singletonMap("quarkus.neo4j.uri", NEO4J.getBoltUrl());
     }
 
     @Override
     public void stop() {
-        System.clearProperty("quarkus.neo4j.uri");
         NEO4J.close();
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/quarkusio/quarkus-quickstarts/pull/480.

The issue was that the system variable (neo4j URL) was not passed to the native executable. The test resource must return a map containing the properties to be passed. It worked in JVM mode as it's the same process, but in native it was not working.

I'm pretty sure it's not the only QS with this issue.

**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [X] makes sure the documentation must not be updated
- [X] links the documentation update pull request (if needed)
- [X] updates or creates the `README.md` file (with build and run instructions)
- [X] For new quickstart, is located in the directory _component-quickstart_
- [X] For new quickstart, is added to the root `pom.xml` and `README.md`


