### PR TITLE
Fixing and reordering imports

### DIFF
--- a/context-propagation/src/main/java/org/acme/context/EmitterResource.java
+++ b/context-propagation/src/main/java/org/acme/context/EmitterResource.java
@@ -1,18 +1,19 @@
 package org.acme.context;
 
-import io.smallrye.mutiny.Multi;
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.jboss.resteasy.annotations.SseElementType;
-import org.reactivestreams.Publisher;
+import java.util.List;
 
 import javax.inject.Inject;
-import javax.transaction.SystemException;
 import javax.transaction.Transactional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.List;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.jboss.resteasy.annotations.SseElementType;
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
 
 @Path("/")
 public class EmitterResource {

--- a/context-propagation/src/main/java/org/acme/context/Price.java
+++ b/context-propagation/src/main/java/org/acme/context/Price.java
@@ -1,8 +1,8 @@
 package org.acme.context;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
-
 import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
 
 @Entity
 public class Price extends PanacheEntity  {

--- a/context-propagation/src/main/java/org/acme/context/PriceResource.java
+++ b/context-propagation/src/main/java/org/acme/context/PriceResource.java
@@ -1,11 +1,11 @@
 package org.acme.context;
 
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
-
 import javax.inject.Inject;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
 
 @Path("/")
 public class PriceResource {

--- a/context-propagation/src/test/java/org/acme/context/prices/DatabaseResource.java
+++ b/context-propagation/src/test/java/org/acme/context/prices/DatabaseResource.java
@@ -1,10 +1,11 @@
 package org.acme.context.prices;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import org.testcontainers.containers.PostgreSQLContainer;
-
 import java.util.Collections;
 import java.util.Map;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class DatabaseResource implements QuarkusTestResourceLifecycleManager {
 

--- a/context-propagation/src/test/java/org/acme/context/prices/KafkaResource.java
+++ b/context-propagation/src/test/java/org/acme/context/prices/KafkaResource.java
@@ -1,10 +1,11 @@
 package org.acme.context.prices;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import org.testcontainers.containers.KafkaContainer;
-
 import java.util.Collections;
 import java.util.Map;
+
+import org.testcontainers.containers.KafkaContainer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class KafkaResource implements QuarkusTestResourceLifecycleManager {
 

--- a/context-propagation/src/test/java/org/acme/context/prices/PriceTest.java
+++ b/context-propagation/src/test/java/org/acme/context/prices/PriceTest.java
@@ -1,22 +1,24 @@
 package org.acme.context.prices;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import io.restassured.common.mapper.TypeRef;
-import org.acme.context.Price;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.sse.SseEventSource;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.awaitility.Awaitility.await;
+import org.acme.context.Price;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
 @QuarkusTestResource(KafkaResource.class)

--- a/dynamodb-quickstart/src/main/java/org/acme/dynamodb/FruitAsyncResource.java
+++ b/dynamodb-quickstart/src/main/java/org/acme/dynamodb/FruitAsyncResource.java
@@ -1,6 +1,6 @@
 package org.acme.dynamodb;
 
-import io.smallrye.mutiny.Uni;
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -10,7 +10,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.List;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/async-fruits")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dynamodb-quickstart/src/main/java/org/acme/dynamodb/FruitAsyncService.java
+++ b/dynamodb-quickstart/src/main/java/org/acme/dynamodb/FruitAsyncService.java
@@ -1,7 +1,6 @@
 package org.acme.dynamodb;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/getting-started-async/src/main/java/org/acme/getting/started/async/GreetingResource.java
+++ b/getting-started-async/src/main/java/org/acme/getting/started/async/GreetingResource.java
@@ -1,14 +1,15 @@
 package org.acme.getting.started.async;
 
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 @Path("/hello")
 public class GreetingResource {

--- a/getting-started-async/src/main/java/org/acme/getting/started/async/GreetingService.java
+++ b/getting-started-async/src/main/java/org/acme/getting/started/async/GreetingService.java
@@ -1,9 +1,9 @@
 package org.acme.getting.started.async;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-
-import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class GreetingService {

--- a/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/Fruit.java
+++ b/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/Fruit.java
@@ -16,14 +16,14 @@
 
 package org.acme.reactive.crud;
 
+import java.util.stream.StreamSupport;
+
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.pgclient.PgPool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
-
-import java.util.stream.StreamSupport;
 
 public class Fruit {
 

--- a/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/FruitResource.java
+++ b/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/FruitResource.java
@@ -16,11 +16,7 @@
 
 package org.acme.reactive.crud;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import java.net.URI;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -35,7 +31,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-import java.net.URI;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.pgclient.PgPool;
 
 @Path("fruits")
 @Produces(MediaType.APPLICATION_JSON)

--- a/getting-started-reactive-crud/src/test/java/org/acme/reactive/crud/DatabaseResource.java
+++ b/getting-started-reactive-crud/src/test/java/org/acme/reactive/crud/DatabaseResource.java
@@ -1,10 +1,11 @@
 package org.acme.reactive.crud;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import org.testcontainers.containers.PostgreSQLContainer;
-
 import java.util.Collections;
 import java.util.Map;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class DatabaseResource implements QuarkusTestResourceLifecycleManager {
 

--- a/getting-started-reactive-crud/src/test/java/org/acme/reactive/crud/FruitResourceTest.java
+++ b/getting-started-reactive-crud/src/test/java/org/acme/reactive/crud/FruitResourceTest.java
@@ -1,12 +1,13 @@
 package org.acme.reactive.crud;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsNot.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(DatabaseResource.class)

--- a/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingResource.java
+++ b/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingResource.java
@@ -6,11 +6,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
 import org.jboss.resteasy.annotations.SseElementType;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
-import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 @Path("/hello")
 public class ReactiveGreetingResource {

--- a/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingService.java
+++ b/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingService.java
@@ -1,10 +1,11 @@
 package org.acme.getting.started;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
+import java.time.Duration;
 
 import javax.enterprise.context.ApplicationScoped;
-import java.time.Duration;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
 public class ReactiveGreetingService {

--- a/getting-started-reactive/src/test/java/org/acme/getting/started/ReactiveGreetingResourceTest.java
+++ b/getting-started-reactive/src/test/java/org/acme/getting/started/ReactiveGreetingResourceTest.java
@@ -2,7 +2,6 @@ package org.acme.getting.started;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasItems;
 
 import java.util.UUID;
 

--- a/getting-started-testing/src/test/java/org/acme/getting/started/testing/GreetingServiceTest.java
+++ b/getting-started-testing/src/test/java/org/acme/getting/started/testing/GreetingServiceTest.java
@@ -5,7 +5,6 @@ import javax.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest

--- a/hibernate-search-elasticsearch-quickstart/src/test/java/org/acme/hibernate/search/elasticsearch/service/LibraryResourceInGraalIT.java
+++ b/hibernate-search-elasticsearch-quickstart/src/test/java/org/acme/hibernate/search/elasticsearch/service/LibraryResourceInGraalIT.java
@@ -15,20 +15,6 @@
  */
 package org.acme.hibernate.search.elasticsearch.service;
 
-/*
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest

--- a/kafka-streams-quickstart/aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/InteractiveQueries.java
+++ b/kafka-streams-quickstart/aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/InteractiveQueries.java
@@ -6,8 +6,8 @@ import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.acme.kafka.streams.aggregator.model.WeatherStationData;
 import org.acme.kafka.streams.aggregator.model.Aggregation;
+import org.acme.kafka.streams.aggregator.model.WeatherStationData;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;

--- a/kafka-streams-quickstart/producer/src/main/java/org/acme/kafka/streams/producer/generator/ValuesGenerator.java
+++ b/kafka-streams-quickstart/producer/src/main/java/org/acme/kafka/streams/producer/generator/ValuesGenerator.java
@@ -12,12 +12,12 @@ import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import io.smallrye.reactive.messaging.kafka.KafkaRecord;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.reactivex.Flowable;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
 
 /**
  * A bean producing random temperature data every second.

--- a/kogito-quickstart/src/test/java/org/acme/kogito/PersonProcessTest.java
+++ b/kogito-quickstart/src/test/java/org/acme/kogito/PersonProcessTest.java
@@ -3,10 +3,7 @@ package org.acme.kogito;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.core.Is.is;
 
-import javax.inject.Inject;
-
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.Application;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;

--- a/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/microprofile/faulttolerance/BaseTest.java
+++ b/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/microprofile/faulttolerance/BaseTest.java
@@ -1,11 +1,11 @@
 package org.acme.microprofile.faulttolerance;
 
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.get;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.StringContains.containsString;
+
+import org.junit.jupiter.api.Test;
 
 public abstract class BaseTest {
 

--- a/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/microprofile/faulttolerance/CoffeeResourceTest.java
+++ b/microprofile-fault-tolerance-quickstart/src/test/java/org/acme/microprofile/faulttolerance/CoffeeResourceTest.java
@@ -1,17 +1,14 @@
 package org.acme.microprofile.faulttolerance;
 
 import static io.restassured.RestAssured.get;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.core.StringContains.containsString;
 
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest

--- a/mongodb-quickstart/src/main/java/org/acme/mongodb/ReactiveFruitResource.java
+++ b/mongodb-quickstart/src/main/java/org/acme/mongodb/ReactiveFruitResource.java
@@ -1,17 +1,16 @@
 package org.acme.mongodb;
 
-import io.smallrye.mutiny.Uni;
-
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/reactive_fruits")
 @Produces(MediaType.APPLICATION_JSON)

--- a/mongodb-quickstart/src/main/java/org/acme/mongodb/ReactiveFruitService.java
+++ b/mongodb-quickstart/src/main/java/org/acme/mongodb/ReactiveFruitService.java
@@ -1,13 +1,15 @@
 package org.acme.mongodb;
 
-import io.quarkus.mongodb.reactive.ReactiveMongoClient;
-import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
-import io.smallrye.mutiny.Uni;
-import org.bson.Document;
+import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.List;
+
+import org.bson.Document;
+
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
+import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
 public class ReactiveFruitService {

--- a/mongodb-quickstart/src/main/java/org/acme/mongodb/codec/FruitCodec.java
+++ b/mongodb-quickstart/src/main/java/org/acme/mongodb/codec/FruitCodec.java
@@ -3,11 +3,11 @@ package org.acme.mongodb.codec;
 import java.util.UUID;
 
 import org.acme.mongodb.Fruit;
-import org.bson.Document;
-import org.bson.BsonWriter;
-import org.bson.BsonValue;
 import org.bson.BsonReader;
 import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.Document;
 import org.bson.codecs.Codec;
 import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.DecoderContext;

--- a/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
+++ b/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
@@ -7,12 +7,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.reactive.RxResult;
 import org.reactivestreams.Publisher;
 
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 @Path("reactivefruits")
 @Produces(MediaType.APPLICATION_JSON)

--- a/neo4j-quickstart/src/test/java/org/acme/neo4j/FruitsEndpointTest.java
+++ b/neo4j-quickstart/src/test/java/org/acme/neo4j/FruitsEndpointTest.java
@@ -1,20 +1,21 @@
 package org.acme.neo4j;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.IsNot.not;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
+
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.IsNot.not;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(Neo4jResource.class)

--- a/neo4j-quickstart/src/test/java/org/acme/neo4j/Neo4jResource.java
+++ b/neo4j-quickstart/src/test/java/org/acme/neo4j/Neo4jResource.java
@@ -1,11 +1,11 @@
 package org.acme.neo4j;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-
 import java.util.Collections;
 import java.util.Map;
 
 import org.testcontainers.containers.Neo4jContainer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class Neo4jResource implements QuarkusTestResourceLifecycleManager {
 

--- a/openapi-swaggerui-quickstart/src/main/java/org/acme/openapi/swaggerui/FruitResource.java
+++ b/openapi-swaggerui-quickstart/src/main/java/org/acme/openapi/swaggerui/FruitResource.java
@@ -4,12 +4,12 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Set;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 @Path("/fruits")

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/bootstrap/DemoDataGenerator.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/bootstrap/DemoDataGenerator.java
@@ -9,11 +9,12 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.transaction.Transactional;
 
-import io.quarkus.runtime.StartupEvent;
 import org.acme.optaplanner.domain.Lesson;
 import org.acme.optaplanner.domain.Room;
 import org.acme.optaplanner.domain.Timeslot;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.runtime.StartupEvent;
 
 @ApplicationScoped
 public class DemoDataGenerator {

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Lesson.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Lesson.java
@@ -1,6 +1,5 @@
 package org.acme.optaplanner.domain;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -9,10 +8,11 @@ import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.lookup.PlanningId;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @PlanningEntity
 @Entity

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Room.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Room.java
@@ -7,8 +7,9 @@ import javax.persistence.Id;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import org.optaplanner.core.api.domain.lookup.PlanningId;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 public class Room extends PanacheEntityBase {

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Timeslot.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Timeslot.java
@@ -9,8 +9,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import org.optaplanner.core.api.domain.lookup.PlanningId;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 public class Timeslot extends PanacheEntityBase {

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/LessonResource.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/LessonResource.java
@@ -13,8 +13,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import io.quarkus.panache.common.Sort;
 import org.acme.optaplanner.domain.Lesson;
+
+import io.quarkus.panache.common.Sort;
 
 @Path("/lessons")
 @Produces(MediaType.APPLICATION_JSON)

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/RoomResource.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/RoomResource.java
@@ -13,8 +13,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import io.quarkus.panache.common.Sort;
 import org.acme.optaplanner.domain.Room;
+
+import io.quarkus.panache.common.Sort;
 
 @Path("/rooms")
 @Produces(MediaType.APPLICATION_JSON)

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/TimeTableResource.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/TimeTableResource.java
@@ -9,7 +9,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.quarkus.panache.common.Sort;
 import org.acme.optaplanner.domain.Lesson;
 import org.acme.optaplanner.domain.Room;
 import org.acme.optaplanner.domain.TimeTable;
@@ -17,6 +16,8 @@ import org.acme.optaplanner.domain.Timeslot;
 import org.optaplanner.core.api.score.ScoreManager;
 import org.optaplanner.core.api.solver.SolverManager;
 import org.optaplanner.core.api.solver.SolverStatus;
+
+import io.quarkus.panache.common.Sort;
 
 @Path("/timeTable")
 @Produces(MediaType.APPLICATION_JSON)

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/TimeslotResource.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/rest/TimeslotResource.java
@@ -13,8 +13,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import io.quarkus.panache.common.Sort;
 import org.acme.optaplanner.domain.Timeslot;
+
+import io.quarkus.panache.common.Sort;
 
 @Path("/timeslots")
 @Produces(MediaType.APPLICATION_JSON)

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/LessonResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/LessonResourceTest.java
@@ -1,18 +1,16 @@
 package org.acme.optaplanner.rest;
 
-import java.time.DayOfWeek;
-import java.time.LocalTime;
-import java.util.List;
-
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.http.ContentType;
-import org.acme.optaplanner.domain.Lesson;
-import org.acme.optaplanner.domain.Timeslot;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+
+import org.acme.optaplanner.domain.Lesson;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class LessonResourceTest {

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/RoomResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/RoomResourceTest.java
@@ -1,18 +1,16 @@
 package org.acme.optaplanner.rest;
 
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.util.List;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.http.ContentType;
 import org.acme.optaplanner.domain.Room;
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class RoomResourceTest {

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeTableResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeTableResourceTest.java
@@ -1,17 +1,18 @@
 package org.acme.optaplanner.rest;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import javax.inject.Inject;
 
-import io.quarkus.test.junit.QuarkusTest;
 import org.acme.optaplanner.domain.Lesson;
 import org.acme.optaplanner.domain.TimeTable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.solver.SolverStatus;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class TimeTableResourceTest {

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeslotResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeslotResourceTest.java
@@ -1,19 +1,18 @@
 package org.acme.optaplanner.rest;
 
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.http.ContentType;
-import org.acme.optaplanner.domain.Room;
 import org.acme.optaplanner.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class TimeslotResourceTest {

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/ui/WebjarLoadingTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/ui/WebjarLoadingTest.java
@@ -1,10 +1,10 @@
 package org.acme.optaplanner.ui;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
-import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class WebjarLoadingTest {

--- a/rest-client-quickstart/src/main/java/org/acme/rest/client/CountriesResource.java
+++ b/rest-client-quickstart/src/main/java/org/acme/rest/client/CountriesResource.java
@@ -9,9 +9,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/country")
 public class CountriesResource {

--- a/rest-client-quickstart/src/main/java/org/acme/rest/client/CountriesService.java
+++ b/rest-client-quickstart/src/main/java/org/acme/rest/client/CountriesService.java
@@ -7,9 +7,10 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
-import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import io.smallrye.mutiny.Uni;
 
 @Path("/v2")
 @RegisterRestClient

--- a/security-openid-connect-multi-tenancy/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
+++ b/security-openid-connect-multi-tenancy/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
@@ -1,7 +1,6 @@
 package org.acme.quickstart.oidc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.util.Cookie;
 
 import io.quarkus.test.junit.QuarkusTest;
 

--- a/validation-quickstart/src/main/java/org/acme/validation/Book.java
+++ b/validation-quickstart/src/main/java/org/acme/validation/Book.java
@@ -1,7 +1,7 @@
 package org.acme.validation;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 
 public class Book {
 

--- a/validation-quickstart/src/main/java/org/acme/validation/BookResource.java
+++ b/validation-quickstart/src/main/java/org/acme/validation/BookResource.java
@@ -8,11 +8,11 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.Validator;
-import javax.ws.rs.Path;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
 
 @Path("/books")

--- a/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
@@ -1,15 +1,14 @@
 package org.acme.vertx;
 
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.smallrye.mutiny.Uni;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
+import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import io.vertx.mutiny.core.eventbus.Message;
 

--- a/vertx-quickstart/src/main/java/org/acme/vertx/Fruit.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/Fruit.java
@@ -16,14 +16,14 @@
 
 package org.acme.vertx;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.pgclient.PgPool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class Fruit {
 

--- a/vertx-quickstart/src/main/java/org/acme/vertx/FruitResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/FruitResource.java
@@ -20,22 +20,22 @@ import java.net.URI;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
-import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 
-import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
+import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.pgclient.PgPool;
 
 @Path("fruits")

--- a/vertx-quickstart/src/main/java/org/acme/vertx/GreetingResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/GreetingResource.java
@@ -1,8 +1,7 @@
 package org.acme.vertx;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.core.Vertx;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -10,8 +9,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
 
 @Path("/hello")
 public class GreetingResource {

--- a/vertx-quickstart/src/main/java/org/acme/vertx/ResourceUsingWebClient.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/ResourceUsingWebClient.java
@@ -1,18 +1,19 @@
 package org.acme.vertx;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.ext.web.client.WebClient;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.ext.web.client.WebClient;
 
 @Path("/fruit-data")
 public class ResourceUsingWebClient {

--- a/vertx-quickstart/src/main/java/org/acme/vertx/SockJsExample.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/SockJsExample.java
@@ -1,15 +1,16 @@
 package org.acme.vertx;
 
-import io.vertx.ext.bridge.PermittedOptions;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.handler.sockjs.BridgeOptions;
-import io.vertx.core.Vertx;
-import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.bridge.PermittedOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
 
 @ApplicationScoped
 public class SockJsExample {

--- a/vertx-quickstart/src/main/java/org/acme/vertx/StreamingResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/StreamingResource.java
@@ -1,15 +1,17 @@
 package org.acme.vertx;
 
-import io.smallrye.mutiny.Multi;
-import io.vertx.axle.core.Vertx;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import java.util.Date;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.Date;
+
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import io.smallrye.mutiny.Multi;
+import io.vertx.axle.core.Vertx;
 
 @Path("/hello")
 public class StreamingResource {

--- a/websockets-quickstart/src/test/java/org/acme/websockets/ChatTestCase.java
+++ b/websockets-quickstart/src/test/java/org/acme/websockets/ChatTestCase.java
@@ -5,10 +5,10 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import javax.websocket.ClientEndpoint;
-import javax.websocket.Session;
-import javax.websocket.OnOpen;
-import javax.websocket.OnMessage;
 import javax.websocket.ContainerProvider;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Fixing and reordering imports

Result of `mvn -fae -Dproject.build.sourceEncoding=UTF-8 net.revelc.code:impsort-maven-plugin:1.3.2:sort -Dimpsort.groups='java.,javax.,org.,com.' -Dimpsort.staticGroups='*' -Dimpsort.removeUnused=true`

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus