### PR TITLE
Migrate the context propagation quickstart to RESTEasy Reactive

### DIFF
--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -34,11 +34,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -47,10 +43,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/context-propagation-quickstart/src/main/java/org/acme/context/EmitterResource.java
+++ b/context-propagation-quickstart/src/main/java/org/acme/context/EmitterResource.java
@@ -9,8 +9,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.jboss.resteasy.annotations.SseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -26,11 +27,14 @@ public class EmitterResource {
     @GET
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @SseElementType(MediaType.TEXT_PLAIN)
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
     public Publisher<Double> prices() {
         // get the next three prices from the price stream
         return Multi.createFrom().publisher(prices)
                 .select().first(3)
+                // The items are received from the event loop, so cannot use Hibernate ORM (classic)
+                // Switch to a worker thread, the transaction will be propagated
+                .emitOn(Infrastructure.getDefaultExecutor())
                 .map(price -> {
                     // store each price before we send them
                     Price priceEntity = new Price();

--- a/context-propagation-quickstart/src/main/java/org/acme/context/PriceResource.java
+++ b/context-propagation-quickstart/src/main/java/org/acme/context/PriceResource.java
@@ -1,20 +1,27 @@
 package org.acme.context;
 
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+
 import javax.inject.Inject;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
-
 @Path("/")
 public class PriceResource {
 
-    @Inject @Channel("prices") Emitter<Double> emitter;
+    @Inject @Channel("prices")
+    MutinyEmitter<Double> emitter;
 
     @POST
-    public void postAPrice(Price price) {
-        emitter.send(price.value);
+    public Uni<Void> postAPrice(Price price) {
+        if (emitter.hasRequests()) {
+            return emitter.send(price.value);
+        } else {
+            return Uni.createFrom().nullItem();
+        }
     }
 
 }


### PR DESCRIPTION
@gsmet FYI, this is what is required to migrate the context propagation QS to resteasy reactive.

Here ate the changes:

1. the `pom.xml` - nothing surprising
2. the emitter part is more an improvement (not required, but better - more idiomatic)
3. the SSE part is where the main change is. We have to use `.emitOn` as it is called on the IO thread that you are not allowed to block. Thanks to CP, you can use `.emitOn` and the transaction will be propagated.