### PR TITLE
Update Keycloak to 10.0.1 and sync on KeycloakServer

### DIFF
--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -14,6 +14,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <keycloak.version>10.0.1</keycloak.version>
         <testcontainers.version>1.14.1</testcontainers.version>
         <surefire.version>2.22.0</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -75,6 +76,7 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
+                        <keycloak.version>${keycloak.version}</keycloak.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -136,6 +138,7 @@
                                             org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <maven.home>${maven.home}</maven.home>
+                                        <keycloak.version>${keycloak.version}</keycloak.version>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/security-keycloak-authorization-quickstart/src/test/java/org/acme/security/keycloak/authorization/KeycloakServer.java
+++ b/security-keycloak-authorization-quickstart/src/test/java/org/acme/security/keycloak/authorization/KeycloakServer.java
@@ -1,20 +1,20 @@
 package org.acme.security.keycloak.authorization;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-public class KeycloakServer implements BeforeAllCallback, AfterAllCallback {
+import java.util.Collections;
+import java.util.Map;
 
+public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
     private GenericContainer keycloak;
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) {
-        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:7.0.1")
+    public Map<String, String> start() {
+        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:" + System.getProperty("keycloak.version"))
                 .withFixedExposedPort(8180, 8080)
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
@@ -22,10 +22,11 @@ public class KeycloakServer implements BeforeAllCallback, AfterAllCallback {
                 .withClasspathResourceMapping("quarkus-realm.json", "/tmp/realm.json", BindMode.READ_ONLY)
                 .waitingFor(Wait.forHttp("/auth"));
         keycloak.start();
+        return Collections.emptyMap();
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) {
+    public void stop() {
         keycloak.stop();
     }
 }

--- a/security-keycloak-authorization-quickstart/src/test/java/org/acme/security/keycloak/authorization/PolicyEnforcerTest.java
+++ b/security-keycloak-authorization-quickstart/src/test/java/org/acme/security/keycloak/authorization/PolicyEnforcerTest.java
@@ -1,14 +1,14 @@
 package org.acme.security.keycloak.authorization;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.representations.AccessTokenResponse;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
-@ExtendWith(KeycloakServer.class)
 @QuarkusTest
+@QuarkusTestResource(KeycloakServer.class)
 public class PolicyEnforcerTest {
 
     private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");

--- a/security-openid-connect-multi-tenancy/pom.xml
+++ b/security-openid-connect-multi-tenancy/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <keycloak.version>9.0.0</keycloak.version>
+        <keycloak.version>10.0.1</keycloak.version>
         <surefire.version>2.22.0</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-multi-tenancy/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
+++ b/security-openid-connect-multi-tenancy/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
 import com.gargoylesoftware.htmlunit.WebClient;
@@ -15,8 +15,8 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.junit.QuarkusTest;
 
-@ExtendWith(KeycloakServer.class)
 @QuarkusTest
+@QuarkusTestResource(KeycloakServer.class)
 public class CodeFlowTest {
 
     @Test

--- a/security-openid-connect-multi-tenancy/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
+++ b/security-openid-connect-multi-tenancy/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
@@ -1,19 +1,20 @@
 package org.acme.quickstart.oidc;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-public class KeycloakServer implements BeforeAllCallback, AfterAllCallback {
+import java.util.Collections;
+import java.util.Map;
+
+public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
 
     private GenericContainer keycloak;
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) {
+    public Map<String, String> start() {
         keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:" + System.getProperty("keycloak.version"))
                 .withFixedExposedPort(8180, 8080)
                 .withEnv("KEYCLOAK_USER", "admin")
@@ -23,10 +24,11 @@ public class KeycloakServer implements BeforeAllCallback, AfterAllCallback {
                 .withClasspathResourceMapping("tenant-a-realm.json", "/tmp/tenant-a-realm.json", BindMode.READ_ONLY)
                 .waitingFor(Wait.forHttp("/auth"));
         keycloak.start();
+        return Collections.emptyMap();
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) {
+    public void stop() {
         keycloak.stop();
     }
 }

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <keycloak.version>9.0.0</keycloak.version>
+        <keycloak.version>10.0.1</keycloak.version>
         <surefire.version>2.22.0</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Update Keycloak to 10.0.1 and sync on KeycloakServer

`@QuarkusTestResource(KeycloakServer.class)` approach used by Stuart in  security-openid-connect-web-authentication-quickstart

Keycloak 10.0.1 ... https://github.com/quarkusio/quarkus/blob/master/bom/runtime/pom.xml#L187

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
