### PR TITLE
Remove durability when sending to the AMQP broker 

### DIFF
--- a/amqp-quickstart/src/main/resources/application.properties
+++ b/amqp-quickstart/src/main/resources/application.properties
@@ -5,7 +5,6 @@ amqp-password=quarkus
 # Configure the AMQP connector to write to the `prices`  address
 mp.messaging.outgoing.generated-price.connector=smallrye-amqp
 mp.messaging.outgoing.generated-price.address=prices
-mp.messaging.outgoing.generated-price.durable=true
 
 # Configure the AMQP connector to read from the `prices` queue
 mp.messaging.incoming.prices.connector=smallrye-amqp


### PR DESCRIPTION
Remove durability when sending messages to the AMQP broker as the broker may reject the messages if it does not support durability.

Documentation has already been updated.

**Checklist**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [X] makes sure the documentation must not be updated
- [X] links the documentation update pull request (if needed)
- [X] updates or creates the `README.md` file (with build and run instructions)
- [X] For new quickstart, is located in the directory _component-quickstart_
- [X] For new quickstart, is added to the root `pom.xml` and `README.md`


