### PR TITLE
Unresolvable wrong enum field replaced with correct drop_and_create

### DIFF
--- a/hibernate-search-elasticsearch-quickstart/src/main/resources/application.properties
+++ b/hibernate-search-elasticsearch-quickstart/src/main/resources/application.properties
@@ -11,6 +11,6 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 
 quarkus.hibernate-search.elasticsearch.version=7
 quarkus.hibernate-search.elasticsearch.analysis.configurer=org.acme.hibernate.search.elasticsearch.config.AnalysisConfigurer
-quarkus.hibernate-search.schema-management.strategy=drop-and-create
+quarkus.hibernate-search.schema-management.strategy=drop_and_create
 quarkus.hibernate-search.elasticsearch.schema-management.required-status=yellow
 quarkus.hibernate-search.automatic-indexing.synchronization.strategy=sync


### PR DESCRIPTION
Wrong drop-and-create field of SchemaManagementStrategyName used in the application.properties file, it can not be resolved