### PR TITLE
Bump testcontainers from 1.15.0 to 1.15.1

### DIFF
--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 

--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testcontainers.version>1.15.0</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kafka-quickstart/pom.xml
+++ b/kafka-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testcontainers.version>1.15.0</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <testcontainers.version>1.15.0</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testcontainers.version>1.15.0</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <keycloak.version>11.0.2</keycloak.version>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/security-openid-connect-multi-tenancy/pom.xml
+++ b/security-openid-connect-multi-tenancy/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlunit.version>2.36.0</htmlunit.version>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlunit.version>2.36.0</htmlunit.version>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Bump testcontainers from 1.15.0 to 1.15.1

Came across https://github.com/testcontainers/testcontainers-java/issues/3574, let's update testcontainers

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)