### PR TITLE
hsearch-es: Upgrade to Hibernate Search 6.0.0.Beta6

### DIFF
--- a/hibernate-search-elasticsearch-quickstart/README.md
+++ b/hibernate-search-elasticsearch-quickstart/README.md
@@ -48,7 +48,7 @@ You can launch a test instance easily from the project directory:
 
 If you prefer using Docker:
 
-> docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.0
+> docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.1
 
 Alternatively you can setup an Elasticsearch instance in any another way.
 

--- a/hibernate-search-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-elasticsearch-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>
         <elasticsearch-maven-plugin.version>6.15</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.6.0</elasticsearch-server.version>
+        <elasticsearch-server.version>7.6.1</elasticsearch-server.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-search-elasticsearch-quickstart/src/main/resources/application.properties
+++ b/hibernate-search-elasticsearch-quickstart/src/main/resources/application.properties
@@ -11,6 +11,6 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 
 quarkus.hibernate-search.elasticsearch.version=7
 quarkus.hibernate-search.elasticsearch.analysis.configurer=org.acme.hibernate.search.elasticsearch.config.AnalysisConfigurer
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.required-status=yellow
+quarkus.hibernate-search.schema-management.strategy=drop-and-create
+quarkus.hibernate-search.elasticsearch.index-defaults.schema-management.required-status=yellow
 quarkus.hibernate-search.automatic-indexing.synchronization.strategy=sync


### PR DESCRIPTION
Requires https://github.com/quarkusio/quarkus/pull/8328 .
