### PR TITLE
Adjusted PR approach 

### DIFF
--- a/amazon-dynamodb-quickstart/README.md
+++ b/amazon-dynamodb-quickstart/README.md
@@ -5,7 +5,11 @@ This example showcases how to use the AWS DynamoDB client with Quarkus. As a pre
 # DynamoDB local instance
 
 Just run it as follows:
-`docker run --rm --name local-dynamo -p 8000:4569 -e SERVICES=dynamodb -e START_WEB=0 -d localstack/localstack`
+`docker run --rm --name local-dynamo -p 8000:4566 -e SERVICES=dynamodb -e START_WEB=0 -d localstack/localstack`
+
+or use the provided docker-compose file
+
+> docker-compose up -d
 
 DynamoDB listens on `localhost:8000` for REST endpoints.
 
@@ -67,7 +71,7 @@ Stop your localstack container you started at the beginning
 `docker stop local-dynamo`
 
 Start localstack and connect to the network
-`docker run --rm --network=localstack --name localstack -p 8000:4569 -e SERVICES=dynamodb -e START_WEB=0 -d localstack/localstack`
+`docker run --rm --network=localstack --name localstack -p 8000:4566 -e SERVICES=dynamodb -e START_WEB=0 -d localstack/localstack`
 
 Create Dynamo table
 ```

--- a/amazon-dynamodb-quickstart/docker-compose.yaml
+++ b/amazon-dynamodb-quickstart/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+  localstack:
+    image: localstack/localstack:0.11.2
+    container_name: local-dynamo
+    ports:
+    - 8000:4566
+    environment:
+      SERVICES: dynamodb
+      START_WEB: 0

--- a/amazon-s3-quickstart/README.md
+++ b/amazon-s3-quickstart/README.md
@@ -5,7 +5,11 @@ This example showcases how to use the AWS S3 client with Quarkus. As a prerequis
 # S3 local instance
 
 Just run it as follows:
-`docker run --rm --name local-s3 -p 8008:4572 -e SERVICES=s3 -e START_WEB=0 -d localstack/localstack`
+`docker run --rm --name local-s3 -p 8008:4566 -e SERVICES=s3 -e START_WEB=0 -d localstack/localstack`
+
+or use the provided docker-compose file
+
+> docker-compose up -d
 
 S3 listens on `localhost:8008` for REST endpoints.
 

--- a/amazon-s3-quickstart/docker-compose.yaml
+++ b/amazon-s3-quickstart/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+  localstack:
+    image: localstack/localstack:0.11.2
+    container_name: local-s3
+    ports:
+    - 8008:4566
+    environment:
+      SERVICES: s3
+      START_WEB: 0

--- a/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
+++ b/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
@@ -64,7 +64,7 @@ public class S3AsyncClientResource extends CommonResource {
         return Uni.createFrom()
                 .completionStage(() -> s3.getObject(buildGetRequest(objectKey), AsyncResponseTransformer.toFile(tempFile)))
                 .onItem()
-                .apply(object -> Response.ok(tempFile)
+                .transform(object -> Response.ok(tempFile)
                         .header("Content-Disposition", "attachment;filename=" + objectKey)
                         .header("Content-Type", object.contentType()).build());
     }

--- a/amazon-ses-quickstart/README.md
+++ b/amazon-ses-quickstart/README.md
@@ -7,7 +7,11 @@ Local instance of SES only mocks service APIs and doesn't send any emails.
 # AWS SES local instance
 
 Just run it as follows in order to start SES locally:
-`docker run --rm --name local-ses -p 8012:4579 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:0.11.1`
+`docker run --rm --name local-ses -p 8012:4566 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:0.11.1`
+
+or use the provided docker-compose file
+> docker-compose up -d
+
 SES listens on `localhost:8012` for REST endpoints.
 
 Create an AWS profile for your local instance using AWS CLI:

--- a/amazon-ses-quickstart/docker-compose.yaml
+++ b/amazon-ses-quickstart/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+  localstack:
+    image: localstack/localstack:0.11.1
+    container_name: local-ses
+    ports:
+    - 8012:4566
+    environment:
+      SERVICES: ses
+      START_WEB: 0

--- a/amazon-ses-quickstart/src/main/java/org/acme/ses/QuarkusSesAsyncResource.java
+++ b/amazon-ses-quickstart/src/main/java/org/acme/ses/QuarkusSesAsyncResource.java
@@ -20,7 +20,7 @@ public class QuarkusSesAsyncResource {
     SesAsyncClient ses;
 
     @POST
-    @Path("/email")
+    @Path("email")
     public Uni<String> encrypt(Email data) {
         return Uni.createFrom()
             .completionStage(

--- a/amazon-ses-quickstart/src/main/java/org/acme/ses/QuarkusSesSyncResource.java
+++ b/amazon-ses-quickstart/src/main/java/org/acme/ses/QuarkusSesSyncResource.java
@@ -18,7 +18,7 @@ public class QuarkusSesSyncResource {
     SesClient ses;
 
     @POST
-    @Path("/email")
+    @Path("email")
     public String encrypt(Email data) {
         return ses.sendEmail(req -> req
             .source(data.getFrom())

--- a/amazon-ses-quickstart/src/test/java/org/acme/ses/SesResourcesTest.java
+++ b/amazon-ses-quickstart/src/test/java/org/acme/ses/SesResourcesTest.java
@@ -25,7 +25,7 @@ public class SesResourcesTest {
         given()
             .pathParam("resource", testedResource)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-            .body(String.format(JSON, SesResource.FROM_EMAIL, SesResource.TO_EMAIL, "Hello from Quarkus", "Quarkus is awsome"))
+            .body(String.format(JSON, SesResource.FROM_EMAIL, SesResource.TO_EMAIL, "Hello from Quarkus", "Quarkus is awesome"))
             .when()
             .post("/{resource}/email")
             .then()

--- a/amazon-sns-quickstart/README.md
+++ b/amazon-sns-quickstart/README.md
@@ -5,8 +5,12 @@ This example showcases how to use the AWS SNS client with Quarkus. As a prerequi
 # AWS SNS local instance
 
  Just run it as follows in order to start SNS locally:
-`docker run --rm --name local-sns -p 8009:4575 -e SERVICES=sns -e START_WEB=0 -d localstack/localstack:0.11.1`
+`docker run --rm --name local-sns -p 8009:4566 -e SERVICES=sns -e START_WEB=0 -d localstack/localstack:0.11.1`
 SNS listens on `localhost:8009` for REST endpoints.
+
+or use the provided docker-compose file
+
+> docker-compose up -d
 
 Create an AWS profile for your local instance using AWS CLI:
 
@@ -21,7 +25,7 @@ Default output format [None]:
 ## Create topic
 Create a topic using AWS CLI with the localstack profile and store the generated ARN in the environment variable
 ```
