### PR TITLE
Workaround for failures, when running with podman

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -1,0 +1,6 @@
+---
+# The format of this file is documented here:
+# https://github.com/quarkusio/quarkus-bot#triage-issues
+features: [ANALYZE_WORKFLOW_RUN_RESULTS]
+workflowRunAnalysis:
+  workflows: ["Pull Request Build - development"]

--- a/.github/workflows/build-pr-development.yml
+++ b/.github/workflows/build-pr-development.yml
@@ -7,8 +7,29 @@ on:
       - "2.2"
 
 jobs:
+  # This is a hack to work around a GitHub API limitation:
+  # when the PR is coming from another fork, the pull_requests field of the
+  # workflow_run payload is empty.
+  # For more details, see
+  # https://github.community/t/pull-request-attribute-empty-in-workflow-run-event-object-for-pr-from-forked-repo/154682
+  attach-pr-number:
+    runs-on: ubuntu-latest
+    name: Attach pull request number
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Create file
+        shell: bash
+        run: |
+          echo -n ${{ github.event.number }} > pull-request-number
+      - name: Upload pull request number
+        uses: actions/upload-artifact@v2
+        with:
+          name: pull-request-number-${{ github.event.number }}
+          path: pull-request-number
+          retention-days: 1
   build:
-    runs-on: ubuntu-18.04
+    name: Build - JDK ${{ matrix.java }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -50,3 +71,13 @@ jobs:
       - name: Delete Local Artifacts From Cache
         shell: bash
         run: rm -rf ~/.m2/repository/org/acme
+      - name: Upload build reports (if build failed)
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: "build-reports-Build - JDK ${{ matrix.java }}"
+          path: |
+            **/target/*-reports/TEST-*.xml
+            target/build-report.json
+            LICENSE
+          retention-days: 2

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>2.7.4.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.5.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>2.7.3.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.4.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>2.7.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>2.7.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/cache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/cache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: cache-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/src/main/docker/Dockerfile.jvm
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/src/main/docker/Dockerfile.jvm
@@ -16,7 +16,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 
-ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.5
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
@@ -38,8 +38,11 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
-COPY target/lib/* /deployments/lib/
-COPY target/*-runner.jar /deployments/app.jar
+COPY target/quarkus-app/lib/ /deployments/lib/
+COPY target/quarkus-app/*.jar /deployments/
+COPY target/quarkus-app/app/ /deployments/app/
+COPY target/quarkus-app/quarkus/ /deployments/quarkus/
+
 
 EXPOSE 8080
 USER 1001

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.6.1.Final</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/google-cloud-functions-http-quickstart/src/main/resources/META-INF/resources/index.html
@@ -136,7 +136,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: google-cloud-functions-http</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <assertj.version>3.22.0</assertj.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-multi-tenancy-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>2.7.4.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.5.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>2.7.1.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>2.7.3.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.4.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>2.7.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>2.7.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.7.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/jta-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/jta-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: jta</li>
                 <li>Version: 1.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <strimzi-test-container.version>0.22.1</strimzi-test-container.version>
     </properties>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/kafka-panache-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: kafka-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-        <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-        <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-        <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+        <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-    <kogito-quarkus.version>1.15.0.Final</kogito-quarkus.version>
+    <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <kogito-quarkus.version>1.16.1.Final</kogito-quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/microprofile-health-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-health</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/microprofile-metrics-quickstart/pom.xml
+++ b/microprofile-metrics-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.22.0</assertj.version>

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-panache-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongodb-panache</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mongodb-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: mongo-client</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/mqtt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme.quarkus.sample</li>
                 <li>ArtifactId: mqtt-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/neo4j-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: neo4j-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/openapi-swaggerui-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-openapi-swaggerui</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentelemetry-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentelemetry</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/pom.xml
+++ b/opentracing-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/opentracing-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-opentracing</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.16.1.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.16.1.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
-    <optaplanner-quarkus.version>8.15.0.Final</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>8.16.1.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.15.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.16.1.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.15.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <optaplanner-quarkus.version>8.16.1.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,4 +106,14 @@
         <module>kafka-panache-reactive-quickstart</module>
         <module>jta-quickstart</module>
     </modules>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>io.quarkus.bot</groupId>
+                <artifactId>build-reporting-maven-extension</artifactId>
+                <version>1.0.5</version>
+            </extension>
+        </extensions>
+    </build>
 </project>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-http-quickstart/pom.xml
+++ b/reactive-messaging-http-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-messaging-websockets-quickstart/pom.xml
+++ b/reactive-messaging-websockets-quickstart/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-multipart-quickstart/pom.xml
+++ b/rest-client-multipart-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-client-reactive-quickstart/pom.xml
+++ b/rest-client-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,7 +10,7 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jdbc-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-elytron-security-jdbc</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jwt-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-jwt-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-oauth2-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-oauth2-rbac</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <keycloak.version>13.0.0</keycloak.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
+++ b/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
@@ -4,6 +4,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.util.Collections;
@@ -21,8 +22,8 @@ public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
                 .withEnv("KEYCLOAK_IMPORT", "/tmp/default-tenant-realm.json,/tmp/tenant-a-realm.json")
-                .withClasspathResourceMapping("default-tenant-realm.json", "/tmp/default-tenant-realm.json", BindMode.READ_ONLY)
-                .withClasspathResourceMapping("tenant-a-realm.json", "/tmp/tenant-a-realm.json", BindMode.READ_ONLY)
+                .withClasspathResourceMapping("default-tenant-realm.json", "/tmp/default-tenant-realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
+                .withClasspathResourceMapping("tenant-a-realm.json", "/tmp/tenant-a-realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
                 .waitingFor(Wait.forHttp("/auth"));
         keycloak.start();
         return Collections.emptyMap();

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.3.1.Final</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-boot-properties-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: spring-boot-properties-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.4.Final</li>
+                <li>Quarkus Version: 2.7.5.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 2.7.0.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.1.Final</li>
+                <li>Quarkus Version: 2.7.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.3.Final</li>
+                <li>Quarkus Version: 2.7.4.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.2.Final</li>
+                <li>Quarkus Version: 2.7.3.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/spring-security-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: secured-spring-web-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 2.7.0.Final</li>
+                <li>Quarkus Version: 2.7.1.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.7.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Call to method `withClasspathResourceMapping` with RO and without
Selinux leads to files being copied *after* the start-up of contanier.


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)


