### PR TITLE
Adding step on the `getting-started` project to run quarkus on non-linux systems natively

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -72,6 +72,10 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
+To run on a non-Linux system (GraalVM and Docker required):
+> ./mvnw clean install -Pnative -Dnative-image.docker-build=true
+
+To run on Linux:
 > ./mvnw install -Dnative
 
 After getting a cup of coffee, you'll be able to run this executable directly:


### PR DESCRIPTION
For developers who are starting using `Quarkus`, it's very important for them to have the example working. 

The README file from the `getting-started` project only covers the command to run `Quarkus` natively on Linux but the command to run natively on non-Linux systems is not there.

To make the life of developers who are getting started with `Quarkus` I added the extra command to make it work. 

**Check list**:

Your pull request:

- [X ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [X ] has tests (`mvn clean test`)
- [ X] works in native (`mvn clean package -Pnative`)
- [ X] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ X] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


