### PR TITLE
Remove unused imports

### DIFF
--- a/mongodb-panache-quickstart/src/test/java/org/acme/mongodb/panache/PersonResourceTest.java
+++ b/mongodb-panache-quickstart/src/test/java/org/acme/mongodb/panache/PersonResourceTest.java
@@ -4,13 +4,9 @@ import static io.restassured.config.LogConfig.logConfig;
 
 import java.time.LocalDate;
 
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import io.quarkus.mongodb.panache.jackson.ObjectIdDeserializer;
-import io.quarkus.mongodb.panache.jackson.ObjectIdSerializer;
 import org.acme.mongodb.panache.repository.Person;
 import org.acme.mongodb.panache.repository.Status;
 import org.assertj.core.api.Assertions;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Remove unused imports

Without removal of io.quarkus.mongodb.panache.jackson.ObjectIdDeserializer / ObjectIdSerializer one gets `Error: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile (default-testCompile) on project mongodb-panache-quickstart: Compilation failure: Compilation failure` with the latest Quarkus main

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus