### PR TITLE
Adding step to run natively on mac and windows

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -41,7 +41,7 @@ jobs:
           mvn -B clean install --fail-at-end -Pnative -Ddocker \
             -Dquarkus.native.container-build=true \
             -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11 \
-            -pl '!rest-client-quickstart,!security-jwt-quickstart,!grpc-tls-quickstart'
+            -pl '!rest-client-quickstart,!security-jwt-quickstart,!grpc-tls-quickstart,!amazon-kms-quickstart'
 
       - name: Check RSS
         env:

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -1,10 +1,10 @@
 ---
-name: "Native Test - development"
+name: "Native Tests - Development"
 
 # Adding the dispatch event to allow restarting the build on demand
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 2 * * *'
   repository_dispatch:
 
 jobs:

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -92,6 +92,7 @@ jobs:
           sudo apt-get install -y gnupg2 gnupg-agent
           echo Installing SDKMAN
           curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh && \
+          source ~/.sdkman/bin/sdkman-init.sh
+          sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
           sdk install jbang 0.50.1
           jbang .github/NativeBuildReport.java token="${GITHUB_TOKEN}" status="${STATUS}" issueRepo="quarkusio/quarkus" issueNumber="6588" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -93,5 +93,5 @@ jobs:
           echo Installing SDKMAN
           curl -s "https://get.sdkman.io" | bash
           source ~/.sdkman/bin/sdkman-init.sh && \
-          sdk install jbang 0.36.1
+          sdk install jbang 0.50.1
           jbang .github/NativeBuildReport.java token="${GITHUB_TOKEN}" status="${STATUS}" issueRepo="quarkusio/quarkus" issueNumber="6588" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/amqp-quickstart/pom.xml
+++ b/amqp-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/amqp-quickstart/pom.xml
+++ b/amqp-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/amqp-quickstart/pom.xml
+++ b/amqp-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/amqp-quickstart/pom.xml
+++ b/amqp-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/amqp-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/amqp-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: amqp-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/amqp-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/amqp-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: amqp-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/amqp-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/amqp-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: amqp-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/amqp-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/amqp-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: amqp-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>config-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>config-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>config-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>config-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-amazon-lambda-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-google-cloud-functions-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-google-cloud-functions-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-google-cloud-functions-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-google-cloud-functions-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-http-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-knative-events-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-knative-events-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-knative-events-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>funqy-knative-events-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -72,6 +72,10 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
+To run on a non-Linux system (Docker required):
+> ./mvnw clean install -Pnative -Dnative-image.docker-build=true
+
+To run on Linux:
 > ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this executable directly:

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.6.1.Final</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -13,10 +13,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
 

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart-multi-tenancy/pom.xml
+++ b/hibernate-orm-quickstart-multi-tenancy/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart-multi-tenancy/pom.xml
+++ b/hibernate-orm-quickstart-multi-tenancy/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart-multi-tenancy/pom.xml
+++ b/hibernate-orm-quickstart-multi-tenancy/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart-multi-tenancy/pom.xml
+++ b/hibernate-orm-quickstart-multi-tenancy/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-search-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-elasticsearch-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-elasticsearch-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-elasticsearch-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-elasticsearch-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -10,10 +10,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -10,10 +10,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -10,10 +10,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -10,10 +10,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/kafka-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -13,10 +13,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <debezium.version>1.1.0.Final</debezium.version>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -13,10 +13,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <debezium.version>1.1.0.Final</debezium.version>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -13,10 +13,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <debezium.version>1.1.0.Final</debezium.version>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -13,10 +13,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <debezium.version>1.1.0.Final</debezium.version>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -15,10 +15,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -15,10 +15,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -15,10 +15,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -15,10 +15,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <kogito-quarkus.version>0.11.1</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <kogito-quarkus.version>0.11.1</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <kogito-quarkus.version>0.11.1</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <kogito-quarkus.version>0.11.1</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>lifecycle-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>lifecycle-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>lifecycle-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>lifecycle-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.33.0</docker-plugin.version>
   </properties>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.33.0</docker-plugin.version>
   </properties>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.33.0</docker-plugin.version>
   </properties>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.33.0</docker-plugin.version>
   </properties>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.14.2</testcontainers.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.14.2</testcontainers.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.14.2</testcontainers.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.14.2</testcontainers.version>

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>mqtt-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>mqtt-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>mqtt-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>mqtt-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -8,10 +8,10 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>opentracing-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>opentracing-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>opentracing-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>opentracing-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>7.43.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>7.43.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>7.43.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>7.43.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>quartz-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>quartz-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>quartz-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>quartz-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>qute-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>qute-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>qute-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>qute-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -10,10 +10,10 @@
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -10,10 +10,10 @@
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -10,10 +10,10 @@
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -10,10 +10,10 @@
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>1.8.0.Final</quarkus.version>
+        <quarkus.version>1.8.1.Final</quarkus.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>1.8.1.Final</quarkus.version>
+        <quarkus.version>1.8.2.Final</quarkus.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>1.8.2.Final</quarkus.version>
+        <quarkus.version>1.8.3.Final</quarkus.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.8.0.Final</quarkus.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-multipart-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-multipart-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-multipart-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-multipart-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>rest-client-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>rest-json-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>rest-json-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>rest-json-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>rest-json-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>scheduler-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>scheduler-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>scheduler-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>scheduler-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus.version>1.8.0.Final</quarkus.version>
+        <quarkus.version>1.8.1.Final</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus.version>1.8.2.Final</quarkus.version>
+        <quarkus.version>1.8.3.Final</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
+        <quarkus.version>1.8.0.Final</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus.version>1.8.1.Final</quarkus.version>
+        <quarkus.version>1.8.2.Final</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <testcontainers.version>1.14.1</testcontainers.version>
         <surefire.version>3.0.0-M5</surefire.version>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <testcontainers.version>1.14.1</testcontainers.version>
         <surefire.version>3.0.0-M5</surefire.version>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <testcontainers.version>1.14.1</testcontainers.version>
         <surefire.version>3.0.0-M5</surefire.version>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <testcontainers.version>1.14.1</testcontainers.version>
         <surefire.version>3.0.0-M5</surefire.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-openid-connect-multi-tenancy/pom.xml
