### PR TITLE
update quarkus.hibernate-orm.database.generation to drop-and-create i…

### DIFF
--- a/hibernate-orm-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-quickstart/src/main/resources/application.properties
@@ -4,7 +4,7 @@
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql


### PR DESCRIPTION
…n hibernate-orm-quickstart


Avoid `org.postgresql.util.PSQLException: ERROR: relation "known_fruits" already exists`

