### PR TITLE
Use Multi over raw RS Publisher

### DIFF
--- a/context-propagation-quickstart/src/main/java/org/acme/context/EmitterResource.java
+++ b/context-propagation-quickstart/src/main/java/org/acme/context/EmitterResource.java
@@ -11,7 +11,6 @@ import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.jboss.resteasy.reactive.RestStreamElementType;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -21,14 +20,14 @@ public class EmitterResource {
 
     // Get the prices stream
     @Inject
-    @Channel("prices") Publisher<Double> prices;
+    @Channel("prices") Multi<Double> prices;
 
     @Transactional
     @GET
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS)
     @RestStreamElementType(MediaType.TEXT_PLAIN)
-    public Publisher<Double> prices() {
+    public Multi<Double> prices() {
         // get the next three prices from the price stream
         return Multi.createFrom().publisher(prices)
                 .select().first(3)

--- a/mqtt-quickstart/src/main/java/org/acme/mqtt/PriceResource.java
+++ b/mqtt-quickstart/src/main/java/org/acme/mqtt/PriceResource.java
@@ -6,9 +6,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.reactivestreams.Publisher;
-
-import io.smallrye.reactive.messaging.annotations.Channel;
+import io.smallrye.mutiny.Multi;
+import org.eclipse.microprofile.reactive.messaging.Channel;
 
 /**
  * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
@@ -18,7 +17,7 @@ public class PriceResource {
 
     @Inject
     @Channel("my-data-stream")
-    Publisher<Double> prices;
+    Multi<Double> prices;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
@@ -29,7 +28,7 @@ public class PriceResource {
     @GET
     @Path("/stream")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    public Publisher<Double> stream() {
+    public Multi<Double> stream() {
         return prices;
     }
 }

--- a/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
+++ b/neo4j-quickstart/src/main/java/org/acme/neo4j/ReactiveFruitResource.java
@@ -10,7 +10,6 @@ import javax.ws.rs.core.MediaType;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -23,7 +22,7 @@ public class ReactiveFruitResource {
 
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    public Publisher<String> get() {
+    public Multi<String> get() {
         return Multi.createFrom().<RxSession, String>resource(
                 driver::rxSession,
                 session -> session.readTransaction(tx -> {


### PR DESCRIPTION
- This anticipates the future switch to JDK Flow APIs.
- Once this happens then code depending on legacy RS APIs will need Mutiny Zero adapters (e.g., ReactiveFruitResource / Neo4J).

