### PR TITLE
Add wagon settings to ensure Maven can recover from transient download issues

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10


### PR DESCRIPTION
Same as https://github.com/quarkusio/quarkus/pull/11615