### PR TITLE
Rest client quickstarts: switch to new property notation & change the…

### DIFF
--- a/rest-client-multipart-quickstart/src/main/resources/application.properties
+++ b/rest-client-multipart-quickstart/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-org.acme.rest.client.multipart.MultipartService/mp-rest/url=http://localhost:${quarkus.http.test-port:8080}/
+quarkus.rest-client."org.acme.rest.client.multipart.MultipartService".url=http://localhost:8080/

--- a/rest-client-multipart-quickstart/src/test/resources/application.properties
+++ b/rest-client-multipart-quickstart/src/test/resources/application.properties
@@ -1,1 +1,1 @@
-org.acme.rest.client.multipart.MultipartService/mp-rest/url=http://localhost:8081/
+quarkus.rest-client."org.acme.rest.client.multipart.MultipartService".url=http://localhost:${quarkus.http.test-port:8081}/

--- a/rest-client-quickstart/src/main/resources/application.properties
+++ b/rest-client-quickstart/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 quarkus.tls.trust-all=true
-org.acme.rest.client.CountriesService/mp-rest/url=https://restcountries.eu/rest
+quarkus.rest-client."org.acme.rest.client.CountriesService".url=https://restcountries.com/

--- a/rest-client-quickstart/src/test/java/org/acme/rest/client/resources/WireMockCountriesResource.java
+++ b/rest-client-quickstart/src/test/java/org/acme/rest/client/resources/WireMockCountriesResource.java
@@ -33,7 +33,7 @@ public class WireMockCountriesResource implements QuarkusTestResourceLifecycleMa
         wireMockServer = new WireMockServer(WIREMOCK_PORT);
         wireMockServer.start();
         stubCountries();
-        return Collections.singletonMap("org.acme.rest.client.CountriesService/mp-rest/url",
+        return Collections.singletonMap("quarkus.rest-client.\"org.acme.rest.client.CountriesService\".url",
                 wireMockServer.baseUrl() + BASE_PATH);
     }
 

--- a/rest-client-reactive-quickstart/src/main/resources/application.properties
+++ b/rest-client-reactive-quickstart/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 quarkus.tls.trust-all=true
-country-api/mp-rest/url=https://restcountries.eu/rest
+quarkus.rest-client.country-api.url=https://restcountries.com

--- a/rest-client-reactive-quickstart/src/test/java/org/acme/rest/client/resources/WireMockCountriesResource.java
+++ b/rest-client-reactive-quickstart/src/test/java/org/acme/rest/client/resources/WireMockCountriesResource.java
@@ -33,7 +33,7 @@ public class WireMockCountriesResource implements QuarkusTestResourceLifecycleMa
         wireMockServer = new WireMockServer(WIREMOCK_PORT);
         wireMockServer.start();
         stubCountries();
-        return Collections.singletonMap("org.acme.rest.client.CountriesService/mp-rest/url",
+        return Collections.singletonMap("quarkus.rest-client.country-api.url",
                 wireMockServer.baseUrl() + BASE_PATH);
     }
 


### PR DESCRIPTION
… service URL to restcountries.com

* The property notation ("quarkus.rest-client.ClassName.url=...") has already been merged in quarkus main: https://github.com/quarkusio/quarkus/pull/17220

* The REST service restcountries.eu no longer exists, has been acquired. Use restcountries.com as a replacement?

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


