### PR TITLE
Make FruitResourceTest independent from JAX-RS

### DIFF
--- a/rest-json-quickstart/src/test/java/org/acme/rest/json/FruitResourceTest.java
+++ b/rest-json-quickstart/src/test/java/org/acme/rest/json/FruitResourceTest.java
@@ -4,11 +4,10 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import jakarta.ws.rs.core.MediaType;
-
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class FruitResourceTest {
@@ -28,7 +27,7 @@ public class FruitResourceTest {
     public void testAdd() {
         given()
                 .body("{\"name\": \"Pear\", \"description\": \"Winter fruit\"}")
-                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .header("Content-Type", ContentType.JSON)
                 .when()
                 .post("/fruits")
                 .then()
@@ -39,7 +38,7 @@ public class FruitResourceTest {
 
         given()
                 .body("{\"name\": \"Pear\", \"description\": \"Winter fruit\"}")
-                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .header("Content-Type", ContentType.JSON)
                 .when()
                 .delete("/fruits")
                 .then()


### PR DESCRIPTION
Since the test is written with [REST Assured](https://rest-assured.io/), it should not use a class from jakarta for the content type.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`
