### PR TITLE
Bump GraalVM version used in cron job to 20.1

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -25,10 +25,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Install JDK 8
-        uses: joschi/setup-jdk@v1.0.0
+      - name: Install JDK 11
+        uses: joschi/setup-jdk@v2
         with:
-          java-version: 'openjdk8'
+          java-version: '11'
 
       - name: Build Quarkus master
         run: |
@@ -40,7 +40,7 @@ jobs:
         run: |
           mvn -B clean install --fail-at-end -Pnative -Ddocker \
             -Dquarkus.native.container-build=true \
-            -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8 \
+            -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11 \
             -pl '!rest-client-quickstart,!security-jwt-quickstart,!grpc-tls-quickstart'
 
       - name: Check RSS


### PR DESCRIPTION
Done because the cron job has started failing after we removed support for GraalVM 19.3 (see https://github.com/quarkusio/quarkus/issues/6588)