### PR TITLE
Add quarkus-smallrye-jwt-build dependency to security-jwt-quickstart pom.xml

### DIFF
--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -47,6 +47,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-jwt-build</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This PR follows the update in the main repo for the tests to pass