### PR TITLE
Use new native profile configuration

### DIFF
--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -90,30 +90,20 @@
 
     <profiles>
         <profile>
+            <!-- Optionally activate this profile to compile the demo into native! -->
             <id>native</id>
             <activation>
                 <property>
                     <name>native</name>
                 </property>
             </activation>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <configuration>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${surefire-plugin.version}</version>
                         <executions>


### PR DESCRIPTION
The old configuration that in invokes the `native-image` goal
is no longer valid as that goal has been removed

Relates to https://github.com/quarkusio/quarkus/issues/6588#issuecomment-873770257