### PR TITLE
fix: change store type to `jdbc-cmt` because `db` will be deprecated

### DIFF
--- a/quartz-quickstart/src/main/resources/application.properties
+++ b/quartz-quickstart/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.quartz.store-type=db
+quarkus.quartz.store-type=jdbc-cmt
 quarkus.quartz.clustered=true
 
 quarkus.datasource.db-kind=postgresql


### PR DESCRIPTION
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
- [x] links the documentation update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [x] For new quickstart, is located in the directory _component-quickstart_
- [x] For new quickstart, is added to the root `pom.xml` and `README.md`


To be merged after https://github.com/quarkusio/quarkus/pull/8566 

/cc @mkouba 

