### PR TITLE
[2.2] Use io.quarkus:quarkus-maven-plugin

### DIFF
--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -46,7 +46,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>${quarkus.platform.group-id}</groupId>
+        <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -50,7 +50,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>${quarkus.platform.group-id}</groupId>
+        <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -71,7 +71,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>${quarkus.platform.group-id}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -63,7 +63,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>${quarkus.platform.group-id}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -74,7 +74,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>${quarkus.platform.group-id}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>


### PR DESCRIPTION
Backport of https://github.com/quarkusio/quarkus-quickstarts/pull/944

This is a test conveniant change to allow run the quickstarts using:
- (works) mvn clean verify -Dquarkus.platform.groupId=io.quarkus.platform -Dquarkus.platform.artifactId=quarkus-bom
- (works) mvn clean verify -Dquarkus.platform.groupId=com.redhat.quarkus.platform -Dquarkus.platform.artifactId=quarkus-bom
- (DOES NOT WORK using RHBQ universe bom) mvn clean verify -Dquarkus.platform.groupId=com.redhat.quarkus -Dquarkus.platform.artifactId=quarkus-universe-bom

It does not work because `com.redhat.quarkus:quarkus-maven-plugin` does not exist, but it does exist either `io.quarkus:quarkus-maven-plugin` and `com.redhat.quarkus.platform:quarkus-maven-plugin`

Moreover, at the moment all the quickstarts use `io.quarkus:quarkus-maven-plugin` too.


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


