### PR TITLE
[DO NOT MERGE] getting-started - Change native image tests to use `@QuarkusIntegrationTest`

### DIFF
--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/src/test/java/org/acme/getting/started/GreetingResourceIT.java
+++ b/getting-started/src/test/java/org/acme/getting/started/GreetingResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme.getting.started;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class GreetingResourceIT extends GreetingResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/getting-started/src/test/java/org/acme/getting/started/NativeGreetingResourceIT.java
+++ b/getting-started/src/test/java/org/acme/getting/started/NativeGreetingResourceIT.java
@@ -1,9 +1,0 @@
-package org.acme.getting.started;
-
-import io.quarkus.test.junit.NativeImageTest;
-
-@NativeImageTest
-public class NativeGreetingResourceIT extends GreetingResourceTest {
-
-    // Execute the same tests but in native mode.
-}

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.6.1.Final</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <quarkus-artemis.version>1.0.3</quarkus-artemis.version>
+        <quarkus-artemis.version>1.0.4</quarkus-artemis.version>
 
         <!-- Tests are unstable -->
         <skipTests>true</skipTests>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -17,7 +17,6 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -70,18 +69,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>strimzi-test-container</artifactId>
-            <version>${strimzi-test-container.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-        <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-        <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-        <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-    <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+    <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-    <optaplanner-quarkus.version>8.15.0.Final</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>8.16.1.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.15.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.15.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
+++ b/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
@@ -66,8 +66,6 @@ public class CodeFlowTest {
 
             assertNull(sessionCookie);
 
-            page = webClient.getPage("http://localhost:8081/index.html");
-
             assertEquals("Sign in to quarkus", page.getTitleText());
         }
     }

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.3.1.Final</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
This requires quarkusio/quarkus#23488 to be merged.

That PR changes the way code is generated. The native test using `@NativeImageTest` is changed to use `@QuarkusintegrationTest` instead.

**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [X] has native tests (`mvn clean verify -Pnative`)
- [X] makes sure the associated guide must not be updated
- [X] links the guide update pull request (if needed)
- [X] updates or creates the `README.md` file (with build and run instructions)


