### PR TITLE
Anonymous user is now represented by Principal with an empty name

### DIFF
--- a/security-jwt-quickstart/src/main/java/org/acme/security/jwt/TokenSecuredResource.java
+++ b/security-jwt-quickstart/src/main/java/org/acme/security/jwt/TokenSecuredResource.java
@@ -42,7 +42,7 @@ public class TokenSecuredResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String hello(@Context SecurityContext ctx) {
         Principal caller = ctx.getUserPrincipal();
-        String name = caller == null ? "anonymous" : caller.getName();
+        String name = caller.getName().isEmpty() ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
         String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
                 ctx.getAuthenticationScheme(), hasJWT);
@@ -55,7 +55,7 @@ public class TokenSecuredResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String helloRolesAllowed(@Context SecurityContext ctx) {
         Principal caller = ctx.getUserPrincipal();
-        String name = caller == null ? "anonymous" : caller.getName();
+        String name = caller.getName().isEmpty() ? "anonymous" : caller.getName();
         boolean hasJWT = jwt.getClaimNames() != null;
         String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(),
                 ctx.getAuthenticationScheme(), hasJWT);
@@ -68,7 +68,7 @@ public class TokenSecuredResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String helloShouldDeny(@Context SecurityContext ctx) {
         Principal caller = ctx.getUserPrincipal();
-        String name = caller == null ? "anonymous" : caller.getName();
+        String name = caller.getName().isEmpty() ? "anonymous" : caller.getName();
         return "hello + " + name;
     }
 


### PR DESCRIPTION
Principal with an empty name is probably better than a null Principal (and it is probably more common). https://github.com/quarkusio/quarkus/pull/8556 itself does not change the way the name is handled.
I think we may need to mention it in the migration guide 