### PR TITLE
Update optaplanner to 8.27.0.Final

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <optaplanner-quarkus.version>8.24.1.Final</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>8.27.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
@@ -59,6 +59,12 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-quarkus</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss</groupId>
+          <artifactId>jandex</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>


### PR DESCRIPTION
Rely solely on smallrye jandex by ignoring jandex from optaplanner-quarkus.

Signed-off-by: Adler Fleurant <2609856+AdlerFleurant@users.noreply.github.com>


**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [X] has tests (`mvn clean test`) for optaplanner-quickstart
- [-] works in native (`mvn clean package -Pnative`) for optaplanner-quickstart
- [-] has integration/native tests (`mvn clean verify -Pnative`) for optaplanner-quickstart
- [X] makes sure the associated guide must not be updated


