### PR TITLE
Skip tests for Amazon KMS

### DIFF
--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -19,6 +19,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <testcontainers.version>1.12.5</testcontainers.version>
         <awssdk.testcontainers.version>1.11.774</awssdk.testcontainers.version>
+        <skipTests>true</skipTests>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
@marcinczeczko I don't know what's happening but the Amazon KMS quickstart started to fail with a timeout.

Any chance you could have a look? It might be related to a dependency upgrade.

