### PR TITLE
Fix rest-client-reactive-quickstart by encoding id properly

### DIFF
--- a/rest-client-reactive-quickstart/src/test/java/org/acme/rest/client/resources/WireMockExtensions.java
+++ b/rest-client-reactive-quickstart/src/test/java/org/acme/rest/client/resources/WireMockExtensions.java
@@ -58,7 +58,7 @@ public class WireMockExtensions implements QuarkusTestResourceLifecycleManager {
                 for (JsonValue extension : parser.getArray()) {
                     String id = extension.asJsonObject().getString("id");
 
-                    wireMockServer.stubFor(get(urlEqualTo(BASE_PATH + "/extensions?id=" + id))
+                    wireMockServer.stubFor(get(urlEqualTo(BASE_PATH + "/extensions?id=" + URLEncoder.encode(id, "UTF-8")))
                             .willReturn(okJson("[" + extension + "]")));
                 }
             }


### PR DESCRIPTION
Same as what was already done for the non-reactive REST Client quickstart.

