### PR TITLE
Documentation: Use reactive datasource url config property

### DIFF
--- a/hibernate-reactive-panache-quickstart/README.md
+++ b/hibernate-reactive-panache-quickstart/README.md
@@ -114,5 +114,5 @@ As well as running the DB on Kubernetes, a service needs to be exposed for the d
 Then, rebuild demo docker image with a system property that points to the DB. 
 
 ```bash
--Dquarkus.datasource.jdbc.url=jdbc:postgresql://<DB_SERVICE_NAME>/quarkus_test
+-Dquarkus.datasource.reactive.url=vertx-reactive:postgresql://<DB_SERVICE_NAME>/quarkus_test
 ```


### PR DESCRIPTION
hibernate-reactive-panache-quickstart is using dependencies quarkus-hibernate-reactive-panache and quarkus-reactive-pg-client (and no dependency suggest need for default [non-reactive] datasource), therefore connection string should be set by https://quarkus.io/guides/all-config#quarkus-reactive-datasource_quarkus.datasource.reactive.url instead of https://quarkus.io/guides/all-config#quarkus-agroal_quarkus.datasource.-datasource-name-.jdbc.url as described f.e. in https://quarkus.io/guides/hibernate-reactive-panache, I also replaced 'jdbc' with 'vertx-reactive'.