### PR TITLE
Removal of unrecommended usage of private members

### DIFF
--- a/opentracing-quickstart/src/main/java/org/acme/opentracing/TracedResource.java
+++ b/opentracing-quickstart/src/main/java/org/acme/opentracing/TracedResource.java
@@ -14,7 +14,7 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 public class TracedResource {
 
     @Inject
-    private FrancophoneService exampleBean;
+    FrancophoneService exampleBean;
 
     @Context
     private UriInfo uriInfo;

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/TimeTableResource.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/TimeTableResource.java
@@ -27,9 +27,9 @@ public class TimeTableResource {
     public static final Long SINGLETON_TIME_TABLE_ID = 1L;
 
     @Inject
-    private SolverManager<TimeTable, Long> solverManager;
+    SolverManager<TimeTable, Long> solverManager;
     @Inject
-    private ScoreManager<TimeTable> scoreManager;
+    ScoreManager<TimeTable> scoreManager;
 
     // To try, open http://localhost:8080/timeTable
     @GET

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeTableResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeTableResourceTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TimeTableResourceTest {
 
     @Inject
-    private TimeTableResource timeTableResource;
+    TimeTableResource timeTableResource;
 
     @Test
     @Timeout(600_000)


### PR DESCRIPTION
Removal of unrecommended usage of private members

Otherwise the build log contains `Found unrecommended usage of private members (use package-private instead) in application beans:` messages

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus