### PR TITLE
Explicitly add the rest-client-jackson extension

### DIFF
--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
People are trying this quickstart with RESTEasy Reactive and if they
switch to it, it's missing the RESTEasy classic Jackson support.

