### PR TITLE
Drop Testcontainers version as it's now coming from the BOM

### DIFF
--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -16,7 +16,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -83,7 +82,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -17,7 +17,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -60,7 +59,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/infinispan-client-quickstart/src/test/java/org/acme/infinispan/client/CacheResource.java
+++ b/infinispan-client-quickstart/src/test/java/org/acme/infinispan/client/CacheResource.java
@@ -23,6 +23,7 @@ public class CacheResource implements QuarkusTestResourceLifecycleManager {
                 new GenericContainer("infinispan/server:12.1.6.Final")
                         .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Infinispan Server.*started in.*\\s"))
                         .withStartupTimeout(Duration.ofMillis(20000))
+                .withExposedPorts(INFINISPAN_PORT)
                 .withEnv("USER","admin")
                 .withEnv("PASS","password");
 

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -14,8 +14,6 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <testcontainers.version>1.15.2</testcontainers.version>
-    <mutiny-vertx.version>1.5.0</mutiny-vertx.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -52,7 +50,6 @@
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-mutiny-vertx-kafka-client</artifactId>
-      <version>${mutiny-vertx.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -78,7 +75,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -14,7 +14,6 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <testcontainers.version>1.15.2</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -14,7 +14,6 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <testcontainers.version>1.15.2</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -18,7 +18,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -18,7 +18,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -15,7 +15,6 @@
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <testcontainers.version>1.15.2</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -65,13 +64,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -15,7 +15,6 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <testcontainers.version>1.15.2</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -58,7 +57,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>neo4j</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -15,7 +15,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -54,13 +53,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -12,7 +12,6 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -59,13 +58,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -15,7 +15,6 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -62,7 +61,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -20,7 +20,6 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlunit.version>2.36.0</htmlunit.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -79,7 +78,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -18,7 +18,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -19,7 +19,6 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <htmlunit.version>2.36.0</htmlunit.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
And we need it to be aligned with docker-java.

