### PR TITLE
Fix MailerResource as MailTemplateInstance#send method returns Uni

### DIFF
--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mailer</artifactId>
         </dependency>
         <dependency>

--- a/mailer-quickstart/src/main/java/org/acme/getting/started/MailerResource.java
+++ b/mailer-quickstart/src/main/java/org/acme/getting/started/MailerResource.java
@@ -1,6 +1,5 @@
 package org.acme.getting.started;
 
-import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -12,30 +11,22 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.quarkus.mailer.MailTemplate;
-import io.quarkus.mailer.Mailer;
-import io.quarkus.mailer.reactive.ReactiveMailer;
 import io.quarkus.qute.api.CheckedTemplate;
 import io.smallrye.mutiny.Uni;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
-import java.util.concurrent.CompletionStage;
 
 @Path("/mail")
 public class MailerResource {
 
-    @Inject
-    ReactiveMailer mailer;
-
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public CompletionStage<Response> greeting(
+    public Uni<Response> greeting(
             @Valid @Email @QueryParam("email") String email,
             @Valid @NotBlank @QueryParam("name") String name) {
         return Templates.hello(name)
                 .to(email)
                 .subject("Ahoy " + name + "!")
                 .send()
-                .thenApply(x -> Response.accepted().build());
+                .map(x -> Response.accepted().build());
     }
 
     @CheckedTemplate


### PR DESCRIPTION
Fix MailerResource as MailTemplateInstance#send method returns Uni

Change introduced in https://github.com/quarkusio/quarkus/pull/14344
https://quarkus.io/guides/mailer doesn't need any change, already shows  `.subscribeAsCompletionStage()`

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
