### PR TITLE
Update quickstarts to avoid using the deprecated APIS from Mutiny 0.6.0

### DIFF
--- a/amazon-dynamodb-quickstart/src/main/java/org/acme/dynamodb/FruitAsyncService.java
+++ b/amazon-dynamodb-quickstart/src/main/java/org/acme/dynamodb/FruitAsyncService.java
@@ -17,7 +17,7 @@ public class FruitAsyncService extends AbstractService {
 
     public Uni<List<Fruit>> findAll() {
         return Uni.createFrom().completionStage(() -> dynamoDB.scan(scanRequest()))
-                .onItem().apply(res -> res.items().stream().map(Fruit::from).collect(Collectors.toList()));
+                .onItem().transform(res -> res.items().stream().map(Fruit::from).collect(Collectors.toList()));
     }
 
     public Uni<List<Fruit>> add(Fruit fruit) {
@@ -27,6 +27,6 @@ public class FruitAsyncService extends AbstractService {
 
     public Uni<Fruit> get(String name) {
         return Uni.createFrom().completionStage(() -> dynamoDB.getItem(getRequest(name)))
-                .onItem().apply(resp -> Fruit.from(resp.item()));
+                .onItem().transform(resp -> Fruit.from(resp.item()));
     }
 }

--- a/amazon-kms-quickstart/src/main/java/org/acme/kms/QuarkusKmsAsyncResource.java
+++ b/amazon-kms-quickstart/src/main/java/org/acme/kms/QuarkusKmsAsyncResource.java
@@ -29,16 +29,18 @@ public class QuarkusKmsAsyncResource {
     @Path("/encrypt")
     public Uni<String> encrypt(String data) {
         return Uni.createFrom().completionStage(kms.encrypt(req -> req.keyId(keyArn).plaintext(SdkBytes.fromUtf8String(data))))
-            .onItem().apply(EncryptResponse::ciphertextBlob)
-            .onItem().apply(blob -> Base64.encodeBase64String(blob.asByteArray()));
+            .onItem().transform(EncryptResponse::ciphertextBlob)
+            .onItem().transform(blob -> Base64.encodeBase64String(blob.asByteArray()));
     }
 
     @POST
     @Path("/decrypt")
     public Uni<String> decrypt(String data) {
         return Uni.createFrom().item(SdkBytes.fromByteArray(Base64.decodeBase64(data.getBytes())))
-            .onItem().produceCompletionStage(msg -> kms.decrypt(req -> req.keyId(keyArn).ciphertextBlob(msg)))
-            .onItem().apply(DecryptResponse::plaintext)
-            .onItem().apply(SdkBytes::asUtf8String);
+            .onItem().transformToUni(msg ->
+                        Uni.createFrom().completionStage(kms.decrypt(req -> req.keyId(keyArn).ciphertextBlob(msg)))
+            )
+            .onItem().transform(DecryptResponse::plaintext)
+            .onItem().transform(SdkBytes::asUtf8String);
     }
 }

--- a/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
+++ b/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
@@ -77,7 +77,7 @@ public class S3AsyncClientResource extends CommonResource {
                 .build();
 
         return Uni.createFrom().completionStage(() -> s3.listObjects(listRequest))
-                .onItem().apply(result -> toFileItems(result));
+                .onItem().transform(result -> toFileItems(result));
     }
 
     private List<FileObject> toFileItems(ListObjectsResponse objects) {

--- a/amazon-ses-quickstart/src/main/java/org/acme/ses/QuarkusSesAsyncResource.java
+++ b/amazon-ses-quickstart/src/main/java/org/acme/ses/QuarkusSesAsyncResource.java
@@ -30,6 +30,6 @@ public class QuarkusSesAsyncResource {
                     .message(msg -> msg
                         .subject(sub -> sub.data(data.getSubject()))
                         .body(b -> b.text(txt -> txt.data(data.getBody()))))))
-            .onItem().apply(SendEmailResponse::messageId);
+            .onItem().transform(SendEmailResponse::messageId);
     }
 }

