### PR TITLE
Add docker-compose.yml to hibernate-orm-multi-tenancy quickstart

### DIFF
--- a/hibernate-orm-quickstart-multi-tenancy/docker-compose.yml
+++ b/hibernate-orm-quickstart-multi-tenancy/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+
+  database1:
+    image: postgres
+    environment:
+      POSTGRES_USER: "quarkus_test"
+      POSTGRES_PASSWORD: "quarkus_test"
+    ports:
+      - 5432:5432
+
+  database2:
+    image: postgres
+    environment:
+      POSTGRES_USER: "mycompany"
+      POSTGRES_PASSWORD: "mycompany"
+    ports:
+      - 5433:5432
+
+  quarkus:
+    image: quarkus/hibernate-orm-multi-tenancy
+    environment:
+      DB_HOST_TENANT_BASE: "database1"
+      DB_HOST_TENANT_MYCOMPANY: "database2"
+      DB_PORT_TENANT_BASE: "5432"
+      DB_PORT_TENANT_MYCOMPANY: "5432"
+    depends_on:
+      - database1
+      - database2
+    ports:
+      - 8080:8080

--- a/hibernate-orm-quickstart-multi-tenancy/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-quickstart-multi-tenancy/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/hibernate-orm-resteasy-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/hibernate-orm-multi-tenancy-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-resteasy-jvm
+# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-multi-tenancy-jvm
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1

--- a/hibernate-orm-quickstart-multi-tenancy/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-quickstart-multi-tenancy/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/hibernate-orm-resteasy .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/hibernate-orm-multi-tenancy .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-resteasy
+# docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-multi-tenancy
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal

--- a/hibernate-orm-quickstart-multi-tenancy/src/main/resources/application.properties
+++ b/hibernate-orm-quickstart-multi-tenancy/src/main/resources/application.properties
@@ -9,11 +9,11 @@ quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=SCHEMA
 %database.quarkus.hibernate-orm.multitenant=DATABASE
 
-# SCHEMA Tenant Configuration
+# SCHEMA Tenant Configuration (environment variable expansion is used to facilitate docker-compose setup)
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=quarkus_test
 quarkus.datasource.password=quarkus_test
-quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/quarkus_test
+quarkus.datasource.jdbc.url=jdbc:postgresql://${DB_HOST_TENANT_BASE:localhost}:${DB_PORT_TENANT_BASE:5432}/quarkus_test
 quarkus.datasource.jdbc.max-size=8
 quarkus.datasource.jdbc.min-size=2
 quarkus.flyway.schemas=base,mycompany
@@ -27,7 +27,7 @@ quarkus.flyway.migrate-at-start=true
 %database.quarkus.datasource.base.db-kind=postgresql
 %database.quarkus.datasource.base.username=quarkus_test
 %database.quarkus.datasource.base.password=quarkus_test
-%database.quarkus.datasource.base.jdbc.url=jdbc:postgresql://localhost:5432/quarkus_test
+%database.quarkus.datasource.base.jdbc.url=jdbc:postgresql://${DB_HOST_TENANT_BASE:localhost}:${DB_PORT_TENANT_BASE:5432}/quarkus_test
 %database.quarkus.datasource.base.jdbc.max-size=8
 %database.quarkus.datasource.base.jdbc.min-size=2
 %database.quarkus.flyway.base.locations=classpath:database/base
@@ -37,7 +37,7 @@ quarkus.flyway.migrate-at-start=true
 %database.quarkus.datasource.mycompany.db-kind=postgresql
 %database.quarkus.datasource.mycompany.username=mycompany
 %database.quarkus.datasource.mycompany.password=mycompany
-%database.quarkus.datasource.mycompany.jdbc.url=jdbc:postgresql://localhost:5433/mycompany
+%database.quarkus.datasource.mycompany.jdbc.url=jdbc:postgresql://${DB_HOST_TENANT_MYCOMPANY:localhost}:${DB_PORT_TENANT_MYCOMPANY:5433}/mycompany
 %database.quarkus.datasource.mycompany.jdbc.max-size=8
 %database.quarkus.datasource.mycompany.jdbc.min-size=2
 %database.quarkus.flyway.mycompany.locations=classpath:database/mycompany


### PR DESCRIPTION
- use environment variable expansion to facilitate docker-compose setup
- fix Docker image names to hibernate-orm-multi-tenancy


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] updates or creates the `README.md` file (with build and run instructions)

I am not sure about the last one. Shall I add instructions how to run the quickstart using docker-compose?
Additional changes that might be useful:

- simplify docker run commands to start PostgreSQL databases in README.md
- add a 'build' configuration for 'quarkus' service in docker-compose.yml 
