### PR TITLE
Revert "Fix amazon-sqs docker startup timeout error"

### DIFF
--- a/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
+++ b/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
@@ -7,8 +7,6 @@ import java.util.Map;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
-import org.testcontainers.utility.DockerImageName;
-
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -19,8 +17,6 @@ public class SqsResource implements QuarkusTestResourceLifecycleManager {
 
     public final static String QUEUE_NAME = "Quarkus";
 
-    private final static String LOCALSTACK_IMAGE = "localstack/localstack:0.11.3";
-
     private LocalStackContainer services;
     private SqsClient client;
 
@@ -29,8 +25,7 @@ public class SqsResource implements QuarkusTestResourceLifecycleManager {
         DockerClientFactory.instance().client();
         String queueUrl;
         try {
-            DockerImageName dockerImageName = DockerImageName.parse(LOCALSTACK_IMAGE);
-            services = new LocalStackContainer(dockerImageName).withServices(Service.SQS);
+            services = new LocalStackContainer("0.11.1").withServices(Service.SQS);
             services.start();
             StaticCredentialsProvider staticCredentials = StaticCredentialsProvider
                 .create(AwsBasicCredentials.create("accesskey", "secretKey"));


### PR DESCRIPTION
This reverts commit 4f7efab999d1540abb6a0a1e3fe0bfd034bebcec.

The build is now always failing for the native quickstarts as commented here: https://github.com/quarkusio/quarkus-quickstarts/pull/920 .

So reverting because sometimes failing is better than always failing. If someone has the time to dig into the issue, be my guest :).