### PR TITLE
Extend the timeout when checking for the message to be received.

### DIFF
--- a/jms-quickstart/src/test/java/org/acme/jms/ArtemisTestResource.java
+++ b/jms-quickstart/src/test/java/org/acme/jms/ArtemisTestResource.java
@@ -19,6 +19,7 @@ public class ArtemisTestResource implements QuarkusTestResourceLifecycleManager 
             FileUtils.deleteDirectory(Paths.get("./target/artemis").toFile());
             embedded = new EmbeddedActiveMQ();
             embedded.start();
+            System.out.println("Artemis server started");
         } catch (Exception e) {
             throw new RuntimeException("Could not start embedded ActiveMQ server", e);
         }
@@ -29,6 +30,7 @@ public class ArtemisTestResource implements QuarkusTestResourceLifecycleManager 
     public void stop() {
         try {
             embedded.stop();
+            System.out.println("Artemis server stoppped");
         } catch (Exception e) {
             throw new RuntimeException("Could not stop embedded ActiveMQ server", e);
         }

--- a/jms-quickstart/src/test/java/org/acme/jms/PriceTest.java
+++ b/jms-quickstart/src/test/java/org/acme/jms/PriceTest.java
@@ -9,15 +9,15 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
-
+import java.time.Duration;
 
 @QuarkusTest
 @QuarkusTestResource(ArtemisTestResource.class)
 public class PriceTest {
 
     @Test
-    public void testLastPrice() throws InterruptedException {
-        await().untilAsserted(() -> {
+    public void testLastPrice() {
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
             RestAssured.given()
             .when().get("/prices/last")
             .then()

--- a/jms-quickstart/src/test/java/org/acme/jms/PriceTestIT.java
+++ b/jms-quickstart/src/test/java/org/acme/jms/PriceTestIT.java
@@ -1,5 +1,6 @@
 package org.acme.jms;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest


### PR DESCRIPTION
This commit also adds traces to help me debug the broker start/stop sequence.