### PR TITLE
Revert "Use non application endpoints prefix introduced in #13601"

### DIFF
--- a/microprofile-metrics-quickstart/src/test/java/org/acme/microprofile/metrics/PrimeNumberCheckerTest.java
+++ b/microprofile-metrics-quickstart/src/test/java/org/acme/microprofile/metrics/PrimeNumberCheckerTest.java
@@ -26,7 +26,7 @@ public class PrimeNumberCheckerTest {
 
     private void assertMetricValue(String metric, Object value) {
         given().header(new Header("Accept", "application/json"))
-                .get("/q/metrics/application").then()
+                .get("/metrics/application").then()
                 .statusCode(200)
                 .body("'" + metric + "'", is(value));
     }


### PR DESCRIPTION
This reverts commit 9c802b2f0f985644dba23497886fb24ca9baab47.

Redirect of old URLs should work and it was fixed in Quarkus upstream.
Tracked in https://github.com/quarkusio/quarkus/issues/13901