### PR TITLE
Revert enforcing antlr4.9

### DIFF
--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -24,13 +24,6 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- Temporary workaround for this specific quickstart: Quarkus and Kogito need to upgrade to ANTLR 4.10,
-                we need to keep this particular quickstart on 4.9.2 for a while longer to avoid a deadlock in the migration process -->
-            <dependency>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>4.9.2</version>
-            </dependency>
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>

--- a/kogito-dmn-quickstart/pom.xml
+++ b/kogito-dmn-quickstart/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
         <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-        <kogito.platform.version>1.24.0.Final</kogito.platform.version>
+        <kogito.platform.version>1.32.0.Final</kogito.platform.version>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-drl-quickstart/pom.xml
+++ b/kogito-drl-quickstart/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
         <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-        <kogito.platform.version>1.24.0.Final</kogito.platform.version>
+        <kogito.platform.version>1.32.0.Final</kogito.platform.version>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
         <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-        <kogito.platform.version>1.24.0.Final</kogito.platform.version>
+        <kogito.platform.version>1.32.0.Final</kogito.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/kogito-pmml-quickstart/pom.xml
+++ b/kogito-pmml-quickstart/pom.xml
@@ -20,13 +20,6 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- Temporary workaround for this specific quickstart: Quarkus and Kogito need to upgrade to ANTLR 4.10,
-                we need to keep this particular quickstart on 4.9.2 for a while longer to avoid a deadlock in the migration process -->
-            <dependency>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>4.9.2</version>
-            </dependency>
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <kogito.platform.group-id>org.kie.kogito</kogito.platform.group-id>
     <kogito.platform.artifact-id>kogito-quarkus-bom</kogito.platform.artifact-id>
-    <kogito.platform.version>1.24.0.Final</kogito.platform.version>
+    <kogito.platform.version>1.32.0.Final</kogito.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kogito-quickstart/pom.xml
+++ b/kogito-quickstart/pom.xml
@@ -20,13 +20,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!-- Temporary workaround for this specific quickstart: Quarkus and Kogito need to upgrade to ANTLR 4.10,
-                we need to keep this particular quickstart on 4.9.2 for a while longer to avoid a deadlock in the migration process -->
-      <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-runtime</artifactId>
-        <version>4.9.2</version>
-      </dependency>
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
Reverts:
- https://github.com/quarkusio/quarkus-quickstarts/pull/1155
- https://github.com/quarkusio/quarkus-quickstarts/pull/1213

Drools / Kogito is now using Antlr 4.10.1

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


