### PR TITLE
Fix Vert.x SockJS API breakage.

### DIFF
--- a/vertx-quickstart/src/main/java/org/acme/vertx/SockJsExample.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/SockJsExample.java
@@ -7,6 +7,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.sockjs.BridgeOptions;
@@ -18,11 +19,9 @@ public class SockJsExample {
     @Inject Vertx vertx;
 
     public void init(@Observes Router router) {
-        BridgeOptions opts = new BridgeOptions()
-                .addOutboundPermitted(new PermittedOptions().setAddress("ticks"));
-
         SockJSHandler sockJSHandler = SockJSHandler.create(vertx);
-        sockJSHandler.bridge(opts);
+        sockJSHandler.bridge(new BridgeOptions(new JsonObject())
+                .addOutboundPermitted(new PermittedOptions().setAddress("ticks")));
         router.route("/eventbus/*").handler(sockJSHandler);
 
         AtomicInteger counter = new AtomicInteger();


### PR DESCRIPTION
Finding a way that works with both Vert.x 3.9.0 and 3.9.1 was surprisingly difficult.
