### PR TITLE
Add missing config files (including latest configuration, as per http…

### DIFF
--- a/opentelemetry-quickstart/docker-compose.yml
+++ b/opentelemetry-quickstart/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "2"
+services:
+
+  # Jaeger
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"
+      - "14268"
+      - "14250"
+  # Collector
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "13133:13133" # Health_check extension
+      - "4317:4317"   # OTLP gRPC receiver
+      - "55680:55680" # OTLP gRPC receiver alternative port
+    depends_on:
+      - jaeger-all-in-one

--- a/opentelemetry-quickstart/otel-collector-config.yaml
+++ b/opentelemetry-quickstart/otel-collector-config.yaml
@@ -11,7 +11,8 @@ receivers:
 exporters:
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:

--- a/opentelemetry-quickstart/otel-collector-config.yaml
+++ b/opentelemetry-quickstart/otel-collector-config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: otel-collector:4317
+  otlp/2:
+    protocols:
+      grpc:
+        endpoint: otel-collector:55680
+
+exporters:
+  jaeger:
+    endpoint: jaeger-all-in-one:14250
+    insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp,otlp/2]
+      processors: [batch]
+      exporters: [jaeger]
+

--- a/opentelemetry-quickstart/src/main/resources/application.properties
+++ b/opentelemetry-quickstart/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.opentelemetry.enabled=true
 quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
 
 quarkus.opentelemetry.tracer.exporter.otlp.headers=Authorization=Bearer my_secret
+quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
+

--- a/opentelemetry-quickstart/src/main/resources/application.properties
+++ b/opentelemetry-quickstart/src/main/resources/application.properties
@@ -1,7 +1,5 @@
 quarkus.application.name=myservice
-quarkus.opentelemetry.enabled=true
-quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
-
-quarkus.opentelemetry.tracer.exporter.otlp.headers=Authorization=Bearer my_secret
+quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.traces.headers=Authorization=Bearer my_secret
 quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
 

--- a/opentelemetry-quickstart/src/main/resources/application.properties
+++ b/opentelemetry-quickstart/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 quarkus.application.name=myservice
+quarkus.opentelemetry.enabled=true
+quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
+
+quarkus.opentelemetry.tracer.exporter.otlp.headers=Authorization=Bearer my_secret


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus-quickstarts/issues/1114

I haven't changed any function, only added the three main config files referenced in https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/opentelemetry.adoc into the quickstart source code so the out-of-the-box experience is better.

I've manually confirmed these steps work with the new source (and no manual extra file creation):

```
docker-compose up -d
quarkus dev
curl http://localhost:8080/hello
```

and that http://localhost:16686/ then shows the traces.


