### PR TITLE
Missing protocol in the mocked kubernetes environment for the Stork Kubernetes quickstart

### DIFF
--- a/stork-kubernetes-quickstart/src/test/java/org/acme/FrontendApiResourceTest.java
+++ b/stork-kubernetes-quickstart/src/test/java/org/acme/FrontendApiResourceTest.java
@@ -65,7 +65,7 @@ public class FrontendApiResourceTest {
         Endpoints endpoint = new EndpointsBuilder()
                 .withNewMetadata().withName("color-service").endMetadata()
                 .addToSubsets(new EndpointSubsetBuilder().withAddresses(endpointAddresses)
-                        .addToPorts(new EndpointPortBuilder().withPort(9001).build())
+                        .addToPorts(new EndpointPortBuilder().withPort(9001).withProtocol("tcp").build())
                         .build())
                 .build();
 


### PR DESCRIPTION
\CC @gsmet 