### PR TITLE
Enable rest-client-quickstart,security-jwt-quickstart,grpc-tls-quickstart for native build in GH Actions

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -41,7 +41,7 @@ jobs:
           mvn -B clean install --fail-at-end -Pnative -Ddocker \
             -Dquarkus.native.container-build=true \
             -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11 \
-            -pl '!rest-client-quickstart,!security-jwt-quickstart,!grpc-tls-quickstart,!amazon-kms-quickstart'
+            -pl '!amazon-kms-quickstart'
 
       - name: Check RSS
         env:


### PR DESCRIPTION
Enable rest-client-quickstart,security-jwt-quickstart,grpc-tls-quickstart for native build in GH Actions

Builds for these extensions went fine locally, using GraalVM Version 20.1.0 (Java Version 11.0.7)

- [x] targets the `development` branch