### PR TITLE
Add tests to the KafkaStreams quickstart

### DIFF
--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -19,6 +19,7 @@
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <debezium.version>1.1.0.Final</debezium.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -52,6 +53,29 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-streams-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.debezium</groupId>
+      <artifactId>debezium-core</artifactId>
+      <version>${debezium.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.debezium</groupId>
+      <artifactId>debezium-core</artifactId>
+      <version>${debezium.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kafka-streams-quickstart/aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStation.java
+++ b/kafka-streams-quickstart/aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStation.java
@@ -7,4 +7,12 @@ public class WeatherStation {
 
     public int id;
     public String name;
+
+    public WeatherStation(){
+    }
+
+    public WeatherStation(int id, String name){
+        this.id = id;
+        this.name = name;
+    }
 }

--- a/kafka-streams-quickstart/aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/TopologyProducer.java
+++ b/kafka-streams-quickstart/aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/TopologyProducer.java
@@ -25,9 +25,9 @@ public class TopologyProducer {
 
     static final String WEATHER_STATIONS_STORE = "weather-stations-store";
 
-    private static final String WEATHER_STATIONS_TOPIC = "weather-stations";
-    private static final String TEMPERATURE_VALUES_TOPIC = "temperature-values";
-    private static final String TEMPERATURES_AGGREGATED_TOPIC = "temperatures-aggregated";
+    static final String WEATHER_STATIONS_TOPIC = "weather-stations";
+    static final String TEMPERATURE_VALUES_TOPIC = "temperature-values";
+    static final String TEMPERATURES_AGGREGATED_TOPIC = "temperatures-aggregated";
 
     @Produces
     public Topology buildTopology() {

--- a/kafka-streams-quickstart/aggregator/src/main/resources/application.properties
+++ b/kafka-streams-quickstart/aggregator/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
 quarkus.kafka-streams.application-id=temperature-aggregator
 quarkus.kafka-streams.application-server=${hostname}:8080
+# Workaround as HOSTNAME env variable doesn't exist in Quarkus CI nor Windows
+# See https://github.com/quarkusio/quarkus/issues/10064
+hostname=localhost
 quarkus.kafka-streams.topics=weather-stations,temperature-values
 
 # streams options
@@ -9,6 +12,9 @@ kafka-streams.commit.interval.ms=1000
 kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=earliest
 kafka-streams.metrics.recording.level=DEBUG
+# Use sub-folder of embedded broker, so it gets cleaned by KafkaResource between re-runs
+# This does not work for native tests, manually clean-up /tmp/kafka-streams/temperature-aggregator
+%test.kafka-streams.state.dir=target/data/kafka-data/stores
 
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/AggregatorTest.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/AggregatorTest.java
@@ -1,0 +1,108 @@
+package org.acme.kafka.streams.aggregator.streams;
+
+import io.quarkus.kafka.client.serialization.JsonbDeserializer;
+import io.quarkus.kafka.client.serialization.JsonbSerializer;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.acme.kafka.streams.aggregator.model.Aggregation;
+import org.acme.kafka.streams.aggregator.model.WeatherStation;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.acme.kafka.streams.aggregator.streams.TopologyProducer.TEMPERATURES_AGGREGATED_TOPIC;
+import static org.acme.kafka.streams.aggregator.streams.TopologyProducer.TEMPERATURE_VALUES_TOPIC;
+import static org.acme.kafka.streams.aggregator.streams.TopologyProducer.WEATHER_STATIONS_TOPIC;
+
+/**
+ * Integration testing of the application with an embedded broker.
+ */
+@QuarkusTest
+@QuarkusTestResource(KafkaResource.class)
+public class AggregatorTest {
+
+    static final String BROKER_LIST = "localhost:9092";
+
+    KafkaProducer<Integer, String> temperatureProducer;
+
+    KafkaProducer<Integer, WeatherStation> weatherStationsProducer;
+
+    KafkaConsumer<Integer, Aggregation> weatherStationsConsumer;
+
+    @BeforeEach
+    public void setUp(){
+        temperatureProducer = new KafkaProducer(producerProps(), new IntegerSerializer(), new StringSerializer());
+        weatherStationsProducer = new KafkaProducer(producerProps(), new IntegerSerializer(), new JsonbSerializer());
+        weatherStationsConsumer =  new KafkaConsumer(consumerProps(), new IntegerDeserializer(), new JsonbDeserializer<>(Aggregation.class));
+    }
+
+    @AfterEach
+    public void tearDown(){
+        temperatureProducer.close();
+        weatherStationsProducer.close();
+        weatherStationsConsumer.close();
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void test() throws InterruptedException {
+        weatherStationsConsumer.subscribe(Collections.singletonList(TEMPERATURES_AGGREGATED_TOPIC));
+        weatherStationsProducer.send(new ProducerRecord<>(WEATHER_STATIONS_TOPIC, 1, new WeatherStation(1, "Station 1")));
+        temperatureProducer.send(new ProducerRecord<>(TEMPERATURE_VALUES_TOPIC, 1,Instant.now() + ";" + "15" ));
+        temperatureProducer.send(new ProducerRecord<>(TEMPERATURE_VALUES_TOPIC, 1,Instant.now() + ";" + "25" ));
+        List<ConsumerRecord<Integer, Aggregation>> results = poll(weatherStationsConsumer,1);
+
+        // Assumes the state store was initially empty
+        Assertions.assertEquals(2, results.get(0).value().count);
+        Assertions.assertEquals(1, results.get(0).value().stationId);
+        Assertions.assertEquals("Station 1", results.get(0).value().stationName);
+        Assertions.assertEquals(20, results.get(0).value().avg);
+    }
+
+    private Properties consumerProps() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BROKER_LIST);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return props;
+    }
+
+    private Properties producerProps() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BROKER_LIST);
+        return props;
+    }
+
+    private List<ConsumerRecord<Integer, Aggregation>> poll(Consumer<Integer, Aggregation> consumer, int expectedRecordCount) {
+        int fetched = 0;
+        List<ConsumerRecord<Integer, Aggregation>> result = new ArrayList<>();
+        while (fetched < expectedRecordCount) {
+            ConsumerRecords<Integer, Aggregation> records = consumer.poll(Duration.ofSeconds(1));
+            records.forEach(result::add);
+            fetched = result.size();
+        }
+        return result;
+    }
+}

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/KafkaResource.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/KafkaResource.java
@@ -1,0 +1,42 @@
+package org.acme.kafka.streams.aggregator.streams;
+
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Testing;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+public class KafkaResource implements QuarkusTestResourceLifecycleManager  {
+
+    private KafkaCluster kafka;
+
+    @Override
+    public Map<String, String> start() {
+        try {
+            Properties props = new Properties();
+            props.setProperty("zookeeper.connection.timeout.ms", "45000");
+            File directory = Testing.Files.createTestingDirectory("kafka-data", true);
+            kafka = new KafkaCluster().withPorts(2182, 9092)
+                    .addBrokers(1)
+                    .usingDirectory(directory)
+                    .deleteDataUponShutdown(true)
+                    .withKafkaConfiguration(props)
+                    .deleteDataPriorToStartup(true)
+                    .startup();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        if (kafka != null) {
+            kafka.shutdown();
+        }
+    }
+}

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/NativeAggregatorIT.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/NativeAggregatorIT.java
@@ -1,0 +1,13 @@
+package org.acme.kafka.streams.aggregator.streams;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+/**
+ * Native tests execute with prod profile, not test. cf https://github.com/quarkusio/quarkus/issues/4371
+ * Since we extend the Hotspot tests and share the QuarkusTestResource,
+ * this means broker test port MUST be the same as production port.
+ */
+@NativeImageTest
+public class NativeAggregatorIT extends AggregatorTest {
+
+}

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/TopologyProducerTest.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/TopologyProducerTest.java
@@ -1,0 +1,83 @@
+package org.acme.kafka.streams.aggregator.streams;
+
+import io.quarkus.kafka.client.serialization.JsonbDeserializer;
+import io.quarkus.kafka.client.serialization.JsonbSerializer;
+import io.quarkus.test.junit.QuarkusTest;
+import org.acme.kafka.streams.aggregator.model.Aggregation;
+import org.acme.kafka.streams.aggregator.model.WeatherStation;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.test.TestRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.time.Instant;
+import java.util.Properties;
+
+import static org.acme.kafka.streams.aggregator.streams.TopologyProducer.TEMPERATURES_AGGREGATED_TOPIC;
+import static org.acme.kafka.streams.aggregator.streams.TopologyProducer.TEMPERATURE_VALUES_TOPIC;
+import static org.acme.kafka.streams.aggregator.streams.TopologyProducer.WEATHER_STATIONS_STORE;
+import static org.acme.kafka.streams.aggregator.streams.TopologyProducer.WEATHER_STATIONS_TOPIC;
+
+/**
+ * Testing of the Topology without a broker, using TopologyTestDriver
+ */
+@QuarkusTest
+public class TopologyProducerTest {
+
+    @Inject
+    Topology topology;
+
+    TopologyTestDriver testDriver;
+
+    TestInputTopic<Integer, String> temperatures;
+
+    TestInputTopic<Integer, WeatherStation> weatherStations;
+
+    TestOutputTopic<Integer, Aggregation> temperaturesAggregated;
+
+    @BeforeEach
+    public void setUp(){
+        Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testApplicationId");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+        testDriver = new TopologyTestDriver(topology, config);
+
+        temperatures = testDriver.createInputTopic(TEMPERATURE_VALUES_TOPIC, new IntegerSerializer(), new StringSerializer());
+        weatherStations = testDriver.createInputTopic(WEATHER_STATIONS_TOPIC, new IntegerSerializer(), new JsonbSerializer());
+
+        temperaturesAggregated = testDriver.createOutputTopic(TEMPERATURES_AGGREGATED_TOPIC, new IntegerDeserializer(),
+                new JsonbDeserializer<>(Aggregation.class));
+    }
+
+    @AfterEach
+    public void tearDown(){
+        testDriver.getTimestampedKeyValueStore(WEATHER_STATIONS_STORE).flush();
+        testDriver.close();
+    }
+
+    @Test
+    public void test(){
+        WeatherStation station1 = new WeatherStation(1,"Station 1");
+        weatherStations.pipeInput(station1.id, station1);
+        temperatures.pipeInput(station1.id, Instant.now() + ";" + "15");
+        temperatures.pipeInput(station1.id, Instant.now() + ";" + "25");
+
+        temperaturesAggregated.readRecord();
+        TestRecord<Integer, Aggregation> result = temperaturesAggregated.readRecord();
+
+        Assertions.assertEquals(2, result.getValue().count);
+        Assertions.assertEquals(1, result.getValue().stationId);
+        Assertions.assertEquals("Station 1", result.getValue().stationName);
+        Assertions.assertEquals(20, result.getValue().avg);
+    }
+}


### PR DESCRIPTION
Fixes #546

- Add a QuarkusTest using Kafka Streams TopologyTestDriver - this is the standard way to test a KStream topology. 
- Add a QuarkusTest using Debezium embedded Kafka broker - this fully tests the application, not only the topology.
- Add a NativeImageTest, based on the embedded broker QuarkusTest

Should the writing of the tests be documented in the guide https://quarkus.io/guides/kafka-streams as well ?

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`