+++ b/security-openid-connect-multi-tenancy/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy/pom.xml
+++ b/security-openid-connect-multi-tenancy/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy/pom.xml
+++ b/security-openid-connect-multi-tenancy/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy/pom.xml
+++ b/security-openid-connect-multi-tenancy/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -10,10 +10,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <keycloak.version>11.0.1</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-boot-properties-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-boot-properties-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-boot-properties-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-boot-properties-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.3.1.Final</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-data-jpa-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-data-jpa-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-data-jpa-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-data-jpa-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-di-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-di-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-di-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-di-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-scheduled-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-scheduled-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-scheduled-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-scheduled-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-security-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-security-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-security-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>spring-security-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.0.Final</li>
+                <li>Quarkus Version: 1.8.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.1.Final</li>
+                <li>Quarkus Version: 1.8.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 1.8.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.8.2.Final</li>
+                <li>Quarkus Version: 1.8.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-web-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-web-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-web-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>spring-web-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -11,10 +11,10 @@
         <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -11,10 +11,10 @@
         <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -11,10 +11,10 @@
         <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -11,10 +11,10 @@
         <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>validation-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>validation-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>validation-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <artifactId>validation-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>websockets-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>websockets-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>websockets-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.8.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>websockets-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus-plugin.version>1.8.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.8.2.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.8.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.8.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
For developers who are starting using `Quarkus`, it's very important for them to have the example working. 

The README file from the `getting-started` project only covers the command to run `Quarkus` natively on Linux but the command to run natively on non-Linux systems is not there.

To make the life of developers who are getting started with `Quarkus` I added the extra command to make it work. 

**Check list**:

Your pull request:

- [X ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [X ] has tests (`mvn clean test`)
- [ X] works in native (`mvn clean package -Pnative`)
- [ X] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ X] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


