### PR TITLE
Replace deprecated annotations

### DIFF
--- a/hibernate-reactive-stateless-quickstart/src/test/java/org/acme/hibernate/reactive/NativeFruitsEndpointIT.java
+++ b/hibernate-reactive-stateless-quickstart/src/test/java/org/acme/hibernate/reactive/NativeFruitsEndpointIT.java
@@ -1,8 +1,8 @@
 package org.acme.hibernate.reactive;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeFruitsEndpointIT extends FruitsEndpointTest {
 
     // Runs the same tests as the parent class

--- a/kafka-bare-quickstart/src/test/java/org/acme/kafka/KafkaClientTest.java
+++ b/kafka-bare-quickstart/src/test/java/org/acme/kafka/KafkaClientTest.java
@@ -1,6 +1,6 @@
 package org.acme.kafka;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +15,7 @@ import static org.hamcrest.core.StringContains.containsString;
 class KafkaClientTest {
 
     @Test
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     void testBareClients() {
         given()
                 .queryParam("key", "my-key")


### PR DESCRIPTION
- Replaces the `@NativeImageTest` with `@QuarkusIntegrationTest`
- Replaces `@DisabledOnNativeImage` with `@DisabledOnIntegrationTest`


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


