### PR TITLE
Only run the native build once a day during the night

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -1,10 +1,10 @@
 ---
-name: "Native Test - development"
+name: "Native Tests - Development"
 
 # Adding the dispatch event to allow restarting the build on demand
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 2 * * *'
   repository_dispatch:
 
 jobs:


### PR DESCRIPTION
The build now takes more than 5 hours so running it every 6 hours looks
a bit too much.

Let's run it once a day.