--- a/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksCannonAsyncResource.java
+++ b/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksCannonAsyncResource.java
@@ -39,7 +39,7 @@ public class QuarksCannonAsyncResource {
         return Uni.createFrom()
             .completionStage(sns.publish(p -> p.topicArn(topicArn).message(message)))
             .onItem().invoke(item -> LOGGER.infov("Fired Quark[{0}, {1}}]", quark.getFlavor(), quark.getSpin()))
-            .onItem().apply(PublishResponse::messageId)
-            .onItem().apply(id -> Response.ok().entity(id).build());
+            .onItem().transform(PublishResponse::messageId)
+            .onItem().transform(id -> Response.ok().entity(id).build());
     }
 }

--- a/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksCannonAsyncResource.java
+++ b/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksCannonAsyncResource.java
@@ -39,7 +39,7 @@ public class QuarksCannonAsyncResource {
         return Uni.createFrom()
             .completionStage(sqs.sendMessage(m -> m.queueUrl(queueUrl).messageBody(message)))
             .onItem().invoke(item -> LOGGER.infov("Fired Quark[{0}, {1}}]", quark.getFlavor(), quark.getSpin()))
-            .onItem().apply(SendMessageResponse::messageId)
-            .onItem().apply(id -> Response.ok().entity(id).build());
+            .onItem().transform(SendMessageResponse::messageId)
+            .onItem().transform(id -> Response.ok().entity(id).build());
     }
 }

