### PR TITLE
Update OptaPlanner to the version 8.24.1.Final

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <optaplanner-quarkus.version>8.19.0.Final</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>8.24.1.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/solver/TimeTableConstraintProviderTest.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/solver/TimeTableConstraintProviderTest.java
@@ -6,7 +6,6 @@ import java.time.LocalTime;
 import javax.inject.Inject;
 
 import io.quarkus.test.junit.QuarkusTest;
-import org.acme.optaplanner.solver.TimeTableConstraintProvider;
 import org.acme.optaplanner.domain.Lesson;
 import org.acme.optaplanner.domain.Room;
 import org.acme.optaplanner.domain.TimeTable;


### PR DESCRIPTION
Upgrade to the latest version of OptaPlanner should fix https://github.com/quarkusio/quarkus/issues/6588.

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


