### PR TITLE
Use quarkus-micrometer-registry-prometheus extension

### DIFF
--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -36,11 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`

Guide already updated. Quickstart needs to catch up to new `quarkus-micrometer-registry-prometheus` extension in 1.11 
