### PR TITLE
Remove verbose JPA annotations from the quickstarts

### DIFF
--- a/hibernate-orm-quickstart-multi-tenancy/src/main/java/org/acme/hibernate/orm/Fruit.java
+++ b/hibernate-orm-quickstart-multi-tenancy/src/main/java/org/acme/hibernate/orm/Fruit.java
@@ -3,7 +3,6 @@ package org.acme.hibernate.orm;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
@@ -17,7 +16,7 @@ public class Fruit {
 
     @Id
     @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fruitsSequence")
+    @GeneratedValue(generator = "fruitsSequence")
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
+++ b/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
@@ -4,7 +4,6 @@ import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.NamedQuery;
 import javax.persistence.QueryHint;
@@ -19,7 +18,7 @@ public class Fruit {
 
     @Id
     @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fruitsSequence")
+    @GeneratedValue(generator = "fruitsSequence")
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
+++ b/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
@@ -3,7 +3,6 @@ package org.acme.hibernate.reactive;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.NamedQuery;
 import javax.persistence.QueryHint;
@@ -17,7 +16,7 @@ public class Fruit {
 
     @Id
     @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fruitsSequence")
+    @GeneratedValue(generator = "fruitsSequence")
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-reactive-routes-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
+++ b/hibernate-reactive-routes-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
@@ -3,7 +3,6 @@ package org.acme.hibernate.reactive;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
@@ -17,7 +16,7 @@ public class Fruit {
 
     @Id
     @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fruitsSequence")
+    @GeneratedValue(generator = "fruitsSequence")
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Lesson.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Lesson.java
@@ -2,7 +2,6 @@ package org.acme.optaplanner.domain;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotBlank;
@@ -20,7 +19,7 @@ public class Lesson extends PanacheEntityBase {
 
     @PlanningId
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     @NotNull
     private Long id;
 

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Room.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Room.java
@@ -2,7 +2,6 @@ package org.acme.optaplanner.domain;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -16,7 +15,7 @@ public class Room extends PanacheEntityBase {
 
     @PlanningId
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     @NotNull
     private Long id;
 

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Timeslot.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Timeslot.java
@@ -5,7 +5,6 @@ import java.time.LocalTime;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
@@ -18,7 +17,7 @@ public class Timeslot extends PanacheEntityBase {
 
     @PlanningId
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     @NotNull
     private Long id;
 


### PR DESCRIPTION
These annotation parameters are redundant and can be removed as discussed here https://github.com/quarkusio/quarkus/pull/11728