### PR TITLE
Parametrize kogito groupId

### DIFF
--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -17,7 +17,9 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
+        <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
+        <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
+        <kogito.platform.version>1.16.1.Final</kogito.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>
@@ -29,11 +31,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Ideally, it should import the quarkus-universe-bom instead, so it doesn't have to import this kogito-bom -->
+            <!-- Ideally, groupID should be the same as quarkus-bom -->
             <dependency>
-                <groupId>org.kie.kogito</groupId>
-                <artifactId>kogito-quarkus-bom</artifactId>
-                <version>${kogito-quarkus.version}</version>
+                <groupId>${kogito.platform.group-id}</groupId>
+                <artifactId>${kogito.platform.artifact-id}</artifactId>
+                <version>${kogito.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -17,7 +17,9 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
+        <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
+        <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
+        <kogito.platform.version>1.16.1.Final</kogito.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>
@@ -29,11 +31,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Ideally, it should import the quarkus-universe-bom instead, so it doesn't have to import this kogito-bom -->
+            <!-- Ideally, groupID should be the same as quarkus-bom -->
             <dependency>
-                <groupId>org.kie.kogito</groupId>
-                <artifactId>kogito-quarkus-bom</artifactId>
-                <version>${kogito-quarkus.version}</version>
+                <groupId>${kogito.platform.group-id}</groupId>
+                <artifactId>${kogito.platform.artifact-id}</artifactId>
+                <version>${kogito.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -12,7 +12,9 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
+        <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
+        <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
+        <kogito.platform.version>1.16.1.Final</kogito.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -25,11 +27,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Ideally, it should import the quarkus-universe-bom instead, so it doesn't have to import this kogito-bom -->
+            <!-- Ideally, groupID should be the same as quarkus-bom -->
             <dependency>
-                <groupId>org.kie.kogito</groupId>
-                <artifactId>kogito-quarkus-bom</artifactId>
-                <version>${kogito-quarkus.version}</version>
+                <groupId>${kogito.platform.group-id}</groupId>
+                <artifactId>${kogito.platform.artifact-id}</artifactId>
+                <version>${kogito.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -12,7 +12,9 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
+    <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
+    <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
+    <kogito.platform.version>1.16.1.Final</kogito.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -25,11 +27,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- Ideally, it should import the quarkus-universe-bom instead, so it doesn't have to import this kogito-bom -->
+      <!-- Ideally, groupID should be the same as quarkus-bom -->
       <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-quarkus-bom</artifactId>
-        <version>${kogito-quarkus.version}</version>
+        <groupId>${kogito.platform.group-id}</groupId>
+        <artifactId>${kogito.platform.artifact-id}</artifactId>
+        <version>${kogito.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Parametrize kogito groupId will allow the developers to replace the provided value with a custom one through a system property. 

For example: 

`mvn clean test -Dkogito.platform.group-id=io.quarkus.platform -Dkogito-quarkus.version=2.7.2.Final -Dquarkus.kogito.artifact-id=quarkus-kogito-bom`

**Check list**:

Your pull request:

- [X ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


