### PR TITLE
Infinispan client create caches using the application.properties

### DIFF
--- a/infinispan-client-quickstart/src/main/java/org/acme/infinispan/client/InfinispanClientApp.java
+++ b/infinispan-client-quickstart/src/main/java/org/acme/infinispan/client/InfinispanClientApp.java
@@ -4,9 +4,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import io.quarkus.logging.Log;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.commons.configuration.XMLStringConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,20 +15,13 @@ import io.quarkus.runtime.StartupEvent;
 @ApplicationScoped
 public class InfinispanClientApp {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger("InfinispanClientApp");
 
     @Inject
     RemoteCacheManager cacheManager;
 
-    private static final String CACHE_CONFIG = "<distributed-cache name=\"%s\">"
-          + " <encoding media-type=\"application/x-protostream\"/>"
-          + "</distributed-cache>";
-
-
     void onStart(@Observes StartupEvent ev) {
-        LOGGER.info("Create or get cache named mycache with the default configuration");
-        RemoteCache<Object, Object> cache = cacheManager.administration().getOrCreateCache("mycache",
-                new XMLStringConfiguration(String.format(CACHE_CONFIG, "mycache")));
+        Log.info("Get cache named mycache and add put a key/value");
+        RemoteCache<Object, Object> cache = cacheManager.getCache("mycache");
         cache.put("hello", "Hello World, Infinispan is up!");
     }
 }

--- a/infinispan-client-quickstart/src/main/resources/application.properties
+++ b/infinispan-client-quickstart/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.infinispan-client.cache.mycache.configuration=<distributed-cache name="mycache"><encoding media-type="application/x-protostream"/></distributed-cache>
+
 # Use the Infinispan Dev Service in dev and test
 %prod.quarkus.infinispan-client.server-list=localhost:11222
 %prod.quarkus.infinispan-client.auth-username=admin


### PR DESCRIPTION
Related to changes on [#27341](https://github.com/quarkusio/quarkus/pull/27341)

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


