### PR TITLE
Bump used Liquibase xsd

### DIFF
--- a/liquibase-mongodb-quickstart/src/main/resources/liquibase/changelog.xml
+++ b/liquibase-mongodb-quickstart/src/main/resources/liquibase/changelog.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.13.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <changeSet id="1" author="loic">

--- a/liquibase-quickstart/src/main/resources/db/changeLog.xml
+++ b/liquibase-quickstart/src/main/resources/db/changeLog.xml
@@ -5,7 +5,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
     http://www.liquibase.org/xml/ns/dbchangelog
-    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.13.xsd">
 
     <changeSet author="quarkus" id="1">
         <createTable tableName="quarkus">


### PR DESCRIPTION
Bump used Liquibase xsd

Needed because of https://github.com/quarkusio/quarkus/pull/26714 change

`Quickstarts Native Build + Quarkus main` CI fails atm on these 2 modules

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus