### PR TITLE
Make GreetingResource independent of Resteasy

### DIFF
--- a/getting-started/src/main/java/org/acme/quickstart/GreetingResource.java
+++ b/getting-started/src/main/java/org/acme/quickstart/GreetingResource.java
@@ -6,8 +6,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.PathParam;
 
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+//import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 @Path("/hello")
 public class GreetingResource {
@@ -18,7 +19,7 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/greeting/{name}")
-    public String greeting(@PathParam String name) {
+    public String greeting(@PathParam("name") String name) {
         return service.greeting(name);
     }
 


### PR DESCRIPTION
Absolutely no reason to depend on reasteasy in this class.


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


