### PR TITLE
[1.11] Fix rest-clients quickstarts by using wiremock to get countries

### DIFF
--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -14,6 +14,7 @@
         <quarkus.platform.version>1.11.7.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <wiremock.version>2.27.2</wiremock.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -54,6 +55,12 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
+            <version>${wiremock.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/rest-client-quickstart/src/main/resources/application.properties
+++ b/rest-client-quickstart/src/main/resources/application.properties
@@ -1,1 +1,2 @@
+quarkus.tls.trust-all=true
 org.acme.rest.client.CountriesService/mp-rest/url=https://restcountries.eu/rest

--- a/rest-client-quickstart/src/test/java/org/acme/rest/client/CountriesResourceTest.java
+++ b/rest-client-quickstart/src/test/java/org/acme/rest/client/CountriesResourceTest.java
@@ -3,11 +3,14 @@ package org.acme.rest.client;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
+import org.acme.rest.client.resources.WireMockCountriesResource;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@QuarkusTestResource(WireMockCountriesResource.class)
 public class CountriesResourceTest {
 
     @Test

--- a/rest-client-quickstart/src/test/java/org/acme/rest/client/resources/WireMockCountriesResource.java
+++ b/rest-client-quickstart/src/test/java/org/acme/rest/client/resources/WireMockCountriesResource.java
@@ -1,0 +1,71 @@
+package org.acme.rest.client.resources;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.json.Json;
+import javax.json.JsonValue;
+import javax.json.stream.JsonParser;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class WireMockCountriesResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final String COUNTRIES_JSON_FILE = "/countries.json";
+    private static final String BASE_PATH = "/rest";
+    private static final int WIREMOCK_PORT = 7777;
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(WIREMOCK_PORT);
+        wireMockServer.start();
+        stubCountries();
+        return Collections.singletonMap("org.acme.rest.client.CountriesService/mp-rest/url",
+                wireMockServer.baseUrl() + BASE_PATH);
+    }
+
+    @Override
+    public void stop() {
+        if (Objects.nonNull(wireMockServer))
+            wireMockServer.stop();
+    }
+
+    private void stubCountries() {
+
+        try (InputStream is = WireMockCountriesResource.class.getResourceAsStream(COUNTRIES_JSON_FILE)) {
+            String countries = new String(is.readAllBytes());
+
+            // Stub for full list of countries:
+            wireMockServer.stubFor(get(urlEqualTo(BASE_PATH))
+                    .willReturn(okJson(countries)));
+
+            // Stub for each country
+            try (StringReader sr = new StringReader(countries);
+                    JsonParser parser = Json.createParser(sr)) {
+                parser.next();
+                for (JsonValue country : parser.getArray()) {
+                    String name = country.asJsonObject().getString("name");
+
+                    wireMockServer.stubFor(get(urlEqualTo(BASE_PATH + "/v2/name/" + name))
+                            .willReturn(okJson("[" + country + "]")));
+                }
+            }
+
+        } catch (IOException e) {
+            fail("Could not configure Wiremock server. Caused by: " + e.getMessage());
+        }
+    }
+}

--- a/rest-client-quickstart/src/test/resources/countries.json
+++ b/rest-client-quickstart/src/test/resources/countries.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "greece",
+    "capital": "Athens",
+    "currencies": [
+      {
+        "code": "EUR",
+        "name": "Euro",
+        "symbol": "€"
+      }
+    ],
+    "alpha2Code": "GR"
+  },
+  {
+    "name": "Germany",
+    "capital": "Berlin",
+    "currencies": [
+      {
+        "code": "EUR",
+        "name": "Euro",
+        "symbol": "€"
+      }
+    ],
+    "alpha2Code": "DE"
+  }
+]


### PR DESCRIPTION


Cherry-pick of https://github.com/quarkusio/quarkus-quickstarts/pull/946 (with only changes related to rest-client-quickstart)

The REST api https://restcountries.eu/rest used to get a list of countries was moved to https://countrylayer.com/ and requires an API key to keep using it.

With these changes, we'll start up a REST API mock server (does not require Docker) to provide a list of countries.

I confirmed that these two modules work fine on JVM and Native.

This change `quarkus.tls.trust-all=true` is not really necessary but by adding it, users will see the real issue (unauthorized access to https://restcountries.eu/rest)


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


