### PR TITLE
hsearch-es: Use a named CDI bean for the analysis configurer

### DIFF
--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/java/org/acme/hibernate/search/elasticsearch/config/AnalysisConfigurer.java
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/java/org/acme/hibernate/search/elasticsearch/config/AnalysisConfigurer.java
@@ -3,6 +3,11 @@ package org.acme.hibernate.search.elasticsearch.config;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 
+import javax.enterprise.context.Dependent;
+import javax.inject.Named;
+
+@Dependent
+@Named("myAnalysisConfigurer")
 public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 
     @Override

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/resources/application.properties
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/resources/application.properties
@@ -10,6 +10,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 
 quarkus.hibernate-search-orm.elasticsearch.version=7
-quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=org.acme.hibernate.search.elasticsearch.config.AnalysisConfigurer
+quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:myAnalysisConfigurer
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync


### PR DESCRIPTION
Corresponding doc update: https://github.com/quarkusio/quarkus/pull/14096
