### PR TITLE
hibernate-search-orm-elasticsearch - reset Author_SEQ to start with 3

### DIFF
--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/resources/import.sql
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/resources/import.sql
@@ -1,6 +1,6 @@
 INSERT INTO author(id, firstname, lastname) VALUES (1, 'John', 'Irving');
 INSERT INTO author(id, firstname, lastname) VALUES (2, 'Paul', 'Auster');
-alter sequence Author_SEQ restart with 2;
+alter sequence Author_SEQ restart with 3;
 
 INSERT INTO book(id, title, author_id) VALUES (nextval('Book_SEQ'), 'The World According to Garp', 1);
 INSERT INTO book(id, title, author_id) VALUES (nextval('Book_SEQ'), 'The Hotel New Hampshire', 1);


### PR DESCRIPTION
hibernate-search-orm-elasticsearch - reset Author_SEQ to start with 3

Import script inserts authors with id 1 and 2, the sequence should start with 3 then.

This got reveleaed with the latest changes in Quarkus main, I thinks it's https://github.com/quarkusio/quarkus/pull/31947 done by @yrodiere, but didn't bisect Quarkus main to be sure.

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


