### PR TITLE
Fix quarkus plugin and platform versions (missing dependency in maven).

### DIFF
--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -7,10 +7,10 @@
   <version>1.0.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus-plugin.version>1.11.3.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>1.11.3.Final</quarkus.platform.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Fixing maven dependency. It contradicts the two checklist items below, not sure how relevant they are here.

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus


