### PR TITLE
Temporarily enforce the Kogito quickstart to keep using ANTLR 4.9.2

### DIFF
--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -24,6 +24,13 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <!-- Temporary workaround for this specific quickstart: Quarkus and Kogito need to upgrade to ANTLR 4.10,
+                we need to keep this particular quickstart on 4.9.2 for a while longer to avoid a deadlock in the migration process -->
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>4.9.2</version>
+            </dependency>
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
We need to apply this temporarily to avoid breaking all of main CI jobs testing the Quickstarts while we upgrade ANTLR to 4.10
in both the main repository and in Kogito.

See also:
 - https://github.com/quarkusio/quarkus/pull/27298#issuecomment-1216705851