### PR TITLE
Simplify configuration allowed by the build time wiring of reactive messaging

### DIFF
--- a/amqp-quickstart/amqp-quickstart-processor/src/main/resources/application.properties
+++ b/amqp-quickstart/amqp-quickstart-processor/src/main/resources/application.properties
@@ -1,6 +1,2 @@
-# Configure the incoming AMQP queue `quote-requests`
-mp.messaging.incoming.requests.connector=smallrye-amqp
+# Set the AMQP address for the `requests` channel, as it's not the channel name
 mp.messaging.incoming.requests.address=quote-requests
-
-# Configure the outgoing AMQP queue `quotes`
-mp.messaging.outgoing.quotes.connector=smallrye-amqp

--- a/amqp-quickstart/amqp-quickstart-processor/src/test/java/org/acme/amqp/processor/QuoteProcessorTest.java
+++ b/amqp-quickstart/amqp-quickstart-processor/src/test/java/org/acme/amqp/processor/QuoteProcessorTest.java
@@ -1,0 +1,50 @@
+package org.acme.amqp.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.vertx.amqp.AmqpClientOptions;
+import io.vertx.mutiny.amqp.AmqpClient;
+import io.vertx.mutiny.amqp.AmqpConnection;
+import io.vertx.mutiny.amqp.AmqpMessage;
+import io.vertx.mutiny.amqp.AmqpReceiver;
+import io.vertx.mutiny.amqp.AmqpSender;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class QuoteProcessorTest {
+
+    @ConfigProperty(name = "amqp-host") String host;
+    @ConfigProperty(name = "amqp-port") int port;
+    private AmqpClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = AmqpClient.create(new AmqpClientOptions().setHost(host).setPort(port));
+    }
+
+    @AfterEach
+    void tearDown() {
+        client.closeAndAwait();
+    }
+
+    @Test
+    void testProcessor() {
+        AmqpConnection connection = client.connectAndAwait();
+        AmqpReceiver quotes = connection.createReceiverAndAwait("quotes");
+        AssertSubscriber<AmqpMessage> subscriber = quotes.toMulti().subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        AmqpSender sender = connection.createSenderAndAwait("quote-requests");
+        UUID quoteId = UUID.randomUUID();
+        sender.sendWithAckAndAwait(AmqpMessage.create().address("quote-requests").withBody(quoteId.toString()).build());
+        subscriber.awaitItems(1);
+        AmqpMessage received = subscriber.getItems().get(0);
+        assertEquals(received.bodyAsJsonObject().getString("id"), quoteId.toString());
+    }
+}

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -46,6 +46,11 @@
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/amqp-quickstart/amqp-quickstart-producer/src/main/resources/application.properties
+++ b/amqp-quickstart/amqp-quickstart-producer/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-# Configure the outgoing `quote-requests` queue
-mp.messaging.outgoing.quote-requests.connector=smallrye-amqp
-
-# Configure the incoming `quotes` queue
-mp.messaging.incoming.quotes.connector=smallrye-amqp

--- a/amqp-quickstart/amqp-quickstart-producer/src/test/java/org/acme/amqp/producer/QuotesResourceIT.java
+++ b/amqp-quickstart/amqp-quickstart-producer/src/test/java/org/acme/amqp/producer/QuotesResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.amqp.producer;
+
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class QuotesResourceIT extends QuotesResourceTest {
+
+}

--- a/amqp-quickstart/amqp-quickstart-producer/src/test/java/org/acme/amqp/producer/QuotesResourceTest.java
+++ b/amqp-quickstart/amqp-quickstart-producer/src/test/java/org/acme/amqp/producer/QuotesResourceTest.java
@@ -1,0 +1,26 @@
+package org.acme.amqp.producer;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class QuotesResourceTest {
+
+    @Test
+    void testQuotesEventStream() {
+        String body = given()
+                .when()
+                .post("/quotes/request")
+                .then()
+                .statusCode(200)
+                .extract().body()
+                .asString();
+        assertDoesNotThrow(() -> UUID.fromString(body));
+    }
+}

--- a/kafka-avro-schema-quickstart/src/main/resources/application.properties
+++ b/kafka-avro-schema-quickstart/src/main/resources/application.properties
@@ -1,21 +1,8 @@
-# set the connector for the outgoing channel to `smallrye-kafka`
-mp.messaging.outgoing.movies.connector=smallrye-kafka
-
-# set the topic name for the channel to `movies`
-mp.messaging.outgoing.movies.topic=movies
-
 # automatically register the schema with the registry, if not present
