### PR TITLE
Remove deprecated

### DIFF
--- a/hibernate-reactive-quickstart/src/test/java/org/acme/hibernate/reactive/FruitsEndpointTest.java
+++ b/hibernate-reactive-quickstart/src/test/java/org/acme/hibernate/reactive/FruitsEndpointTest.java
@@ -113,19 +113,4 @@ public class FruitsEndpointTest {
 				.statusCode(404)
 				.body(emptyString());
     }
-
-	@Test
-	public void testMissingNameForUpdate() {
-		given()
-			.when()
-				.contentType("application/json")
-				.put("/fruits/3")
-			.then()
-				.statusCode(422)
-				.body(
-					containsString("\"code\":422"),
-					containsString("\"error\":\"Fruit name was not set on request.\""),
-					containsString("\"exceptionType\":\"javax.ws.rs.WebApplicationException\"")
-				);
-	}
 }

--- a/hibernate-reactive-routes-quickstart/src/main/java/org/acme/hibernate/reactive/FruitsRoutes.java
+++ b/hibernate-reactive-routes-quickstart/src/main/java/org/acme/hibernate/reactive/FruitsRoutes.java
@@ -52,7 +52,7 @@ public class FruitsRoutes {
             return Uni.createFrom().failure(new IllegalArgumentException("Fruit id invalidly set on request."));
         }
         return session.persist(fruit)
-                .onItem().transformToUni(session -> session.flush())
+                .chain(session -> session.flush())
                 .onItem().transform(ignore -> {
                     response.setStatusCode(201);
                     return fruit;
@@ -80,7 +80,7 @@ public class FruitsRoutes {
         return session.find(Fruit.class, Integer.valueOf(id))
                 // If entity exists then delete
                 .onItem().ifNotNull().transformToUni(entity -> session.remove(entity)
-                        .onItem().transformToUni(ignore -> session.flush())
+                        .chain(ignore -> session.flush())
                         .onItem().transform(ignore -> {
                             response.setStatusCode(204).end();
                             return entity;

--- a/hibernate-reactive-routes-quickstart/src/test/java/org/acme/hibernate/reactive/FruitsEndpointTest.java
+++ b/hibernate-reactive-routes-quickstart/src/test/java/org/acme/hibernate/reactive/FruitsEndpointTest.java
@@ -91,40 +91,4 @@ public class FruitsEndpointTest {
                         containsString("Banana"),
                         containsString("Pear"));
     }
-
-    @Test
-    public void testEntityNotFoundForDelete() {
-        given()
-                .when()
-                .delete("/fruits/9236")
-                .then()
-                .statusCode(404)
-                .body(emptyString());
-    }
-
-    @Test
-    public void testEntityNotFoundForUpdate() {
-        given()
-                .when()
-                .body("{\"name\" : \"Watermelon\"}")
-                .contentType("application/json")
-                .put("/fruits/32432")
-                .then()
-                .statusCode(404)
-                .body(emptyString());
-    }
-
-    @Test
-    public void testMissingNameForUpdate() {
-        given()
-                .when()
-                .contentType("application/json")
-                .put("/fruits/3")
-                .then()
-                .statusCode(422)
-                .body(
-                        containsString("\"code\":422"),
-                        containsString("\"error\":\"Fruit name was not set on request.\""),
-                        containsString("\"exceptionType\":\"java.lang.IllegalArgumentException\""));
-    }
 }


### PR DESCRIPTION
Created on top of https://github.com/quarkusio/quarkus-quickstarts/pull/655

This PR replace deprecated methods and use `.chain()` where possible, making the code less verbose.

@cescoffier @gsmet 