-$> TOPIC_ARN=`aws sns create-topic --name=QuarksCollider --profile localstack --endpoint-url=http://localhost:8009`
+$> export TOPIC_ARN=`aws sns create-topic --name=QuarksCollider --profile localstack --endpoint-url=http://localhost:8009 | jq -r .TopicArn`
 ```
 
 # Run the demo on dev mode

--- a/amazon-sns-quickstart/docker-compose.yaml
+++ b/amazon-sns-quickstart/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+  localstack:
+    image: localstack/localstack:0.11.1
+    container_name: local-sns
+    ports:
+    - 8009:4566
+    environment:
+      SERVICES: sns
+      START_WEB: 0

--- a/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksCannonAsyncResource.java
+++ b/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksCannonAsyncResource.java
@@ -32,7 +32,7 @@ public class QuarksCannonAsyncResource {
     static ObjectWriter QUARK_WRITER = new ObjectMapper().writerFor(Quark.class);
 
     @POST
-    @Path("/shoot")
+    @Path("shoot")
     @Consumes(MediaType.APPLICATION_JSON)
     public Uni<Response> publish(Quark quark) throws Exception {
         String message = QUARK_WRITER.writeValueAsString(quark);

--- a/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksCannonSyncResource.java
+++ b/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksCannonSyncResource.java
@@ -30,7 +30,7 @@ public class QuarksCannonSyncResource {
     static ObjectWriter QUARK_WRITER = new ObjectMapper().writerFor(Quark.class);
 
     @POST
-    @Path("/shoot")
+    @Path("shoot")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response publish(Quark quark) throws Exception {
         String message = QUARK_WRITER.writeValueAsString(quark);

--- a/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksShieldAsyncResource.java
+++ b/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksShieldAsyncResource.java
@@ -79,7 +79,7 @@ public class QuarksShieldAsyncResource {
     }
 
     @POST
-    @Path("/subscribe")
+    @Path("subscribe")
     public Uni<Response> subscribe() {
         return Uni.createFrom()
             .completionStage(sns.subscribe(s -> s.topicArn(topicArn).protocol("http").endpoint(notificationEndpoint())))
@@ -90,7 +90,7 @@ public class QuarksShieldAsyncResource {
     }
 
     @POST
-    @Path("/unsubscribe")
+    @Path("unsubscribe")
     public Uni<Response> unsubscribe() {
         if (subscriptionArn != null) {
             return Uni.createFrom()

--- a/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksShieldSyncResource.java
+++ b/amazon-sns-quickstart/src/main/java/org/acme/sns/QuarksShieldSyncResource.java
@@ -73,7 +73,7 @@ public class QuarksShieldSyncResource {
     }
 
     @POST
-    @Path("/subscribe")
+    @Path("subscribe")
     public Response subscribe() {
         String notificationEndpoint = notificationEndpoint();
         SubscribeResponse response = sns.subscribe(s -> s.topicArn(topicArn).protocol("http").endpoint(notificationEndpoint));
@@ -83,7 +83,7 @@ public class QuarksShieldSyncResource {
     }
 
     @POST
-    @Path("/unsubscribe")
+    @Path("unsubscribe")
     public Response unsubscribe() {
         if (subscriptionArn != null) {
             sns.unsubscribe(s -> s.subscriptionArn(subscriptionArn));

--- a/amazon-sqs-quickstart/README.md
+++ b/amazon-sqs-quickstart/README.md
@@ -5,7 +5,11 @@ This example showcases how to use the AWS SQS client with Quarkus. As a prerequi
 # AWS SQS local instance
 
 Just run it as follows in order to start SQS locally:
-`docker run --rm --name local-sqs -p 8010:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1`
+`docker run --rm --name local-sqs -p 8010:4566 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1`
+
+or use the provided docker compose file
+> docker-compose up -d
+
 SQS listens on `localhost:8010` for REST endpoints.
 
 Create an AWS profile for your local instance using AWS CLI:
@@ -22,7 +26,7 @@ Default output format [None]:
 
 Create a SQS queue and store Queue url in environment variable as we will need to provide it to the our app
 ```
