### PR TITLE
Native tests sync and additions

### DIFF
--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/src/test/java/org/acme/funqy/FunqyIT.java
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/src/test/java/org/acme/funqy/FunqyIT.java
@@ -1,0 +1,11 @@
+package org.acme.funqy;
+
+import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.Disabled;
+
+@NativeImageTest
+@Disabled("https://github.com/quarkusio/quarkus/issues/7362")
+public class FunqyIT extends FunqyTest {
+
+    // Run the same tests
+}

--- a/jms-quickstart/src/test/java/org/acme/jms/PriceTestIT.java
+++ b/jms-quickstart/src/test/java/org/acme/jms/PriceTestIT.java
@@ -3,5 +3,5 @@ package org.acme.jms;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-public class PriceTestITCase extends PriceTest {
+public class PriceTestIT extends PriceTest {
 }

--- a/qute-quickstart/src/test/java/org/acme/qute/NativeItemsResourceIT.java
+++ b/qute-quickstart/src/test/java/org/acme/qute/NativeItemsResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.qute;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeItemsResourceIT extends ItemsResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/websockets-quickstart/src/test/java/org/acme/websockets/ChatIT.java
+++ b/websockets-quickstart/src/test/java/org/acme/websockets/ChatIT.java
@@ -3,6 +3,6 @@ package org.acme.websockets;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-public class ChatITCase extends ChatTestCase {
+public class ChatIT extends ChatTestCase {
 
 }

--- a/websockets-quickstart/src/test/java/org/acme/websockets/ChatIT.java
+++ b/websockets-quickstart/src/test/java/org/acme/websockets/ChatIT.java
@@ -3,6 +3,6 @@ package org.acme.websockets;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-public class ChatIT extends ChatTestCase {
+public class ChatIT extends ChatTest {
 
 }

--- a/websockets-quickstart/src/test/java/org/acme/websockets/ChatTest.java
+++ b/websockets-quickstart/src/test/java/org/acme/websockets/ChatTest.java
@@ -17,7 +17,7 @@ import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-public class ChatTestCase {
+public class ChatTest {
 
     private static final LinkedBlockingDeque<String> MESSAGES = new LinkedBlockingDeque<>();
 


### PR DESCRIPTION
 - Adding IT tests for qute and funqy-amazon-lambda-http to match JVM vs Native coverage
 - Rename ChatTestCase to ChatTest to be in sync with the rest of tests
 - Sync native tests to follow FooBarIT.java naming

Checks
- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
