### PR TITLE
Use quay.io/bitnami/postgresql to lower pressure on DockerHub limits

### DIFF
--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -115,7 +115,7 @@
                     <skip>${skipTests}</skip>
                     <images>
                         <image>
-                            <name>postgres:13.3</name>
+                            <name>quay.io/bitnami/postgresql:13.5.0</name>
                             <alias>quarkus_test</alias>
                             <run>
                                 <env>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -104,7 +104,7 @@
                     <images>
                         <!-- Automatically start PostgreSQL for integration testing - requires Docker -->
                         <image>
-                            <name>postgres:13.3</name>
+                            <name>quay.io/bitnami/postgresql:13.5.0</name>
                             <alias>postgresql</alias>
                             <run>
                                 <env>


### PR DESCRIPTION
Use quay.io/bitnami/postgresql to lower pressure on DockerHub limits

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
