### PR TITLE
Close the Kafka Consumer when terminating in the Bare Kafka quickstart

### DIFF
--- a/kafka-bare-quickstart/src/main/java/org/acme/kafka/KafkaEndpoint.java
+++ b/kafka-bare-quickstart/src/main/java/org/acme/kafka/KafkaEndpoint.java
@@ -61,7 +61,7 @@ public class KafkaEndpoint {
 
 
     public void terminate(@Observes ShutdownEvent ev) {
-        done = false;
+        done = true;
         producer.close();
         admin.close();
     }


### PR DESCRIPTION
The Kafka Consumer in the `bare-kafka-quickstart` is polling Kafka in a while loop based on `!done`. So it runs as long as the `done` is set to `false`. When terminating, the endpoint sets the `hold`, but it sets it to `false` again, so the Kafka Consumer will keep running. I assume this is just a typo and it should be set to `false` to close the consumer as well and not just the producer and admin clients..

**Check list**:

Your pull request:

- [x] targets the `development` branch