### PR TITLE
Bump Kogito to 1.24.0.Final, enable kogito and kogito-drl module

### DIFF
--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
         <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-        <kogito.platform.version>1.19.0.Final</kogito.platform.version>
+        <kogito.platform.version>1.24.0.Final</kogito.platform.version>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
         <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-        <kogito.platform.version>1.19.0.Final</kogito.platform.version>
+        <kogito.platform.version>1.24.0.Final</kogito.platform.version>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
         <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-        <kogito.platform.version>1.19.0.Final</kogito.platform.version>
+        <kogito.platform.version>1.24.0.Final</kogito.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
     <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-    <kogito.platform.version>1.19.0.Final</kogito.platform.version>
+    <kogito.platform.version>1.24.0.Final</kogito.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,8 @@
         <module>kafka-avro-schema-quickstart</module>
         <module>kafka-bare-quickstart</module>
         <module>kafka-streams-quickstart</module>
-        <!-- TODO enable once https://github.com/quarkusio/quarkus-quickstarts/issues/1126 is resolved -->
-        <!-- <module>kogito-quickstart</module> -->
-        <!-- <module>kogito-drl-quickstart</module> -->
+        <module>kogito-quickstart</module>
+        <module>kogito-drl-quickstart</module>
         <module>kogito-dmn-quickstart</module>
         <module>kogito-pmml-quickstart</module>
         <module>optaplanner-quickstart</module>


### PR DESCRIPTION
Bump Kogito to 1.24.0.Final, enable kogito and kogito-drl module

Fixes https://github.com/quarkusio/quarkus-quickstarts/issues/1126

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


