### PR TITLE
Update setup-jdk to avoid build warnings

### DIFF
--- a/.github/workflows/build-pr-development.yml
+++ b/.github/workflows/build-pr-development.yml
@@ -35,7 +35,7 @@ jobs:
           fi
       - name: Install JDK ${{ matrix.java }}
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus master

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -32,7 +32,7 @@ jobs:
           key: q2maven-native-${{ steps.get-date.outputs.date }}
 
       - name: Install JDK 11
-        uses: joschi/setup-jdk@68381f2c0646f942f70b69f8e81fe10e1ed5d293
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: '11'
 


### PR DESCRIPTION
GitHub deprecated some calls that our current version of setup-jdk is still doing.

The new version should avoid that.