### PR TITLE
Upgrade OptaPlanner from 7.41.0.Final to 7.43.0.Final

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <optaplanner-quarkus.version>7.41.0.Final</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>7.43.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>


### PR DESCRIPTION
Related PR: https://github.com/quarkusio/quarkus-platform/pull/122

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


