### PR TITLE
Upgrade OptaPlanner to 7.39.0.Final

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <optaplanner-quarkus.version>7.39.0.CR1</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>7.39.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>


### PR DESCRIPTION
Should also be in the stable branch once 1.6.0 is out, if still possible

Relates to https://github.com/quarkusio/quarkus-platform/pull/84