### PR TITLE
Remove JMS quickstart native tests

### DIFF
--- a/jms-quickstart/src/test/java/org/acme/jms/PriceTestIT.java
+++ b/jms-quickstart/src/test/java/org/acme/jms/PriceTestIT.java
@@ -1,7 +1,0 @@
-package org.acme.jms;
-
-import io.quarkus.test.junit.NativeImageTest;
-
-@NativeImageTest
-public class PriceTestIT extends PriceTest {
-}


### PR DESCRIPTION
It has been unreliable for weeks without any clear explanation. 
Let's remove it for now. 