### PR TITLE
multi-tenancy-quickstart - use Keycloak 18.0.2-legacy, property name adjustment, com.gargoylesoftware.htmlunit warnings suppression

### DIFF
--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <keycloak.version>17.0.0-legacy</keycloak.version>
+        <keycloak.image.version>18.0.2-legacy</keycloak.image.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -90,7 +90,7 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
-                        <keycloak.version>${keycloak.version}</keycloak.version>
+                        <keycloak.image.version>${keycloak.image.version}</keycloak.image.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -140,7 +140,7 @@
                                             org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <maven.home>${maven.home}</maven.home>
-                                        <keycloak.version>${keycloak.version}</keycloak.version>
+                                        <keycloak.image.version>${keycloak.image.version}</keycloak.image.version>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/resources/application.properties
@@ -11,3 +11,5 @@ quarkus.oidc.tenant-a.application-type=web-app
 # HTTP Security Configuration
 quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
+
+quarkus.log.category."com.gargoylesoftware.htmlunit".level=ERROR

--- a/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
+++ b/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/KeycloakServer.java
@@ -16,7 +16,7 @@ public class KeycloakServer implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:" + System.getProperty("keycloak.version"))
+        keycloak = new FixedHostPortGenericContainer("quay.io/keycloak/keycloak:" + System.getProperty("keycloak.image.version"))
                 .withFixedExposedPort(8180, 8080)
                 .withEnv("DB_VENDOR", "H2")
                 .withEnv("KEYCLOAK_USER", "admin")


### PR DESCRIPTION
security-openid-connect-multi-tenancy-quickstart updates:

 - Use Keycloak 18.0.2-legacy instead of 17.0.0-legacy
 - property name adjustment
 - Log com.gargoylesoftware.htmlunit on ERROR level to avoid 100+ lines of `WARN  [com.gar.htm.jav.hos.css.CSSStyleSheet] (main) CSSValue '0' has to be a 'px', 'em', '%', 'mm', 'ex', or 'pt' value."`

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus