### PR TITLE
Attempt to fix Amazon KMS tests failures

### DIFF
--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.12.5</testcontainers.version>
-        <awssdk.testcontainers.version>1.11.774</awssdk.testcontainers.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
+        <awssdk.testcontainers.version>1.11.784</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-kms-quickstart/src/test/java/org/acme/kms/KmsResource.java
+++ b/amazon-kms-quickstart/src/test/java/org/acme/kms/KmsResource.java
@@ -1,7 +1,10 @@
 package org.acme.kms;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import org.testcontainers.DockerClientFactory;
@@ -28,7 +31,7 @@ public class KmsResource implements QuarkusTestResourceLifecycleManager {
                 .create(AwsBasicCredentials.create("accesskey", "secretKey"));
 
             client = KmsClient.builder()
-                .endpointOverride(new URI(endpoint()))
+                .endpointOverride(services.getEndpointOverride())
                 .credentialsProvider(staticCredentials)
                 .httpClientBuilder(UrlConnectionHttpClient.builder())
                 .region(Region.US_EAST_1).build();
@@ -42,7 +45,7 @@ public class KmsResource implements QuarkusTestResourceLifecycleManager {
         }
 
         Map<String, String> properties = new HashMap<>();
-        properties.put("quarkus.kms.endpoint-override", endpoint());
+        properties.put("quarkus.kms.endpoint-override", services.getEndpointOverride().toString());
         properties.put("quarkus.kms.aws.region", "us-east-1");
         properties.put("quarkus.kms.aws.credentials.type", "static");
         properties.put("quarkus.kms.aws.credentials.static-provider.access-key-id", "accessKey");
@@ -57,9 +60,5 @@ public class KmsResource implements QuarkusTestResourceLifecycleManager {
         if (services != null) {
             services.close();
         }
-    }
-
-    private String endpoint() {
-        return String.format("http://%s:%s", services.getContainerIpAddress(), services.getMappedPort(services.getKmsPort()));
     }
 }


### PR DESCRIPTION
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


