### PR TITLE
Workaround for failures, when running with podman

### DIFF
--- a/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
+++ b/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
@@ -4,6 +4,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.util.Collections;
@@ -21,8 +22,8 @@ public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
                 .withEnv("KEYCLOAK_USER", "admin")
                 .withEnv("KEYCLOAK_PASSWORD", "admin")
                 .withEnv("KEYCLOAK_IMPORT", "/tmp/default-tenant-realm.json,/tmp/tenant-a-realm.json")
-                .withClasspathResourceMapping("default-tenant-realm.json", "/tmp/default-tenant-realm.json", BindMode.READ_ONLY)
-                .withClasspathResourceMapping("tenant-a-realm.json", "/tmp/tenant-a-realm.json", BindMode.READ_ONLY)
+                .withClasspathResourceMapping("default-tenant-realm.json", "/tmp/default-tenant-realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
+                .withClasspathResourceMapping("tenant-a-realm.json", "/tmp/tenant-a-realm.json", BindMode.READ_ONLY, SelinuxContext.SINGLE)
                 .waitingFor(Wait.forHttp("/auth"));
         keycloak.start();
         return Collections.emptyMap();


### PR DESCRIPTION
Call to method `withClasspathResourceMapping` with RO and without
Selinux leads to files being copied *after* the start-up of contanier.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated


