### PR TITLE
Use non application endpoints prefix introduced in #13601

### DIFF
--- a/microprofile-metrics-quickstart/src/test/java/org/acme/microprofile/metrics/PrimeNumberCheckerTest.java
+++ b/microprofile-metrics-quickstart/src/test/java/org/acme/microprofile/metrics/PrimeNumberCheckerTest.java
@@ -26,7 +26,7 @@ public class PrimeNumberCheckerTest {
 
     private void assertMetricValue(String metric, Object value) {
         given().header(new Header("Accept", "application/json"))
-                .get("/metrics/application").then()
+                .get("/q/metrics/application").then()
                 .statusCode(200)
                 .body("'" + metric + "'", is(value));
     }


### PR DESCRIPTION
Use non application endpoints prefix introduced in https://github.com/quarkusio/quarkus/pull/13601

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)