### PR TITLE
Upgrade MongoDB Panache Entity Annotation

### DIFF
--- a/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/entity/Person.java
+++ b/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/entity/Person.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
-import io.quarkus.mongodb.panache.MongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
 import io.quarkus.mongodb.panache.PanacheMongoEntity;
 
 @MongoEntity(collection = "ThePerson")

--- a/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/repository/Person.java
+++ b/mongodb-panache-quickstart/src/main/java/org/acme/mongodb/panache/repository/Person.java
@@ -1,12 +1,10 @@
 package org.acme.mongodb.panache.repository;
 
-import io.quarkus.mongodb.panache.MongoEntity;
-import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @MongoEntity(collection = "ThePerson")
 public class Person {


### PR DESCRIPTION
In the Quickstart, the MongoEntity annotation is the deprecated one.
Moving to the up-to-date one.

**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


