### PR TITLE
postgres + mariadb + mysql databases

### DIFF
--- a/hibernate-orm-quickstart/README.md
+++ b/hibernate-orm-quickstart/README.md
@@ -6,7 +6,7 @@ with a front-end based on Angular so you can play with it from your browser.
 While the code is surprisingly simple, under the hood this is using:
  - RESTEasy to expose the REST endpoints
  - Hibernate ORM to perform the CRUD operations on the database
- - A PostgreSQL database; see below to run one via Docker
+ - A PostgreSQL|MariaDB|MySQL database; see below to run one via Docker
  - ArC, the CDI inspired dependency injection tool with zero overhead
  - The high performance Agroal connection pool
  - Infinispan based caching
@@ -19,7 +19,7 @@ To compile and run this demo you will need:
 - JDK 1.8+
 - GraalVM
 
-In addition, you will need either a PostgreSQL database, or Docker to run one.
+In addition, you will need a database - PostgreSQL, MariaDB or MySQL, or Docker to run one.
 
 ### Configuring GraalVM and JDK 1.8+
 
@@ -33,15 +33,25 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw install
+> ./mvnw clean install
 
 ## Running the demo
 
-### Prepare a PostgreSQL instance
+### Prepare a database instance
 
-Make sure you have a PostgreSQL instance running. To set up a PostgreSQL database with Docker:
+Make sure you have a database instance running - one of PostgreSQL, MariaDB or MySQL.
 
-> docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:10.5
+To set up a PostgreSQL database with Docker:
+
+> docker run --ulimit memlock=-1:-1 -d -it --memory-swappiness=0 --name postgres -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:10.5
+
+To set up a MariaDB database with Docker:
+
+> docker run --ulimit memlock=-1:-1 -d -it --memory-swappiness=0 --name mariadb -e MYSQL_USER=quarkus_test -e MYSQL_PASSWORD=quarkus_test -e MYSQL_DATABASE=quarkus_test -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 mariadb:10.3
+
+To set up a MySQL database with Docker:
+
+> docker run --ulimit memlock=-1:-1 -d -it --memory-swappiness=0 --name mysql -e MYSQL_USER=quarkus_test -e MYSQL_PASSWORD=quarkus_test -e MYSQL_DATABASE=quarkus_test -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 mysql:8.0
 
 Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
 `src/main/resources/application.properties`.
@@ -49,9 +59,13 @@ Connection properties for the Agroal datasource are defined in the standard Quar
 ### Live coding with Quarkus
 
 The Maven Quarkus plugin provides a development mode that supports
-live coding. To try this out:
+live coding. Try this out. If you have PostgreSQL running:
 
-> ./mvnw quarkus:dev
+> ./mvnw clean quarkus:dev
+
+In case you have MariaDB or MySQL running choose appropriate profile:
+
+> ./mvnw clean quarkus:dev -Dquarkus.profile=<mariadb|mysql>
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
@@ -63,9 +77,13 @@ Try it! Even the database schema will be updated on the fly.
 When you're done iterating in developer mode, you can run the application as a
 conventional jar file.
 
-First compile it:
+First compile it. For PostgreSQL run:
 
-> ./mvnw install
+> ./mvnw clean install
+
+For MariaDB or MySQL choose appropriate profile:
+
+> ./mvnw clean install -Dquarkus.profile=<mariadb|mysql> -Dquarkus.test.profile=<mariadb|mysql>
 
 Then run it:
 
@@ -83,9 +101,13 @@ the executable, allowing the application to run with minimal resource overhead.
 
 Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
-native executable:
+native executable. For PostgreSQL:
 
-> ./mvnw install -Dnative
+> ./mvnw clean install -Dnative
+
+For MariaDB or MySQL choose appropriate profile:
+
+> ./mvnw clean install -Dnative -Dquarkus.profile=<mariadb|mysql> -Dquarkus.test.profile=<mariadb|mysql>
 
 After getting a cup of coffee, you'll be able to run this binary directly:
 
@@ -99,7 +121,7 @@ Next, maybe you're ready to measure how much memory this service is consuming.
 
 N.B. This implies all dependencies have been compiled to native;
 that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM
-applies to your entities, to the lower level essential components such as the PostgreSQL JDBC driver, the Undertow webserver.
+applies to your entities, to the lower level essential components such as the jdbc driver, the Undertow webserver.
 
 ## See the demo in your browser
 
@@ -118,4 +140,12 @@ Then, rebuild demo docker image with a system property that points to the DB.
 
 ```bash
 -Dquarkus.datasource.jdbc.url=jdbc:postgresql://<DB_SERVICE_NAME>/quarkus_test
+```
+
+```bash
+-Dquarkus.datasource.jdbc.url=jdbc:mariadb://<DB_SERVICE_NAME>/quarkus_test
+```
+
+```bash
+-Dquarkus.datasource.jdbc.url=jdbc:mysql://<DB_SERVICE_NAME>/quarkus_test
 ```

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -50,9 +50,8 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-postgresql</artifactId>
+            <artifactId>${jdbc.driver}</artifactId>
         </dependency>
