### PR TITLE
Improve names for Rest Clients in security-openid-connect-client-quickstart

### DIFF
--- a/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/FrontendResource.java
+++ b/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/FrontendResource.java
@@ -13,37 +13,37 @@ import io.smallrye.mutiny.Uni;
 public class FrontendResource {
     @Inject
     @RestClient
-    ProtectedResourceOidcClientFilter protectedResourceOidcClientFilter;
+    RestClientWithOidcClientFilter restClientWithOidcClientFilter;
 
     @Inject
     @RestClient
-    ProtectedResourceTokenPropagationFilter protectedResourceTokenPropagationFilter;
+    RestClientWithTokenPropagationFilter restClientWithTokenPropagationFilter;
 
     @GET
     @Path("user-name-with-oidc-client-token")
     @Produces("text/plain")
     public Uni<String> getUserNameWithOidcClientToken() {
-        return protectedResourceOidcClientFilter.getUserName();
+        return restClientWithOidcClientFilter.getUserName();
     }
     
     @GET
     @Path("admin-name-with-oidc-client-token")
     @Produces("text/plain")
     public Uni<String> getAdminNameWithOidcClientToken() {
-	    return protectedResourceOidcClientFilter.getAdminName();
+	    return restClientWithOidcClientFilter.getAdminName();
     }
     
     @GET
     @Path("user-name-with-propagated-token")
     @Produces("text/plain")
     public Uni<String> getUserNameWithPropagatedToken() {
-        return protectedResourceTokenPropagationFilter.getUserName();
+        return restClientWithTokenPropagationFilter.getUserName();
     }
     
     @GET
     @Path("admin-name-with-propagated-token")
     @Produces("text/plain")
     public Uni<String> getAdminNameWithPropagatedToken() {
-        return protectedResourceTokenPropagationFilter.getAdminName();
+        return restClientWithTokenPropagationFilter.getAdminName();
     }
 }

--- a/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/RestClientWithOidcClientFilter.java
+++ b/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/RestClientWithOidcClientFilter.java
@@ -13,7 +13,7 @@ import io.smallrye.mutiny.Uni;
 @RegisterRestClient
 @RegisterProvider(OidcClientRequestReactiveFilter.class)
 @Path("/")
-public interface ProtectedResourceOidcClientFilter {
+public interface RestClientWithOidcClientFilter {
 
     @GET
     @Produces("text/plain")

--- a/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/RestClientWithTokenPropagationFilter.java
+++ b/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/RestClientWithTokenPropagationFilter.java
@@ -13,7 +13,7 @@ import io.smallrye.mutiny.Uni;
 @RegisterRestClient
 @RegisterProvider(AccessTokenRequestReactiveFilter.class)
 @Path("/")
-public interface ProtectedResourceTokenPropagationFilter {
+public interface RestClientWithTokenPropagationFilter {
 
     @GET
     @Produces("text/plain")

--- a/security-openid-connect-client-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-client-quickstart/src/main/resources/application.properties
@@ -16,6 +16,6 @@ quarkus.test.native-image-profile=test
 %prod.port=8080
 %dev.port=8080
 %test.port=8081
-org.acme.security.openid.connect.client.ProtectedResourceOidcClientFilter/mp-rest/url=http://localhost:${port}/protected
-org.acme.security.openid.connect.client.ProtectedResourceTokenPropagationFilter/mp-rest/url=http://localhost:${port}/protected
+org.acme.security.openid.connect.client.RestClientWithOidcClientFilter/mp-rest/url=http://localhost:${port}/protected
+org.acme.security.openid.connect.client.RestClientWithTokenPropagationFilter/mp-rest/url=http://localhost:${port}/protected
 


### PR DESCRIPTION
I and a collegue of mine found in unnecessarily hard to understand the security-openid-connect-client-quickstart.

This was caused by confusing class and field names.

### About the example

The `FrontendResource` uses two MP REST clients in order to access the `ProtectedResource`.
The  only relevant difference between the two REST clients is that they use different `ClientRequestFilter`s: one uses the _OpenID Connect Client Reactive Filter_ and the other uses the _OpenID Connect Token Propagation Reactive Filter_.

### What confused me

The two REST client interfaces used in `FrontendResource` are called `ProtectedResourceOidcClientFilter` and `ProtectedResourceTokenPropagationFilter`. 
In the context of an example on how to use two quarkus-supplied `ClientRequestFilter`s, these names cause confusion.
It requires mental mapping to understand that the two `*Filter` classes are not filters but REST clients (that use Filters).

### Suggestion

This PR renames the classes, giving them names that communicate the intent of the example more clearly.

### Follow-up

I will create a follow-up PR in the Quarkus repo to update the [guide](https://quarkus.io/guides/security-openid-connect-client) accordingly once this PR is merged.