### PR TITLE
"quarkus-maven-plugin" in RabbitMQ modules groupId parametrization

### DIFF
--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -51,7 +51,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -55,7 +55,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>


### PR DESCRIPTION
`quarkus-maven-plugin` in RabbitMQ modules have a hardcoded groupId. This PR, parametrize this variable. 

**Check list**:

Your pull request:

- [X] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