-
         <!-- Testing: -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -102,63 +101,52 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <!-- Automatically start PostgreSQL for integration testing - requires Docker -->
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>${docker-plugin.version}</version>
-                <configuration>
-                    <skip>${skipTests}</skip>
-                    <images>
-                        <image>
-                            <name>postgres:10.5</name>
-                            <alias>postgresql</alias>
-                            <run>
-                                <env>
-                                    <POSTGRES_USER>quarkus_test</POSTGRES_USER>
-                                    <POSTGRES_PASSWORD>quarkus_test</POSTGRES_PASSWORD>
-                                    <POSTGRES_DB>quarkus_test</POSTGRES_DB>
-                                </env>
-                                <ports>
-                                    <port>5432:5432</port>
-                                </ports>
-                                <log>
-                                    <prefix>PostgreSQL: </prefix>
-                                    <date>default</date>
-                                    <color>cyan</color>
-                                </log>
-                                <wait>
-                                    <tcp>
-                                        <mode>mapped</mode>
-                                        <ports>
-                                            <port>5432</port>
-                                        </ports>
-                                    </tcp>
-                                    <time>10000</time>
-                                </wait>
-                            </run>
-                        </image>
-                    </images>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>docker-start</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>stop</goal>
-                            <goal>start</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>docker-stop</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-plugin.version}</version>
+                    <configuration>
+                        <skip>${skipTests}</skip>
+                        <images>
+                            <image>
+                                <name>${image.name}</name>
+                                <alias>${image.alias}</alias>
+                                <run>
+                                    <ports>
+                                        <port>${database.port}:${database.port}</port>
+                                    </ports>
+                                    <log>
+                                        <prefix>${image.alias}: </prefix>
+                                        <date>default</date>
+                                        <color>cyan</color>
+                                    </log>
+                                </run>
+                            </image>
+                        </images>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>docker-start</id>
+                            <phase>test-compile</phase>
+                            <goals>
+                                <goal>stop</goal>
+                                <goal>start</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>docker-stop</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>stop</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>
@@ -251,6 +239,132 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>postgres</id>
+            <activation>
+                <property>
+                    <name>!quarkus.profile</name>
+                </property>
+            </activation>
+            <properties>
+                <jdbc.driver>quarkus-jdbc-postgresql</jdbc.driver>
+                <database.port>5432</database.port>
+                <image.name>postgres:10.5</image.name>
+                <image.alias>postgres</image.alias>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <run>
+                                        <env>
+                                            <POSTGRES_USER>quarkus_test</POSTGRES_USER>
+                                            <POSTGRES_PASSWORD>quarkus_test</POSTGRES_PASSWORD>
+                                            <POSTGRES_DB>quarkus_test</POSTGRES_DB>
+                                        </env>
+                                        <wait>
+                                            <tcp>
+                                                <mode>mapped</mode>
+                                                <ports>
+                                                    <port>${database.port}</port>
+                                                </ports>
+                                            </tcp>
+                                            <time>20000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>mariadb</id>
+            <activation>
+                <property>
+                    <name>quarkus.profile</name>
+                    <value>mariadb</value>
+                </property>
+            </activation>
+            <properties>
+                <jdbc.driver>quarkus-jdbc-mariadb</jdbc.driver>
+                <database.port>3306</database.port>
+                <image.name>mariadb:10.3</image.name>
+                <image.alias>mariadb</image.alias>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <run>
+                                        <env>
+                                            <MYSQL_USER>quarkus_test</MYSQL_USER>
+                                            <MYSQL_PASSWORD>quarkus_test</MYSQL_PASSWORD>
+                                            <MYSQL_DATABASE>quarkus_test</MYSQL_DATABASE>
+                                            <MYSQL_RANDOM_ROOT_PASSWORD>true</MYSQL_RANDOM_ROOT_PASSWORD>
+                                        </env>
+                                        <wait>
+                                            <log>MySQL init process done. Ready for start up.</log>
+                                            <time>20000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>mysql</id>
+            <activation>
+                <property>
+                    <name>quarkus.profile</name>
+                    <value>mysql</value>
+                </property>
+            </activation>
+            <properties>
+                <jdbc.driver>quarkus-jdbc-mysql</jdbc.driver>
+                <database.port>3306</database.port>
+                <image.name>mysql:8.0</image.name>
+                <image.alias>mysql</image.alias>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <run>
+                                        <env>
+                                            <MYSQL_USER>quarkus_test</MYSQL_USER>
+                                            <MYSQL_PASSWORD>quarkus_test</MYSQL_PASSWORD>
+                                            <MYSQL_DATABASE>quarkus_test</MYSQL_DATABASE>
+                                            <MYSQL_RANDOM_ROOT_PASSWORD>true</MYSQL_RANDOM_ROOT_PASSWORD>
+                                        </env>
+                                        <wait>
+                                            <log>MySQL init process done. Ready for start up.</log>
+                                            <time>20000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
@@ -3,7 +3,7 @@
 #
 # Before building the docker image run:
 #
-# mvn package
+# mvn clean install
 #
 # Then, build the image with:
 #

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.native
@@ -3,7 +3,7 @@
 #
 # Before building the docker image run:
 #
-# mvn package -Pnative -Dquarkus.native.container-build=true
+# mvn clean install -Pnative -Dquarkus.native.container-build=true
 #
 # Then, build the image with:
 #

--- a/hibernate-orm-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-quickstart/src/main/resources/application.properties
@@ -1,3 +1,11 @@
+%mariadb.quarkus.datasource.db-kind=mariadb
+%mariadb.quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB103Dialect
+%mariadb.quarkus.datasource.jdbc.url=jdbc:mariadb://localhost:3306/quarkus_test
+
+%mysql.quarkus.datasource.db-kind=mysql
+%mysql.quarkus.hibernate-orm.dialect=org.hibernate.dialect.MySQL8Dialect
+%mysql.quarkus.datasource.jdbc.url=jdbc:mysql://localhost:3306/quarkus_test
+
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=quarkus_test
 quarkus.datasource.password=quarkus_test


### PR DESCRIPTION
Added mysql and mariadb database options, so that we have coverage of their extensions.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


