### PR TITLE
Replace deprecated .collectItems() with .collect()

### DIFF
--- a/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/FruitMutinyResource.java
+++ b/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/FruitMutinyResource.java
@@ -39,7 +39,7 @@ public class FruitMutinyResource {
     @GET
     public Uni<List<Fruit>> get() {
         return mutinySession
-                .createNamedQuery( "Fruits.findAll", Fruit.class ).getResults().collectItems().asList();
+                .createNamedQuery( "Fruits.findAll", Fruit.class ).getResults().collect().asList();
     }
 
     @GET

--- a/mongodb-quickstart/src/main/java/org/acme/mongodb/ReactiveFruitService.java
+++ b/mongodb-quickstart/src/main/java/org/acme/mongodb/ReactiveFruitService.java
@@ -24,7 +24,7 @@ public class ReactiveFruitService {
                     fruit.setName(doc.getString("name"));
                     fruit.setDescription(doc.getString("description"));
                     return fruit;
-                }).collectItems().asList();
+                }).collect().asList();
     }
 
     public Uni<Void> add(Fruit fruit) {


### PR DESCRIPTION
Remove some deprecated calls from the quickstarts by using the non deprecated method.