### PR TITLE
Update the security-jpa quickstart to use Dev Services for Postgresql

### DIFF
--- a/security-jpa-quickstart/README.md
+++ b/security-jpa-quickstart/README.md
@@ -16,6 +16,8 @@ The database can be started using:
 
 Once the database is up you can start your Quarkus application.
 
+Note you do not need to start the database when running your application in dev mode or testing. It will be started automatically as a Dev Service.
+
 ## Start the application
 
 The application can be started using: 
@@ -47,7 +49,8 @@ _NOTE:_ Stop the database using: `docker-compose down; docker-compose rm`
 
 ### Integration testing
 
-We have provided integration tests based on [TestContainers](https://www.testcontainers.org) to verify the security configuration in a JVM and native  mode.
+We have provided integration tests based on [Dev Services for PostgreSQL](https://quarkus.io/guides/dev-services#databases) to verify the security configuration in JVM and native modes. The test and dev modes containers will be launched automatically because all the PostgreSQL configuration properties are only enabled in production (`prod`) mode.
+
 
 The test can be executed using: 
 
@@ -57,7 +60,7 @@ mvn test
 
 # Native mode
 mvn verify -Pnative
-```  
+```
 
 ## Running in native
 

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -54,16 +54,6 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/security-jpa-quickstart/src/main/resources/application.properties
+++ b/security-jpa-quickstart/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=quarkus
-quarkus.datasource.password=quarkus
-quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_jpa
+%prod.quarkus.datasource.db-kind=postgresql
+%prod.quarkus.datasource.username=quarkus
+%prod.quarkus.datasource.password=quarkus
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_jpa
 
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/security-jpa-quickstart/src/test/java/org/acme/elytron/security/jpa/JpaSecurityRealmTest.java
+++ b/security-jpa-quickstart/src/test/java/org/acme/elytron/security/jpa/JpaSecurityRealmTest.java
@@ -9,32 +9,12 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 
 import io.quarkus.test.junit.QuarkusTest;
 
-@Testcontainers
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class JpaSecurityRealmTest {
-
-    @Container
-    public static final PostgreSQLContainer DATABASE = new PostgreSQLContainer<>()
-            .withDatabaseName("elytron_security_jpa")
-            .withUsername("quarkus")
-            .withPassword("quarkus")
-            .withExposedPorts(5432)
-            .withCreateContainerCmdModifier(cmd ->
-                    cmd
-                            .withHostName("localhost")
-                            .withPortBindings(new PortBinding(Ports.Binding.bindPort(5432), new ExposedPort(5432)))
-            );
 
     @Test
     @Order(1)


### PR DESCRIPTION
I'm looking at the `security-jpa` quickstart as the source for a `Getting Started with Quarkus Security` document, https://github.com/quarkusio/quarkus/issues/20627, where I'd like to show how easily one can secure Quarkus with something close to reality (Basic Auth, DB) (as opposed to Hello World Basic Auth), so `Security JPA` fits perfectly - however manually coding starting the container is not ideal for a quickstart.

So this PR switches the tests to `DevServices for Postgress`. Next I'll work on refocusing `security-jpa.adoc` to be a main entry to Quarkus Security for new Quarkus users (I'll include the info how to start the container without Dev Services as well).   