### PR TITLE
Set quarkus.test.native-image-profile to 'test' in the OidcClient quickstart

### DIFF
--- a/security-openid-connect-client-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-client-quickstart/src/main/resources/application.properties
@@ -11,6 +11,11 @@ quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 
-org.acme.security.openid.connect.client.ProtectedResourceOidcClientFilter/mp-rest/url=${test.url}/protected
-org.acme.security.openid.connect.client.ProtectedResourceTokenPropagationFilter/mp-rest/url=${test.url}/protected
+quarkus.test.native-image-profile=test
+
+%prod.port=8080
+%dev.port=8080
+%test.port=8081
+org.acme.security.openid.connect.client.ProtectedResourceOidcClientFilter/mp-rest/url=http://localhost:${port}/protected
+org.acme.security.openid.connect.client.ProtectedResourceTokenPropagationFilter/mp-rest/url=http://localhost:${port}/protected
 


### PR DESCRIPTION
I've verified this configuration works with tests (JVM, native), in devmode (and tested the token propagation by invoking the endpoint from DevServices for Keycloak console), when running in JVM and native modes (and starting Keycloak and using curl to test)