### PR TITLE
KOGITO-5643 Kogito quickstarts on Quarkus is failing

### DIFF
--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <kogito-quarkus.version>1.6.0.Final</kogito-quarkus.version>
+    <kogito-quarkus.version>1.9.1.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kogito-quickstart/src/main/java/org/acme/kogito/PersonUnit.java
+++ b/kogito-quickstart/src/main/java/org/acme/kogito/PersonUnit.java
@@ -1,0 +1,28 @@
+package org.acme.kogito;
+
+import org.acme.kogito.model.Person;
+import org.kie.kogito.rules.DataSource;
+import org.kie.kogito.rules.RuleUnitData;
+import org.kie.kogito.rules.SingletonStore;
+
+public class PersonUnit implements RuleUnitData {
+
+    private SingletonStore<Person> person;
+ 
+    public PersonUnit() {
+        this(DataSource.createSingleton());
+    }
+ 
+    public PersonUnit(SingletonStore<Person> person) {
+        this.person = person;
+    }
+
+    public SingletonStore<Person> getPerson() {
+        return person;
+    }
+
+    public void setPerson(SingletonStore<Person> person) {
+        this.person = person;
+    }
+}
+ 

--- a/kogito-quickstart/src/main/resources/org/acme/kogito/person-rules.drl
+++ b/kogito-quickstart/src/main/resources/org/acme/kogito/person-rules.drl
@@ -1,12 +1,12 @@
-package org.acme.kogito
+package org.acme.kogito;
+
+unit PersonUnit; 
 
 import org.acme.kogito.model.Person;
 
-
-rule "Is adult" ruleflow-group "person"
-
+rule "Is adult"
 when
-    $person: Person(age > 18)
+    $person: /person[age > 18]
 then
     modify($person) { 
     	setAdult(true) 

--- a/kogito-quickstart/src/main/resources/org/acme/kogito/persons.bpmn2
+++ b/kogito-quickstart/src/main/resources/org/acme/kogito/persons.bpmn2
@@ -18,7 +18,7 @@
       </bpmn2:extensionElements>
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
-    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="person" name="Evaluate person">
+    <bpmn2:businessRuleTask id="BusinessRuleTask_1" tns:ruleFlowGroup="unit:org.acme.kogito.PersonUnit" name="Evaluate person">
       <bpmn2:extensionElements>
         <tns:metaData name="elementname">
           <tns:metaValue><![CDATA[Evaluate person]]></tns:metaValue>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5643

/cc @danielezonca @gsmet this fixes the problem the quarkus kogito-quickstart couldn't be bumped to kogito 1.9.1.Final.

Update of the Quarkus Kogito ("main") quickstart guide : https://github.com/quarkusio/quarkus/pull/19297

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [x] links the guide update pull request: https://github.com/quarkusio/quarkus/pull/19297
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`