### PR TITLE
AWT: quarkus-micro-image:2.0 and ubi-minimal:8.6, ubi-minimal:8.7

### DIFF
--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
@@ -1,5 +1,5 @@
 ####
-# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+# This Dockerfile is used to build a container that runs the Quarkus application in native (no JVM) mode
 #
 # Before building the container image run:
 #
@@ -7,7 +7,7 @@
 #
 # or
 #
-# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11
+# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
 #
 # If you don't have necessary libraries installed locally.
 #
@@ -20,7 +20,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/awt-graphics-rest
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 RUN microdnf install freetype fontconfig \
     && microdnf clean all
 WORKDIR /work/

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
@@ -7,37 +7,37 @@
 # Preparing distroless Dockerfile in this fashion is highly
 # application specific.
 #
-# The undermentioned example uses ubi-micro image and manually copies necessary
-# libraries and files from ubi-minimal image.
-#
-# See https://www.redhat.com/en/blog/introduction-ubi-micro on how to start using Buildah.
-#
-# ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-# ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-# ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-# This Dockerfile is used in order to build a distroless container that runs the Quarkus application in native (no JVM) mode
+# This Dockerfile is used to build a container that runs the Quarkus application in native (no JVM) mode.
+# It uses a micro base image, tuned for Quarkus native executables.
+# It reduces the size of the resulting container image.
+# Check https://quarkus.io/guides/quarkus-runtime-base-image for further information about this image.
 #
 # Before building the container image run:
 #
-# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11
+# ./mvnw package -Pnative
 #
-# The previous step produces an executable compatible with ubi-minimal.
+# or use the builder image if your host is not CentOS/Fedora based:
+#
+# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/awt-graphics-rest-micro .
+# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/awt-graphics-rest-quickstart .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/awt-graphics-rest-micro
+# docker run -i --rm -p 8080:8080 quarkus/awt-graphics-rest-quickstart
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 as nativelibs
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as nativelibs
 RUN microdnf install freetype fontconfig
 
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 COPY --from=nativelibs \
+   /lib64/libz.so.1 \
+   /lib64/libstdc++.so.6 \
    /lib64/libfreetype.so.6 \
+   /lib64/libgcc_s.so.1 \
    /lib64/libbz2.so.1 \
    /lib64/libpng16.so.16 \
    /lib64/libm.so.6 \


### PR DESCRIPTION
Hello,

The issue with the main branch still stands as described in #1190.
This PR merely updates versions, but does not help the main branch and  does not fix user's trouble with the main branch: https://github.com/quarkusio/quarkus/issues/29711

The reason why I am keeping the micro flavor on 8.6 is that quarkus-micro-image itself is at 8.6. 
Update proposed on https://github.com/quarkusio/quarkus-images/pull/219