### PR TITLE
Oauth2 wiremock

### DIFF
--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -15,6 +15,7 @@
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <wiremock.version>2.26.3</wiremock.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -30,8 +31,13 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-elytron-security-oauth2</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
@@ -43,12 +49,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jsonb</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-elytron-security-oauth2</artifactId>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <scope>test</scope>
+      <version>${wiremock.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/MockAuthorizationServerTestResource.java
+++ b/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/MockAuthorizationServerTestResource.java
@@ -1,0 +1,34 @@
+package org.acme.security.oauth2;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MockAuthorizationServerTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer();
+        wireMockServer.start();
+
+        // define the mock for the introspect endpoint
+        WireMock.stubFor(WireMock.post("/introspect").willReturn(WireMock.aResponse()
+                .withBody(
+                        "{\"active\":true,\"scope\":\"READER\",\"username\":null,\"iat\":1562315654,\"exp\":1562317454,\"expires_in\":1458,\"client_id\":\"my_client_id\"}")));
+
+
+        return Collections.singletonMap("quarkus.oauth2.introspection-url", wireMockServer.baseUrl() + "/introspect");
+    }
+
+    @Override
+    public void stop() {
+        if (null != wireMockServer) {
+            wireMockServer.stop();
+        }
+    }
+}

--- a/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceIT.java
+++ b/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.security.oauth2;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class TokenSecuredResourceIT extends TokenSecuredResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceTest.java
+++ b/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceTest.java
@@ -1,0 +1,37 @@
+package org.acme.security.oauth2;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+@QuarkusTestResource(MockAuthorizationServerTestResource.class)
+class TokenSecuredResourceTest {
+    // use whatever token you want as the mock OAuth server will accept all tokens
+    private static final String BEARER_TOKEN = "337aab0f-b547-489b-9dbd-a54dc7bdf20d";
+
+    @Test
+    void testPermitAll() {
+        RestAssured.given()
+                .when()
+                .header("Authorization", "Bearer: " + BEARER_TOKEN)
+                .get("/secured/permit-all")
+                .then()
+                .statusCode(200)
+                .body(containsString("hello"));
+    }
+
+    @Test
+    void testRolesAllowed() {
+        RestAssured.given()
+                .when()
+                .header("Authorization", "Bearer: " + BEARER_TOKEN)
+                .get("/secured/roles-allowed")
+                .then()
+                .statusCode(200)
+                .body(containsString("hello"));
+    }
+}


### PR DESCRIPTION
Adds a test to the OAuth2 quickstart and an example of a test resource that mock an OAuth2 authorization server.
This is part of https://github.com/quarkusio/quarkus/issues/10364

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the documentation must not be updated
- [ ] links the documentation update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] For new quickstart, is located in the directory _component-quickstart_
- [ ] For new quickstart, is added to the root `pom.xml` and `README.md`


