### PR TITLE
Fix OIDC web-app quickstart test

### DIFF
--- a/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
+++ b/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
@@ -66,8 +66,6 @@ public class CodeFlowTest {
 
             assertNull(sessionCookie);
 
-            page = webClient.getPage("http://localhost:8081/index.html");
-
             assertEquals("Sign in to quarkus", page.getTitleText());
         }
     }


### PR DESCRIPTION
`CodeFlowTest#testTokenTimeoutLogout` has started failing after a stricter code check was introduced - only if the state cookie exists - the code can only be retrurned from Keycloak as part of the code flow redirect and it is the only time the state cookie can exist.

In this test, what happens, is that 1) the user is authenticated 2) the call to Quarkus is made again after a 5 sec timeout - and checks the session has been cleared out due to the session expiry 3) then calls Quarkus again - but the problem here is that the current redirect from Quarkus to OIDC has not completed yet (i.e the same action of the user signing in again was not tested) and therefore this repeated call retains the state cookie but no any data from Keycloak exist which can be observed on the log:

```
2022-02-07 16:57:51,401 DEBUG [io.qua.oid.run.CodeAuthenticationMechanism] (vert.x-eventloop-thread-10) State parameter can not be empty or multi-valued
2022-02-07 16:57:51,403 INFO  [com.gar.htm.WebClient] (main) statusCode=[401] contentType=[]
```

This is the check which is done to verify that the state cookie matches the `state` value returned from KC which, as explained, is not provided, hence 401, so I fixed it by removing the now duplicate Quarkus call.

The reason it worked before is that Quarkus would redirect to Keycloak straight away if no `code` was found, did not check if the state cookie was already there.

CC @pedroigor 