### PR TITLE
Fix for localstack container not starting on fips machines

### DIFF
--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testcontainers.version>1.15.2</testcontainers.version>
+        <testcontainers.version>1.16.3</testcontainers.version>
         <awssdk.testcontainers.version>1.11.916</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
+++ b/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
@@ -1,12 +1,12 @@
 package org.acme.sqs;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -25,13 +25,13 @@ public class SqsResource implements QuarkusTestResourceLifecycleManager {
         DockerClientFactory.instance().client();
         String queueUrl;
         try {
-            services = new LocalStackContainer("0.11.1").withServices(Service.SQS);
+            services = new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.14.0")).withServices(Service.SQS);
             services.start();
             StaticCredentialsProvider staticCredentials = StaticCredentialsProvider
                 .create(AwsBasicCredentials.create("accesskey", "secretKey"));
 
             client = SqsClient.builder()
-                .endpointOverride(new URI(endpoint()))
+                .endpointOverride(services.getEndpointOverride(Service.SQS))
                 .credentialsProvider(staticCredentials)
                 .httpClientBuilder(UrlConnectionHttpClient.builder())
                 .region(Region.US_EAST_1).build();
@@ -43,7 +43,7 @@ public class SqsResource implements QuarkusTestResourceLifecycleManager {
         }
 
         Map<String, String> properties = new HashMap<>();
-        properties.put("quarkus.sqs.endpoint-override", endpoint());
+        properties.put("quarkus.sqs.endpoint-override", services.getEndpointOverride(Service.SQS).toString());
         properties.put("quarkus.sqs.aws.region", "us-east-1");
         properties.put("quarkus.sqs.aws.credentials.type", "static");
         properties.put("quarkus.sqs.aws.credentials.static-provider.access-key-id", "accessKey");
@@ -58,9 +58,5 @@ public class SqsResource implements QuarkusTestResourceLifecycleManager {
         if (services != null) {
             services.close();
         }
-    }
-
-    private String endpoint() {
-        return String.format("http://%s:%s", services.getContainerIpAddress(), services.getMappedPort(Service.SQS.getPort()));
     }
 }


### PR DESCRIPTION
**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


Fixed https://github.com/quarkusio/quarkus-quickstarts/issues/1056