### PR TITLE
Dockerfile - Do not use chown during copy as Kaniko does not support it

### DIFF
--- a/getting-started/src/main/docker/Dockerfile.jvm
+++ b/getting-started/src/main/docker/Dockerfile.jvm
@@ -43,10 +43,11 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001 target/quarkus-app/*.jar /deployments/
-COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
-COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY  target/quarkus-app/lib/ /deployments/lib/
+COPY  target/quarkus-app/*.jar /deployments/
+COPY  target/quarkus-app/app/ /deployments/app/
+COPY  target/quarkus-app/quarkus/ /deployments/quarkus/
+RUN chown -R 1001 /deployments
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


