### PR TITLE
package -> install

### DIFF
--- a/amqp-quickstart/README.md
+++ b/amqp-quickstart/README.md
@@ -35,7 +35,7 @@ NOTE: Hey, it's the same code as the Kafka quickstart! Yes, it is, the only diff
 
 You can compile the application into a native binary using:
 
-`mvn clean package -Pnative`
+`mvn clean install -Pnative`
 
 and run with:
 

--- a/dynamodb-quickstart/README.md
+++ b/dynamodb-quickstart/README.md
@@ -69,7 +69,7 @@ Alternatively, go to `http://localhost:8080/async-fruits.html` with the simple A
 
 You can compile the application into a native binary using:
 
-`mvn clean package -Pnative`
+`mvn clean install -Pnative`
 
 and run with:
 
@@ -80,7 +80,7 @@ and run with:
 --
 Build a native image in container by running:
 
-`mvn package -Pnative -Dnative-image.docker-build=true`
+`mvn install -Pnative -Dnative-image.docker-build=true`
 
 Build a docker image:
 `docker build -f src/main/docker/Dockerfile.native -t quarkus/dynamodb-quickstart .`

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -26,7 +26,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 ### Live coding with Quarkus
 
@@ -53,7 +53,7 @@ conventional jar file.
 
 First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Then run it:
 
@@ -72,7 +72,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 

--- a/hibernate-orm-panache-quickstart/README.md
+++ b/hibernate-orm-panache-quickstart/README.md
@@ -33,7 +33,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 ## Running the demo
 
@@ -65,7 +65,7 @@ conventional jar file.
 
 First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Then run it:
 
@@ -85,7 +85,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this binary directly:
 

--- a/hibernate-orm-quickstart/README.md
+++ b/hibernate-orm-quickstart/README.md
@@ -33,7 +33,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 ## Running the demo
 
@@ -65,7 +65,7 @@ conventional jar file.
 
 First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Then run it:
 
@@ -85,7 +85,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this binary directly:
 

--- a/hibernate-search-elasticsearch-quickstart/README.md
+++ b/hibernate-search-elasticsearch-quickstart/README.md
@@ -34,7 +34,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 Note that running this command will start an Elasticsearch cluster, start a PostgreSQL instance and run the tests.
 
@@ -80,7 +80,7 @@ conventional jar file.
 
 First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Note that this command will start a PostgreSQL instance and an Elasticsearch cluster to execute the tests.
 Thus your PostgreSQL and Elasticsearch containers need to be stopped.
@@ -103,7 +103,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this binary directly:
 

--- a/infinispan-client-quickstart/README.md
+++ b/infinispan-client-quickstart/README.md
@@ -31,7 +31,7 @@ If you use an older version of `http://www.infinispan.org/` or ``Red Hat Data Gr
 
 # Run the demo on dev mode
 
-- Run `mvn clean package` and then `java -jar ./target/infinispan-client-quickstart-runner.jar`
+- Run `mvn clean install` and then `java -jar ./target/infinispan-client-quickstart-runner.jar`
 - In dev mode `mvn clean quarkus:dev`
 
 Go to `http://localhost:8081/infinispan`, it should show you a message coming from the Infinispan server.

--- a/jms-quickstart/README.md
+++ b/jms-quickstart/README.md
@@ -33,7 +33,7 @@ The configuration is located in the application configuration.
 
 You can compile the application into a native binary using:
 
-`mvn clean package -Pnative`
+`mvn clean install -Pnative`
 
 and run with:
 

--- a/kafka-quickstart/README.md
+++ b/kafka-quickstart/README.md
@@ -33,7 +33,7 @@ The configuration is located in the application configuration.
 
 You can compile the application into a native binary using:
 
-`mvn clean package -Pnative`
+`mvn clean install -Pnative`
 
 and run with:
 

--- a/kafka-streams-quickstart/README.md
+++ b/kafka-streams-quickstart/README.md
@@ -23,7 +23,7 @@ for a given station using Kafka Streams interactive queries.
 To build the _producer_ and _aggregator_ applications, run
 
 ```bash
-mvn clean package
+mvn clean install
 ```
 
 ## Running
@@ -128,7 +128,7 @@ To run the _producer_ and _aggregator_ applications as native binaries via Graal
 first run the Maven builds using the `native` profile:
 
 ```bash
-mvn clean package -Pnative -Dnative-image.container-runtime=docker
+mvn clean install -Pnative -Dnative-image.container-runtime=docker
 ```
 
 Then create an environment variable named `QUARKUS_MODE` and with value set to "native":

--- a/mqtt-quickstart/README.md
+++ b/mqtt-quickstart/README.md
@@ -33,7 +33,7 @@ The configuration is located in the application configuration.
 
 You can compile the application into a native binary using:
 
-`mvn clean package -Pnative`
+`mvn clean install -Pnative`
 
 and run with:
 

--- a/quartz-quickstart/README.md
+++ b/quartz-quickstart/README.md
@@ -24,7 +24,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 ## Running the demo
 
@@ -53,11 +53,11 @@ conventional jar file.
 
 First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Note that running this command will start a PostgreSQL instance and run the tests. To skip tests use the command below
 
-> ./mvnw package -DskipTests
+> ./mvnw install -DskipTests
 
 Then run the application with:
 
@@ -76,7 +76,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this binary directly:
 

--- a/security-jdbc-quickstart/README.md
+++ b/security-jdbc-quickstart/README.md
@@ -63,7 +63,7 @@ mvn verify -Pnative
 
 You can compile the application into a native binary using:
 
-`mvn clean package -Pnative`
+`mvn clean install -Pnative`
 
 _Note: You need to have a proper GraalVM configuration to build a native binary._
 

--- a/security-keycloak-authorization-quickstart/README.md
+++ b/security-keycloak-authorization-quickstart/README.md
@@ -40,7 +40,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 ## Starting and Configuring the Keycloak Server
 
@@ -115,7 +115,7 @@ export access_token=$(\
 When you're done iterating in developer mode, you can run the application as a
 conventional jar file. First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Then run it:
 
@@ -134,7 +134,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 

--- a/security-openid-connect-multi-tenancy/README.md
+++ b/security-openid-connect-multi-tenancy/README.md
@@ -24,7 +24,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 ## Starting and Configuring the Keycloak Server
 
@@ -83,7 +83,7 @@ user `alice` exists in both tenants, for the application they are distinct users
 When you're done iterating in developer mode, you can run the application as a
 conventional jar file. First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Then run it:
 
@@ -102,7 +102,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 

--- a/security-openid-connect-web-authentication-quickstart/README.md
+++ b/security-openid-connect-web-authentication-quickstart/README.md
@@ -79,7 +79,7 @@ _NOTE:_ Running the tests with, for instance, `mvn package` requires the Keycloa
 When you're done iterating in developer mode, you can run the application as a
 conventional jar file. First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Then run it:
 
@@ -98,7 +98,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 

--- a/spring-data-jpa-quickstart/README.md
+++ b/spring-data-jpa-quickstart/README.md
@@ -21,7 +21,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw package
+> ./mvnw install
 
 ## Running the demo
 
@@ -55,7 +55,7 @@ conventional jar file.
 
 First compile it:
 
-> ./mvnw package
+> ./mvnw install
 
 Then run it:
 
@@ -75,7 +75,7 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Dnative
+> ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this binary directly:
 


### PR DESCRIPTION
Updating ./mvnw package -> ./mvnw install. 
./mvnw package causes containers created with docker-maven-plugin to remain running after build is complete.
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


