### PR TITLE
Update and sync testcontainers version, externalize version definition in security-openid ones

### DIFF
--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.12.5</testcontainers.version>
-        <awssdk.testcontainers.version>1.11.774</awssdk.testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
+        <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.14.3</testcontainers.version>
-        <awssdk.testcontainers.version>1.11.784</awssdk.testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
+        <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.12.5</testcontainers.version>
-        <awssdk.testcontainers.version>1.11.774</awssdk.testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
+        <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.12.5</testcontainers.version>
-        <awssdk.testcontainers.version>1.11.774</awssdk.testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
+        <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.14.1</testcontainers.version>
-        <awssdk.testcontainers.version>1.11.774</awssdk.testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
+        <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.12.5</testcontainers.version>
-        <awssdk.testcontainers.version>1.11.774</awssdk.testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
+        <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.14.1</testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testcontainers.version>1.14.1</testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.14.1</testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testcontainers.version>1.14.1</testcontainers.version>
+    <testcontainers.version>1.15.0</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testcontainers.version>1.14.1</testcontainers.version>
+    <testcontainers.version>1.15.0</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <testcontainers.version>1.14.2</testcontainers.version>
+    <testcontainers.version>1.15.0</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testcontainers.version>1.14.1</testcontainers.version>
+    <testcontainers.version>1.15.0</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.14.1</testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <keycloak.version>11.0.2</keycloak.version>
-        <testcontainers.version>1.14.1</testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-multi-tenancy/pom.xml
+++ b/security-openid-connect-multi-tenancy/pom.xml
@@ -20,6 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlunit.version>2.36.0</htmlunit.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -78,7 +79,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.12.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -19,6 +19,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testcontainers.version>1.15.0</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -56,7 +57,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.12.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -20,6 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlunit.version>2.36.0</htmlunit.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -77,7 +78,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.12.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Update and sync testcontainers version, externalize version definition in security-openid ones

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)