### PR TITLE
Comment out UseConcMarkSweepGC to be able to run on GraalVM

### DIFF
--- a/hibernate-search-elasticsearch-quickstart/src/test/resources/elasticsearch-maven-plugin/configuration/jvm.options
+++ b/hibernate-search-elasticsearch-quickstart/src/test/resources/elasticsearch-maven-plugin/configuration/jvm.options
@@ -36,7 +36,7 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
+# -XX:+UseConcMarkSweepGC
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
 


### PR DESCRIPTION
Comment out UseConcMarkSweepGC to be able to run on GraalVM. Went ahead just with the minimal change, was also considering to comment out whole GC configuration section (PR can be updated if needed).

Fixes https://github.com/quarkusio/quarkus-quickstarts/issues/489

Tested on:
 - JDK 8 / 11  / 13 / 14
 - GraalVM 19.3.1 r11 / 20.0.0 r11

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
