### PR TITLE
Drop of quarkus-plugin.version leftovers

### DIFF
--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -8,7 +8,6 @@
     <artifactId>awt-graphics-rest-quickstart</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <quarkus-plugin.version>2.7.6.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.6.Final</quarkus.platform.version>
@@ -77,9 +76,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-plugin.version}</version>
+                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -8,7 +8,6 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>2.7.6.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.7.6.Final</quarkus.platform.version>


### PR DESCRIPTION
**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


