### PR TITLE
Update OIDC web-app quickstart to test the realm file loaded from the file system

### DIFF
--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -78,9 +78,7 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
-            </resource>
-            <resource>
-                <directory>config</directory>
+                <filtering>true</filtering>
             </resource>
         </resources>
         <plugins>
@@ -91,7 +89,6 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
-                        <keycloak.version>${keycloak.version}</keycloak.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 %prod.quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus
-quarkus.keycloak.devservices.realm-path=quarkus-realm.json
+quarkus.keycloak.devservices.realm-path=${basedir}/config/quarkus-realm.json
 quarkus.oidc.client-id=frontend
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app


### PR DESCRIPTION
Related to #21975.

The test uses Dev Services for Keycloak and now the realm file is loaded from the file system.

`security-openid-connect-quickstart` and `security-keycloak-authorization-quickstart` will continue testing with realm file loaded from the classpath