### PR TITLE
Add application.properties for easy configuration

### DIFF
--- a/getting-started/src/main/resources/application.properties
+++ b/getting-started/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Quarkus Configuration file
+# key = value


### PR DESCRIPTION
Why:

 * getting-started is used by default in Eclipse Che and
   currently user need to know where to put the application.properties
   to start configuring. Would be nice if file is already in place.

This change addreses the need by:

 * Adds empty/default `application.properties`

Related to https://github.com/eclipse/che/issues/16700