-$> QUEUE_URL=`aws sqs create-queue --queue-name=ColliderQueue --profile localstack --endpoint-url=http://localhost:8010`
+$> export QUEUE_URL=`aws sqs create-queue --queue-name=ColliderQueue --profile localstack --endpoint-url=http://localhost:8010 | jq -r .QueueUrl`
 ```
 
 # Run the demo on dev mode
@@ -38,7 +42,7 @@ curl -XPOST -H"Content-type: application/json" http://localhost:8080/sync/cannon
 ```
 And receive it from the queue
 ```
-curl http://localhost:8080/sync/cannon/shoot
+curl http://localhost:8080/sync/shield
 ```
 
 Repeat the same using async endpoints
@@ -48,7 +52,7 @@ curl -XPOST -H"Content-type: application/json" http://localhost:8080/async/canno
 ```
 And receive it from the queue
 ```
-curl http://localhost:8080/async/cannon/shoot
+curl http://localhost:8080/async/shield
 ```
 
 # Running in native
@@ -81,10 +85,10 @@ Start localstack and connect to the network
 
 Create queue
 ```
-$> QUEUE_URL=`aws sqs create-queue --queue-name=ColliderQueue --profile localstack --endpoint-url=http://localhost:8010`
+xport QUEUE_URL=`aws sqs create-queue --queue-name=ColliderQueue --profile localstack --endpoint-url=http://localhost:8010 | jq -r .QueueUrl`
 ```
 Run quickstart container connected to that network (note that we're using internal port of the localstack)
-`docker run -i --rm --network=localstack -p 8080:8080 quarkus/amazon-sqs-quickstart -Dquarkus.sqs.endpoint-override=http://localstack:4576`
+`docker run -i --rm --network=localstack -p 8080:8080 quarkus/amazon-sqs-quickstart -Dquarkus.sqs.endpoint-override=http://localstack:4566`
 
 Send messsage
 ```
@@ -93,5 +97,5 @@ curl -XPOST -H"Content-type: application/json" http://localhost:8080/sync/cannon
 
 Receive message
 ```
