### PR TITLE
Fix amazon-sqs docker startup timeout error

### DIFF
--- a/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
+++ b/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.utility.DockerImageName;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -17,6 +19,8 @@ public class SqsResource implements QuarkusTestResourceLifecycleManager {
 
     public final static String QUEUE_NAME = "Quarkus";
 
+    private final static String LOCALSTACK_IMAGE = "localstack/localstack:0.11.3";
+
     private LocalStackContainer services;
     private SqsClient client;
 
@@ -25,7 +29,8 @@ public class SqsResource implements QuarkusTestResourceLifecycleManager {
         DockerClientFactory.instance().client();
         String queueUrl;
         try {
-            services = new LocalStackContainer("0.11.1").withServices(Service.SQS);
+            DockerImageName dockerImageName = DockerImageName.parse(LOCALSTACK_IMAGE);
+            services = new LocalStackContainer(dockerImageName).withServices(Service.SQS);
             services.start();
             StaticCredentialsProvider staticCredentials = StaticCredentialsProvider
                 .create(AwsBasicCredentials.create("accesskey", "secretKey"));


### PR DESCRIPTION
Sometimes localstack gives the following error:

```
org.testcontainers.containers.ContainerLaunchException: Container startup failed
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:330)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:311)
	at org.acme.sqs.SqsResource.start(SqsResource.java:29)
	at io.quarkus.test.common.TestResourceManager.lambda$start$1(TestResourceManager.java:109)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:323)
	... 8 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:497)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:325)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	... 9 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Timed out waiting for log output matching '.*Ready\.
'
	at org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy.waitUntilReady(LogMessageWaitStrategy.java:49)
	at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:35)
	at org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:892)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:440)
	... 11 more
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 1, Time elapsed: 69.27 s <<< FAILURE! - in org.acme.sqs.SqsResourcesTest
```

We could reproduce this issue on localstack docker image: `localstack/localstack:0.11.1`
Fixed on: `localstack/localstack:0.11.3`
OS: RHEL8

You could also reproduce manually running the following command:
```
docker run -it -e DEBUG=1 -e SERVICES="sqs" -e DEFAULT_REGION="us-east-1" -e TEST_AWS_ACCOUNT_ID="0000000000" --rm --privileged --name localstack_main -p 8080:8080 -p 8081:8081   -p 4572:4572  -v "/tmp/localstack:/tmp/localstack" -v "/var/run/docker.sock:/var/run/docker.sock" -e DOCKER_HOST="unix:///var/run/docker.sock" -e HOST_TMP_FOLDER="/tmp/localstack" "localstack/localstack:0.11.1"
```





