### PR TITLE
Workaround for failing KafkaClientTest

### DIFF
--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -47,6 +47,12 @@
       <artifactId>quarkus-kafka-client</artifactId>
     </dependency>
     <dependency>
+      <!-- Workaround for https://github.com/quarkusio/quarkus/issues/22000 TODO: should be removed, when quarkus team will fix the issue -->
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>2.8.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-mutiny-vertx-kafka-client</artifactId>
       <exclusions>


### PR DESCRIPTION
This PR fixes a problem with KafkaClientTest failing due to https://github.com/quarkusio/quarkus/issues/22000

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