--- a/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksShieldAsyncResource.java
+++ b/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksShieldAsyncResource.java
@@ -37,8 +37,8 @@ public class QuarksShieldAsyncResource {
     public Uni<List<Quark>> receive() {
         return Uni.createFrom()
             .completionStage(sqs.receiveMessage(m -> m.maxNumberOfMessages(10).queueUrl(queueUrl)))
-            .onItem().apply(ReceiveMessageResponse::messages)
-            .onItem().apply(m -> m.stream().map(Message::body).map(this::toQuark).collect(Collectors.toList()));
+            .onItem().transform(ReceiveMessageResponse::messages)
+            .onItem().transform(m -> m.stream().map(Message::body).map(this::toQuark).collect(Collectors.toList()));
     }
 
     private Quark toQuark(String message) {

--- a/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/Fruit.java
+++ b/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/Fruit.java
@@ -46,29 +46,29 @@ public class Fruit {
 
     public static Multi<Fruit> findAll(PgPool client) {
         return client.query("SELECT id, name FROM fruits ORDER BY name ASC").execute()
-                .onItem().produceMulti(set -> Multi.createFrom().iterable(set))
-                .onItem().apply(Fruit::from);
+                .onItem().transformToMulti(set -> Multi.createFrom().iterable(set))
+                .onItem().transform(Fruit::from);
     }
 
     public static Uni<Fruit> findById(PgPool client, Long id) {
         return client.preparedQuery("SELECT id, name FROM fruits WHERE id = $1").execute(Tuple.of(id))
-                .onItem().apply(RowSet::iterator)
-                .onItem().apply(iterator -> iterator.hasNext() ? from(iterator.next()) : null);
+                .onItem().transform(RowSet::iterator)
+                .onItem().transform(iterator -> iterator.hasNext() ? from(iterator.next()) : null);
     }
 
     public Uni<Long> save(PgPool client) {
         return client.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING (id)").execute(Tuple.of(name))
-                .onItem().apply(pgRowSet -> pgRowSet.iterator().next().getLong("id"));
+                .onItem().transform(pgRowSet -> pgRowSet.iterator().next().getLong("id"));
     }
 
     public Uni<Boolean> update(PgPool client) {
         return client.preparedQuery("UPDATE fruits SET name = $1 WHERE id = $2").execute(Tuple.of(name, id))
-                .onItem().apply(pgRowSet -> pgRowSet.rowCount() == 1);
+                .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }
 
     public static Uni<Boolean> delete(PgPool client, Long id) {
         return client.preparedQuery("DELETE FROM fruits WHERE id = $1").execute(Tuple.of(id))
-                .onItem().apply(pgRowSet -> pgRowSet.rowCount() == 1);
+                .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }
 
     private static Fruit from(Row row) {

--- a/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/FruitResource.java
+++ b/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/FruitResource.java
@@ -77,30 +77,30 @@ public class FruitResource {
     @Path("{id}")
     public Uni<Response> getSingle(@PathParam Long id) {
         return Fruit.findById(client, id)
-                .onItem().apply(fruit -> fruit != null ? Response.ok(fruit) : Response.status(Status.NOT_FOUND))
-                .onItem().apply(ResponseBuilder::build);
+                .onItem().transform(fruit -> fruit != null ? Response.ok(fruit) : Response.status(Status.NOT_FOUND))
+                .onItem().transform(ResponseBuilder::build);
     }
 
     @POST
     public Uni<Response> create(Fruit fruit) {
         return fruit.save(client)
-                .onItem().apply(id -> URI.create("/fruits/" + id))
-                .onItem().apply(uri -> Response.created(uri).build());
+                .onItem().transform(id -> URI.create("/fruits/" + id))
+                .onItem().transform(uri -> Response.created(uri).build());
     }
 
     @PUT
     @Path("{id}")
     public Uni<Response> update(@PathParam Long id, Fruit fruit) {
         return fruit.update(client)
-                .onItem().apply(updated -> updated ? Status.OK : Status.NOT_FOUND)
-                .onItem().apply(status -> Response.status(status).build());
+                .onItem().transform(updated -> updated ? Status.OK : Status.NOT_FOUND)
+                .onItem().transform(status -> Response.status(status).build());
     }
 
     @DELETE
     @Path("{id}")
     public Uni<Response> delete(@PathParam Long id) {
         return Fruit.delete(client, id)
-                .onItem().apply(deleted -> deleted ? Status.NO_CONTENT : Status.NOT_FOUND)
-                .onItem().apply(status -> Response.status(status).build());
+                .onItem().transform(deleted -> deleted ? Status.NO_CONTENT : Status.NOT_FOUND)
+                .onItem().transform(status -> Response.status(status).build());
     }
 }

--- a/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingService.java
+++ b/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingService.java
@@ -12,12 +12,12 @@ public class ReactiveGreetingService {
 
     public Uni<String> greeting(String name) {
         return Uni.createFrom().item(name)
-                .onItem().apply(n -> String.format("hello %s", name));
+                .onItem().transform(n -> String.format("hello %s", name));
     }
 
     public Multi<String> greetings(int count, String name) {
         return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
-                .onItem().apply(n -> String.format("hello %s - %d", name, n))
+                .onItem().transform(n -> String.format("hello %s - %d", name, n))
                 .transform().byTakingFirstItems(count);
 
     }

--- a/grpc-plain-text-quickstart/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
+++ b/grpc-plain-text-quickstart/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
@@ -34,7 +34,7 @@ public class HelloWorldEndpoint {
     @Path("/mutiny/{name}")
     public Uni<String> helloMutiny(@PathParam("name") String name) {
         return mutinyHelloService.sayHello(HelloRequest.newBuilder().setName(name).build())
-                .onItem().apply((reply) -> generateResponse(reply));
+                .onItem().transform((reply) -> generateResponse(reply));
     }
 
     public String generateResponse(HelloReply reply) {

--- a/grpc-tls-quickstart/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldTlsEndpoint.java
+++ b/grpc-tls-quickstart/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldTlsEndpoint.java
@@ -32,6 +32,6 @@ public class HelloWorldTlsEndpoint {
     @Path("/mutiny/{name}")
     public Uni<String> helloMutiny(@PathParam("name") String name) {
         return mutinyHelloService.sayHello(HelloRequest.newBuilder().setName(name).build())
-                .onItem().apply(HelloReply::getMessage);
+                .onItem().transform(HelloReply::getMessage);
     }
 }

--- a/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/EventResource.java
@@ -23,6 +23,6 @@ public class EventResource {
     @Path("{name}")
     public Uni<String> greeting(@PathParam String name) {
         return bus.<String> request("greeting", name)
-                .onItem().apply(Message::body);
+                .onItem().transform(Message::body);
     }
 }

--- a/vertx-quickstart/src/main/java/org/acme/vertx/Fruit.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/Fruit.java
@@ -46,7 +46,7 @@ public class Fruit {
 
     public static Uni<List<Fruit>> findAll(PgPool client) {
         return client.query("SELECT id, name FROM fruits ORDER BY name ASC").execute()
-                .onItem().apply(pgRowSet -> {
+                .onItem().transform(pgRowSet -> {
                     List<Fruit> list = new ArrayList<>(pgRowSet.size());
                     for (Row row : pgRowSet) {
                         list.add(from(row));
@@ -57,23 +57,23 @@ public class Fruit {
 
     public static Uni<Fruit> findById(PgPool client, Long id) {
         return client.preparedQuery("SELECT id, name FROM fruits WHERE id = $1").execute(Tuple.of(id))
-                .onItem().apply(RowSet::iterator)
-                .onItem().apply(iterator -> iterator.hasNext() ? from(iterator.next()) : null);
+                .onItem().transform(RowSet::iterator)
+                .onItem().transform(iterator -> iterator.hasNext() ? from(iterator.next()) : null);
     }
 
     public Uni<Long> save(PgPool client) {
         return client.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING (id)").execute(Tuple.of(name))
-                .onItem().apply(pgRowSet -> pgRowSet.iterator().next().getLong("id"));
+                .onItem().transform(pgRowSet -> pgRowSet.iterator().next().getLong("id"));
     }
 
     public Uni<Boolean> update(PgPool client) {
         return client.preparedQuery("UPDATE fruits SET name = $1 WHERE id = $2").execute(Tuple.of(name, id))
-                .onItem().apply(pgRowSet -> pgRowSet.rowCount() == 1);
+                .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }
 
     public static Uni<Boolean> delete(PgPool client, Long id) {
         return client.preparedQuery("DELETE FROM fruits WHERE id = $1").execute(Tuple.of(id))
-                .onItem().apply(pgRowSet -> pgRowSet.rowCount() == 1);
+                .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }
 
     private static Fruit from(Row row) {

--- a/vertx-quickstart/src/main/java/org/acme/vertx/FruitResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/vertx/FruitResource.java
@@ -69,38 +69,38 @@ public class FruitResource {
     @GET
     public Uni<Response> get() {
         return Fruit.findAll(client)
-                .onItem().apply(Response::ok)
-                .onItem().apply(ResponseBuilder::build);
+                .onItem().transform(Response::ok)
+                .onItem().transform(ResponseBuilder::build);
     }
 
     @GET
     @Path("{id}")
     public Uni<Response> getSingle(@PathParam Long id) {
         return Fruit.findById(client, id)
-                .onItem().apply(fruit -> fruit != null ? Response.ok(fruit) : Response.status(Status.NOT_FOUND))
-                .onItem().apply(ResponseBuilder::build);
+                .onItem().transform(fruit -> fruit != null ? Response.ok(fruit) : Response.status(Status.NOT_FOUND))
+                .onItem().transform(ResponseBuilder::build);
     }
 
     @POST
     public Uni<Response> create(Fruit fruit) {
         return fruit.save(client)
-                .onItem().apply(id -> URI.create("/fruits/" + id))
-                .onItem().apply(uri -> Response.created(uri).build());
+                .onItem().transform(id -> URI.create("/fruits/" + id))
+                .onItem().transform(uri -> Response.created(uri).build());
     }
 
     @PUT
     @Path("{id}")
     public Uni<Response> update(@PathParam Long id, Fruit fruit) {
         return fruit.update(client)
-                .onItem().apply(updated -> updated ? Status.OK : Status.NOT_FOUND)
-                .onItem().apply(status -> Response.status(status).build());
+                .onItem().transform(updated -> updated ? Status.OK : Status.NOT_FOUND)
+                .onItem().transform(status -> Response.status(status).build());
     }
 
     @DELETE
     @Path("{id}")
     public Uni<Response> delete(@PathParam Long id) {
         return Fruit.delete(client, id)
-                .onItem().apply(deleted -> deleted ? Status.NO_CONTENT : Status.NOT_FOUND)
-                .onItem().apply(status -> Response.status(status).build());
+                .onItem().transform(deleted -> deleted ? Status.NO_CONTENT : Status.NOT_FOUND)
+                .onItem().transform(status -> Response.status(status).build());
     }
 }


### PR DESCRIPTION
The deprecated methods are still available but are going to be removed in ~ 6 months.

Depends on https://github.com/quarkusio/quarkus/pull/10676


**Checklist**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [X] makes sure the documentation must not be updated
- [X] links the documentation update pull request (if needed)
- [X] updates or creates the `README.md` file (with build and run instructions)
- [X] For new quickstart, is located in the directory _component-quickstart_
- [X] For new quickstart, is added to the root `pom.xml` and `README.md`

