### PR TITLE
Temporarily disable Kogito quickstart build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <module>jms-quickstart</module>
         <module>kafka-quickstart</module>
         <module>kafka-streams-quickstart</module>
-        <module>kogito-quickstart</module>
+<!--        <module>kogito-quickstart</module>-->
         <module>optaplanner-quickstart</module>
         <module>lifecycle-quickstart</module>
         <module>microprofile-fault-tolerance-quickstart</module>


### PR DESCRIPTION
This is done because Kogito has now been moved outside of the Quarkus repo