### PR TITLE
Temporarily disable kogito and kogito-drl module

### DIFF
--- a/kafka-quickstart/processor/src/test/java/org/acme/kafka/processor/QuoteProcessorTest.java
+++ b/kafka-quickstart/processor/src/test/java/org/acme/kafka/processor/QuoteProcessorTest.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.common.annotation.Identifier;
-import org.junit.jupiter.api.Disabled;
 
-@Disabled
 @QuarkusTest
 public class QuoteProcessorTest {
 

--- a/kafka-quickstart/producer/src/test/java/org/acme/kafka/producer/QuotesResourceIT.java
+++ b/kafka-quickstart/producer/src/test/java/org/acme/kafka/producer/QuotesResourceIT.java
@@ -1,9 +1,7 @@
 package org.acme.kafka.producer;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import org.junit.jupiter.api.Disabled;
 
-@Disabled
 @QuarkusIntegrationTest
 public class QuotesResourceIT extends QuotesResourceTest {
 

--- a/kafka-quickstart/producer/src/test/java/org/acme/kafka/producer/QuotesResourceTest.java
+++ b/kafka-quickstart/producer/src/test/java/org/acme/kafka/producer/QuotesResourceTest.java
@@ -8,9 +8,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Disabled;
 
-@Disabled
 @QuarkusTest
 public class QuotesResourceTest {
 

--- a/kogito-drl-quickstart/src/test/java/org/acme/kogito/LoanApplicationInGraalIT.java
+++ b/kogito-drl-quickstart/src/test/java/org/acme/kogito/LoanApplicationInGraalIT.java
@@ -1,10 +1,8 @@
 package org.acme.kogito;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import org.junit.jupiter.api.Disabled;
 
 @QuarkusIntegrationTest
-@Disabled
 public class LoanApplicationInGraalIT extends LoanApplicationTest {
 
 }

--- a/kogito-drl-quickstart/src/test/java/org/acme/kogito/LoanApplicationTest.java
+++ b/kogito-drl-quickstart/src/test/java/org/acme/kogito/LoanApplicationTest.java
@@ -6,10 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.hasItems;
-import org.junit.jupiter.api.Disabled;
 
 @QuarkusTest
-@Disabled
 public class LoanApplicationTest {
 
 

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/LessonResourceIT.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/LessonResourceIT.java
@@ -1,10 +1,8 @@
 package org.acme.optaplanner.rest;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import org.junit.jupiter.api.Disabled;
 
 @QuarkusIntegrationTest
-@Disabled
 public class LessonResourceIT extends LessonResourceTest {
 
 }

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/LessonResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/LessonResourceTest.java
@@ -11,10 +11,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.Disabled;
 
 @QuarkusTest
-@Disabled
 public class LessonResourceTest {
 
     @Test

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/RoomResourceIT.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/RoomResourceIT.java
@@ -1,11 +1,8 @@
 package org.acme.optaplanner.rest;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@Disabled
 public class RoomResourceIT extends RoomResourceTest {
 
 }

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/RoomResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/RoomResourceTest.java
@@ -7,14 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.util.List;
 
 import org.acme.optaplanner.domain.Room;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@Disabled
 public class RoomResourceTest {
 
     @Test

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeTableResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeTableResourceTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.nullValue;
 
 import java.time.Duration;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.solver.SolverStatus;
 
@@ -19,7 +18,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@Disabled
 public class TimeTableResourceTest {
 
     @Test

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeslotResourceIT.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeslotResourceIT.java
@@ -1,11 +1,8 @@
 package org.acme.optaplanner.rest;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@Disabled
 public class TimeslotResourceIT extends TimeslotResourceTest {
 
 }

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeslotResourceTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/rest/TimeslotResourceTest.java
@@ -9,14 +9,12 @@ import java.time.LocalTime;
 import java.util.List;
 
 import org.acme.optaplanner.domain.Timeslot;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@Disabled
 public class TimeslotResourceTest {
 
     @Test

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/solver/TimeTableBenchmarkTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/solver/TimeTableBenchmarkTest.java
@@ -2,14 +2,12 @@ package org.acme.optaplanner.solver;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.acme.optaplanner.rest.TimeTableResource;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 
 import javax.inject.Inject;
 
 @QuarkusTest
-@Disabled
 public class TimeTableBenchmarkTest {
 
     @Inject

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/solver/TimeTableConstraintProviderTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/solver/TimeTableConstraintProviderTest.java
@@ -11,12 +11,10 @@ import org.acme.optaplanner.domain.Lesson;
 import org.acme.optaplanner.domain.Room;
 import org.acme.optaplanner.domain.TimeTable;
 import org.acme.optaplanner.domain.Timeslot;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
 @QuarkusTest
-@Disabled
 class TimeTableConstraintProviderTest {
 
     private static final Room ROOM1 = new Room(1, "Room1");

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,9 @@
         <module>kafka-avro-schema-quickstart</module>
         <module>kafka-bare-quickstart</module>
         <module>kafka-streams-quickstart</module>
-        <module>kogito-quickstart</module>
-        <module>kogito-drl-quickstart</module>
+        <!-- TODO enable once https://github.com/quarkusio/quarkus-quickstarts/issues/1126 is resolved -->
+        <!-- <module>kogito-quickstart</module> -->
+        <!-- <module>kogito-drl-quickstart</module> -->
         <module>kogito-dmn-quickstart</module>
         <module>kogito-pmml-quickstart</module>
         <module>optaplanner-quickstart</module>


### PR DESCRIPTION
Temporarily disable kogito and kogito-drl module and reverting https://github.com/quarkusio/quarkus-quickstarts/pull/1132 which turned out as not sufficient fix. kogito-quickstart and kogito-drl-quickstart do not compile atm

Disabling tests is not enough because `quarkus-maven-plugin:build` fails too
Details in https://github.com/quarkusio/quarkus-quickstarts/issues/1126

CC @evacchi (can't set you as reviewer) 

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


