### PR TITLE
hibernate-orm-panache-kotlin-quickstart fixes

### DIFF
--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -8,7 +8,6 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
@@ -149,20 +148,6 @@
                         <option>all-open:annotation=io.quarkus.test.junit.QuarkusTest</option>
                     </pluginOptions>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <!-- This is what injects the magic Quarkus bytecode -->
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/kotlin/org/acme/hibernate/orm/panache/FruitResource.kt
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/kotlin/org/acme/hibernate/orm/panache/FruitResource.kt
@@ -70,7 +70,7 @@ class FruitResource {
     @Provider
     class ErrorMapper : ExceptionMapper<Exception> {
         @Inject
-        var objectMapper: ObjectMapper? = null
+        lateinit var objectMapper: ObjectMapper
 
         override fun toResponse(exception: Exception): Response {
             LOGGER.error("Failed to handle request", exception)
@@ -78,7 +78,7 @@ class FruitResource {
             if (exception is WebApplicationException) {
                 code = exception.response.status
             }
-            val exceptionJson = objectMapper!!.createObjectNode()
+            val exceptionJson = objectMapper.createObjectNode()
             exceptionJson.put("exceptionType", exception.javaClass.name)
             exceptionJson.put("code", code)
             if (exception.message != null) {

--- a/hibernate-orm-panache-kotlin-quickstart/src/test/kotlin/org/acme/hibernate/orm/panache/NativeFruitsEndpointIT.kt
+++ b/hibernate-orm-panache-kotlin-quickstart/src/test/kotlin/org/acme/hibernate/orm/panache/NativeFruitsEndpointIT.kt
@@ -1,7 +1,7 @@
 package org.acme.hibernate.orm.panache
 
-import io.quarkus.test.junit.NativeImageTest
+import io.quarkus.test.junit.QuarkusIntegrationTest
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NativeFruitsEndpointIT : FruitsEndpointTest() { // Runs the same tests as the parent class
 }


### PR DESCRIPTION
hibernate-orm-panache-kotlin-quickstart fixes:

 - Use recommended way for @Inject
   - https://quarkus.io/guides/kotlin#cdi-inject-with-kotlin
 - Use @QuarkusIntegrationTest instead of @NativeImageTest
 - Avoid dual ivocation of quarkus-maven-plugin 
   - expensive with native mode

Checks:
- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