-mp.messaging.outgoing.movies.apicurio.registry.auto-register=true
+kafka.apicurio.registry.auto-register=true
+kafka.auto.offset.reset=earliest
 
-# set the connector for the incoming channel to `smallrye-kafka`
-mp.messaging.incoming.movies-from-kafka.connector=smallrye-kafka
-
-# set the topic name for the channel to `movies`
+# set the topic name for the incoming channel to `movies`, as it's not the channel name
 mp.messaging.incoming.movies-from-kafka.topic=movies
 
-# disable auto-commit, Reactive Messaging handles it itself
-mp.messaging.incoming.movies-from-kafka.enable.auto.commit=false
-
-mp.messaging.incoming.movies-from-kafka.auto.offset.reset=earliest
-
-%prod.mp.messaging.connector.smallrye-kafka.apicurio.registry.url=http://localhost:8081/apis/registry/v2
+%prod.kafka.apicurio.registry.url=http://localhost:8081/apis/registry/v2

--- a/kafka-panache-quickstart/src/main/resources/application.properties
+++ b/kafka-panache-quickstart/src/main/resources/application.properties
@@ -1,12 +1,8 @@
 # Configure the Kafka sink (we write to it)
-mp.messaging.outgoing.generated-price.connector=smallrye-kafka
 mp.messaging.outgoing.generated-price.topic=prices
 mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
 
 # Configure the Kafka source (we read from it)
-mp.messaging.incoming.prices.connector=smallrye-kafka
-mp.messaging.incoming.prices.topic=prices
-mp.messaging.incoming.prices.health-readiness-enabled=false
 mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
 
 %prod.quarkus.datasource.db-kind=postgresql

--- a/kafka-panache-reactive-quickstart/src/main/resources/application.properties
+++ b/kafka-panache-reactive-quickstart/src/main/resources/application.properties
@@ -1,13 +1,6 @@
-# Configure the Kafka sink (we write to it)
-mp.messaging.outgoing.generated-price.connector=smallrye-kafka
+# We must set the topic we wrtie to, as it's not the channel name.
 mp.messaging.outgoing.generated-price.topic=prices
-mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
 
-# Configure the Kafka source (we read from it)
-mp.messaging.incoming.prices.connector=smallrye-kafka
-mp.messaging.incoming.prices.topic=prices
-mp.messaging.incoming.prices.health-readiness-enabled=false
-mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
 
 %prod.quarkus.datasource.db-kind=postgresql
 %prod.quarkus.datasource.username=quarkus_test

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -39,11 +39,6 @@
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kafka-quickstart/processor/src/main/resources/application.properties
+++ b/kafka-quickstart/processor/src/main/resources/application.properties
@@ -1,10 +1,11 @@
 %dev.quarkus.http.port=8081
 
-# Configure the incoming `quote-requests` Kafka topic
-mp.messaging.incoming.requests.connector=smallrye-kafka
+# Go bad to the first records, if it's out first access
+kafka.auto.offset.reset=earliest
+
+# Set the Kafka topic, as it's not the channel name
 mp.messaging.incoming.requests.topic=quote-requests
-mp.messaging.incoming.requests.auto.offset.reset=earliest
+
 
 # Configure the outgoing `quotes` Kafka topic
-mp.messaging.outgoing.quotes.connector=smallrye-kafka
 mp.messaging.outgoing.quotes.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer

--- a/kafka-quickstart/producer/src/main/resources/application.properties
+++ b/kafka-quickstart/producer/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-# Configure the outgoing `quote-requests` Kafka topic
-mp.messaging.outgoing.quote-requests.connector=smallrye-kafka
-
-# Configure the incoming `quotes` Kafka topic
-mp.messaging.incoming.quotes.connector=smallrye-kafka

--- a/kafka-quickstart/producer/src/test/java/org/acme/kafka/producer/QuotesResourceIT.java
+++ b/kafka-quickstart/producer/src/test/java/org/acme/kafka/producer/QuotesResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.kafka.producer;
+
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class QuotesResourceIT extends QuotesResourceTest {
+
+}


### PR DESCRIPTION
Requires https://github.com/quarkusio/quarkus/pull/20561.


**Checklist**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [X] makes sure the associated guide must not be updated
- [X] links the guide update pull request (if needed)
- [X] updates or creates the `README.md` file (with build and run instructions)
- [X] for new quickstart, is located in the directory _component-quickstart_
- [X] for new quickstart, is added to the root `pom.xml` and `README.md`


