### PR TITLE
Workaround for failures, when running with podman

### DIFF
--- a/security-keycloak-authorization-quickstart/src/test/java/org/acme/security/keycloak/authorization/KeycloakServer.java
+++ b/security-keycloak-authorization-quickstart/src/test/java/org/acme/security/keycloak/authorization/KeycloakServer.java
@@ -4,16 +4,19 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.util.Collections;
 import java.util.Map;
 
 public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
+
     private GenericContainer keycloak;
 
     @Override
     public Map<String, String> start() {
+
         keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:" + System.getProperty("keycloak.version"))
                 .withFixedExposedPort(8543, 8443)
                 .withExposedPorts(8080)
@@ -21,8 +24,9 @@ public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
                 .withEnv("KEYCLOAK_IMPORT", "/tmp/realm.json")
-                .withClasspathResourceMapping("quarkus-realm.json", "/tmp/realm.json", BindMode.READ_ONLY)
+                .withClasspathResourceMapping("quarkus-realm.json", "/tmp/realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
                 .waitingFor(Wait.forHttp("/auth"));
+
         keycloak.start();
         return Collections.emptyMap();
     }

--- a/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
+++ b/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
@@ -4,6 +4,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.util.Collections;
@@ -21,8 +22,8 @@ public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
                 .withEnv("KEYCLOAK_IMPORT", "/tmp/default-tenant-realm.json,/tmp/tenant-a-realm.json")
-                .withClasspathResourceMapping("default-tenant-realm.json", "/tmp/default-tenant-realm.json", BindMode.READ_ONLY)
-                .withClasspathResourceMapping("tenant-a-realm.json", "/tmp/tenant-a-realm.json", BindMode.READ_ONLY)
+                .withClasspathResourceMapping("default-tenant-realm.json", "/tmp/default-tenant-realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
+                .withClasspathResourceMapping("tenant-a-realm.json", "/tmp/tenant-a-realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
                 .waitingFor(Wait.forHttp("/auth"));
         keycloak.start();
         return Collections.emptyMap();

--- a/security-openid-connect-quickstart/src/test/java/org/acme/security/openid/connect/KeycloakServer.java
+++ b/security-openid-connect-quickstart/src/test/java/org/acme/security/openid/connect/KeycloakServer.java
@@ -4,6 +4,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.util.Collections;
@@ -21,7 +22,7 @@ public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
                 .withEnv("KEYCLOAK_IMPORT", "/tmp/realm.json")
-                .withClasspathResourceMapping("quarkus-realm.json", "/tmp/realm.json", BindMode.READ_ONLY)
+                .withClasspathResourceMapping("quarkus-realm.json", "/tmp/realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
                 .waitingFor(Wait.forHttp("/auth"));
         keycloak.start();
 

--- a/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/KeycloakServer.java
+++ b/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/KeycloakServer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -23,7 +24,7 @@ public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
                 .withEnv("KEYCLOAK_IMPORT", "/tmp/realm.json")
-                .withClasspathResourceMapping("quarkus-realm.json", "/tmp/realm.json", BindMode.READ_ONLY)
+                .withClasspathResourceMapping("quarkus-realm.json", "/tmp/realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
                 .waitingFor(Wait.forHttp("/auth"));
         keycloak.start();
         return Collections.emptyMap();


### PR DESCRIPTION
Call to method `withClasspathResourceMapping` with RO and without
Selinux leads to files being copied *after* the start-up of contanier.


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)


