### PR TITLE
Update security-openid-connect-multi-tenancy-quickstart to use Keycloak 17.0.0-legacy image

### DIFF
--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <keycloak.version>13.0.0</keycloak.version>
+        <keycloak.version>17.0.0-legacy</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
Fixes #1081.

WildFly based distro needs to be used for now because we can't test it with Dev Services for Keycloak because it won't work with multiple tenants, while Quarkus based distro does not support importing the realms from the file/class path - realms have to be read and uploaded using KC AdminClient API (which is what Dev Services for Keycloak does) but it would be too complex for a test setup for the new users to see