### PR TITLE
Explicit generics in Multi.createFrom().resource

### DIFF
--- a/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
+++ b/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.reactive.RxResult;
+import org.neo4j.driver.reactive.RxSession;
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -25,7 +26,7 @@ public class ReactiveFruitResource {
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public Publisher<String> get() {
-        return Multi.createFrom().resource(
+        return Multi.createFrom().<RxSession, String>resource(
                 driver::rxSession,
                 session -> session.readTransaction(tx -> {
                     RxResult result = tx.run("MATCH (f:Fruit) RETURN f.name as name ORDER BY f.name");


### PR DESCRIPTION
Explicitly indicate the generic type, even if the compiler should be able to infer them. 
Without, a compilation issue is reported in VSCode.

Fix https://github.com/quarkusio/quarkus/issues/20650