### PR TITLE
Use recommended package-private for inject

### DIFF
--- a/opentelemetry-quickstart/src/main/java/org/acme/opentelemetry/TracedResource.java
+++ b/opentelemetry-quickstart/src/main/java/org/acme/opentelemetry/TracedResource.java
@@ -16,7 +16,7 @@ public class TracedResource {
     private static final Logger LOG = Logger.getLogger(TracedResource.class);
 
     @Context
-    private UriInfo uriInfo;
+    UriInfo uriInfo;
 
     @GET
     @Path("/hello")

--- a/opentracing-quickstart/src/main/java/org/acme/opentracing/TracedResource.java
+++ b/opentracing-quickstart/src/main/java/org/acme/opentracing/TracedResource.java
@@ -20,7 +20,7 @@ public class TracedResource {
     FrancophoneService exampleBean;
 
     @Context
-    private UriInfo uriInfo;
+    UriInfo uriInfo;
 
     @GET
     @Path("/hello")


### PR DESCRIPTION
Use recommended package-private for inject

To avoid
```
[INFO] [io.quarkus.arc.processor.BeanProcessor] Found unrecommended usage of private members (use package-private instead) in application beans:
	- @Inject field org.acme.opentracing.TracedResource#uriInfo
```
	
- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