-curl http://localhost:8080/sync/cannon/shoot
+curl http://localhost:8080/sync/shield
 ```

--- a/amazon-sqs-quickstart/docker-compose.yaml
+++ b/amazon-sqs-quickstart/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+  localstack:
+    image: localstack/localstack:0.11.1
+    container_name: local-sqs
+    ports:
+    - 8010:4566
+    environment:
+      SERVICES: sqs
+      START_WEB: 0

--- a/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksCannonAsyncResource.java
+++ b/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksCannonAsyncResource.java
@@ -32,7 +32,7 @@ public class QuarksCannonAsyncResource {
     static ObjectWriter QUARK_WRITER = new ObjectMapper().writerFor(Quark.class);
 
     @POST
-    @Path("/shoot")
+    @Path("shoot")
     @Consumes(MediaType.APPLICATION_JSON)
     public Uni<Response> sendMessage(Quark quark) throws Exception {
         String message = QUARK_WRITER.writeValueAsString(quark);

--- a/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksCannonSyncResource.java
+++ b/amazon-sqs-quickstart/src/main/java/org/acme/sqs/QuarksCannonSyncResource.java
@@ -30,7 +30,7 @@ public class QuarksCannonSyncResource {
     static ObjectWriter QUARK_WRITER = new ObjectMapper().writerFor(Quark.class);
 
     @POST
-    @Path("/shoot")
+    @Path("shoot")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response sendMessage(Quark quark) throws Exception {
         String message = QUARK_WRITER.writeValueAsString(quark);

--- a/amqp-quickstart/README.md
+++ b/amqp-quickstart/README.md
@@ -5,7 +5,7 @@ This project illustrates how you can interact with AMQP 1.0 (Apache Artemis in t
 
 ## AMQP Broker
 
-First you need an AMQP broker. You can follow the instructions from the [Apache Artemis web site](https://activemq.apache.org/components/artemis/) or run `docker-compose up` if you have docker installed on your machine.
+First you need an AMQP broker. You can follow the instructions from the [Apache Artemis web site](https://activemq.apache.org/components/artemis/) or run `docker-compose up -d` if you have docker installed on your machine.
 
 ## Start the application
 

--- a/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingService.java
+++ b/getting-started-reactive/src/main/java/org/acme/getting/started/ReactiveGreetingService.java
@@ -18,8 +18,6 @@ public class ReactiveGreetingService {
     public Multi<String> greetings(int count, String name) {
         return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
                 .onItem().transform(n -> String.format("hello %s - %d", name, n))
-                .transform().byTakingFirstItems(count);
-
+                .select().first(count);
     }
-
 }

--- a/hibernate-reactive-quickstart/README.md
+++ b/hibernate-reactive-quickstart/README.md
@@ -40,6 +40,10 @@ Make sure you have a PostgreSQL instance running. To set up a PostgreSQL databas
 
 > docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:10.5
 
+or use the provided docker-compose file:
+
+> docker-compose up -d
+
 Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
 `src/main/resources/application.properties`.
 

--- a/hibernate-reactive-quickstart/docker-compose.yaml
+++ b/hibernate-reactive-quickstart/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '3.5'
+
+services:
+  postgres:
+    image: library/postgres:10.5
+    container_name: quarkus_test
+    ports:
+    - 5432:5432
+    ulimits:
+      memlock: -1
+    mem_swappiness: 0
+    environment:
+      POSTGRES_USER: quarkus_test
+      POSTGRES_PASSWORD: quarkus_test
+      POSTGRES_DB: quarkus_test
+

--- a/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/FruitMutinyResource.java
+++ b/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/FruitMutinyResource.java
@@ -12,6 +12,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -28,8 +29,8 @@ import io.smallrye.mutiny.Uni;
 
 @Path("fruits")
 @ApplicationScoped
-@Produces("application/json")
-@Consumes("application/json")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class FruitMutinyResource {
     private static final Logger LOGGER = Logger.getLogger(FruitMutinyResource.class.getName());
 

--- a/hibernate-reactive-routes-quickstart/README.md
+++ b/hibernate-reactive-routes-quickstart/README.md
@@ -40,6 +40,10 @@ Make sure you have a PostgreSQL instance running. To set up a PostgreSQL databas
 
 > docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:10.5
 
+or use the provided docker-compose file:
+
+> docker-compose up -d
+
 Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
 `src/main/resources/application.properties`.
 

--- a/hibernate-reactive-routes-quickstart/docker-compose.yaml
+++ b/hibernate-reactive-routes-quickstart/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '3.5'
+
+services:
+  postgres:
+    image: library/postgres:10.5
+    container_name: quarkus_test
+    ports:
+    - 5432:5432
+    ulimits:
+      memlock: -1
+    mem_swappiness: 0
+    environment:
+      POSTGRES_USER: quarkus_test
+      POSTGRES_PASSWORD: quarkus_test
+      POSTGRES_DB: quarkus_test
+


### PR DESCRIPTION
per gsmet, I revised my PR. 
- focus is on improving developer interaction by providing docker-compose files. 
- any/all code changes were bug fixes, typos, or replacing deprecated code (w/ one aesthetic change where I replaced "application/json" w/ MediaType.APPLICATION_JSON).


**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [N/A] makes sure the associated guide must not be updated
- [N/A] links the guide update pull request (if needed)
- [X] updates or creates the `README.md` file (with build and run instructions)
- [N/A] for new quickstart, is located in the directory _component-quickstart_
- [N/A] for new quickstart, is added to the root `pom.xml` and `README.md`

1.)
Testing w/ postgres containers is a known issue:
It's a run/fail/run effort to test the whole repo:
- fails on test for each test that needs to use a postgres container after another test had previously started a postgres container.
- impacts mvn clean test, mvn clean package -Pnative, mvn clean verify -Pnative

Workaround

When fail:
- docker stop $(docker ps -q); docker rm $(docker ps -a -q)
- mvn <args> -rf :<failed module>

(Another workaround is to babysit the tests w/ Docker desktop open, and then out of the corner of your eye you and kill the docker container if the test isn't using it.) 

2.) mvn clean verify -Pnative exposes a problem running the IT tests. 
- https://github.com/quarkusio/quarkus-quickstarts/issues/793
- I've tried multiple versions of LocalStack, AWS SDK, and Graal (non-exhaustive). 
- this goes away if I rerun the test several times, which makes me think that this is a either a thread visibility problem or 
a race condition. (Also probably why it's a PITA to reproduce using the debugger)

to save time, I only tested the modules I touched, because waiting for each module... was a lot of coffee :)

