### PR TITLE
Don't run CI in forks by default

### DIFF
--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -6,14 +6,16 @@ on:
   schedule:
     - cron: '0 2 * * *'
   repository_dispatch:
+  workflow_dispatch:
 
 jobs:
   build_with_native:
     runs-on: ubuntu-latest
+    if: "github.repository == 'quarkusio/quarkus-quickstarts' || github.event_name == 'workflow_dispatch'"
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: development
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.ref || 'development' }}
 
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
@@ -89,7 +91,7 @@ jobs:
         run: rm -rf ~/.m2/repository/org/acme
 
       - name: Report
-        if: always()
+        if: "github.repository == 'quarkusio/quarkus-quickstarts'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
           STATUS: ${{ job.status }}


### PR DESCRIPTION
IMO it is rather confusing to have a cron scheduled job running in a fork for a branch that you will most likely never push to directly.

This PR auto-skips this job in forks but at the same time adds this nice feature:

![grafik](https://user-images.githubusercontent.com/22860528/108127660-ddedcd80-70ab-11eb-8636-273e76f8a17c.png)

So you can (in your fork) run tests on your yet to be merged branch.

PS: "Report" step is never run in forks for obvious reasons.