### PR TITLE
Align 'Build Quarkus master' to ci-actions.yml

### DIFF
--- a/.github/workflows/build-pr-development.yml
+++ b/.github/workflows/build-pr-development.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus master
-        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B --settings .github/mvn-settings.xml clean install -DskipTests -DskipITs
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git
+          cd quarkus
+          mvn -T1C -e -B --settings .github/mvn-settings.xml clean install -Dquickly-ci
       - name: Build with Maven
         run: export LANG=en_US && mvn --settings .github/mvn-settings.xml -B clean install -Dstart-containers
       - name: Delete Local Artifacts From Cache

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git clone https://github.com/quarkusio/quarkus.git
           cd quarkus
-          mvn --settings .github/mvn-settings.xml -B clean install -DskipTests -DskipITs
+          mvn -T1C -e -B --settings .github/mvn-settings.xml clean install -Dquickly-ci
 
       - name: Build Quickstart with native
         run: |


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/blob/master/.github/workflows/ci-actions.yml#L94

Instead of _some_ `-DskipX` properties we can go the full monty with `-Dquickly-ci`.