### PR TITLE
Build native image in liquibase-quickstart just once

### DIFF
--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -109,21 +109,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus-plugin.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-                <configuration>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${surefire-plugin.version}</version>
             <executions>


### PR DESCRIPTION
Build native image in liquibase-quickstart just once

liquibase-quickstart had both `<goal>native-image</goal>` of `quarkus-maven-plugin` and ` <quarkus.package.type>native</quarkus.package.type>` property defined

The end result was that native image was build twice.

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
