### PR TITLE
Upgrade Kogito to 1.1.0

### DIFF
--- a/.github/workflows/build-pr-development.yml
+++ b/.github/workflows/build-pr-development.yml
@@ -40,8 +40,8 @@ jobs:
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
           java-version: ${{ matrix.java }}
-      - name: Build Quarkus master
-        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -DskipTests -DskipITs
+      - name: Build Quarkus 1.11
+        run: git clone https://github.com/quarkusio/quarkus.git && cd quarkus && git checkout 1.11 && mvn -B clean install -DskipTests -DskipITs
       - name: Build with Maven
         run: export LANG=en_US && mvn -B clean install -Dstart-containers
       - name: Delete Local Artifacts From Cache

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>1.11.6.Final</quarkus.platform.version>
-    <kogito-quarkus.version>0.15.0</kogito-quarkus.version>
+    <kogito-quarkus.version>1.1.0.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>


### PR DESCRIPTION
Align version with `quarkus-platform:1.11.6.Final`.

Fixes https://github.com/quarkusio/quarkus/issues/15684 / https://issues.redhat.com/browse/QUARKUS-867 on 1.11.
Related discussion also in https://github.com/quarkusio/quarkus-platform/pull/220.

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`
