### PR TITLE
Bump test container version in the bare-kafka quickstart

### DIFF
--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -14,7 +14,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testcontainers.version>1.14.1</testcontainers.version>
+    <testcontainers.version>1.15.2</testcontainers.version>
+    <mutiny-vertx.version>1.5.0</mutiny-vertx.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -51,7 +52,7 @@
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-mutiny-vertx-kafka-client</artifactId>
-      <version>1.2.2</version>
+      <version>${mutiny-vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The previous one does not work anymore with the latest Docker versions, including the version used on Github Action


