### PR TITLE
Fix PersonProcessTest#testChild

### DIFF
--- a/kogito-quickstart/src/test/java/org/acme/kogito/PersonProcessTest.java
+++ b/kogito-quickstart/src/test/java/org/acme/kogito/PersonProcessTest.java
@@ -48,7 +48,7 @@ public class PersonProcessTest {
                 .get("/persons/{uuid}/tasks?user=john", processId)
                 .then()
                 .statusCode(200)
-                .body("$.size", is(1))
+                .body("$.size()", is(1))
                 .extract().path("[0].id");
 
         given().contentType(ContentType.JSON).accept(ContentType.JSON)


### PR DESCRIPTION
14 days ago Daily run started failing over `PersonProcessTest#testChild` where response size is checked with JsonPath `size` property instead of same-named method. [RestAssured docs](https://github.com/rest-assured/rest-assured/wiki/Usage#root-path) also uses `size()` over `size`. This PR will fix main runs.

You can hardly reproduce it on `development` branch as [there is an issue](https://github.com/quarkusio/quarkus-quickstarts/issues/1126) with `kogito-quickstart`, however as mentioned by @rsvoboda if you first clone and build https://github.com/kiegroup/kogito-runtimes and run `mvn clean verify -f kogito-quickstart -Dkogito.platform.version=2.0.0-SNAPSHOT`, you can reproduce the issue.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


