### PR TITLE
Update deprecated messaging property to connector for mqtt quickstart.

### DIFF
--- a/mqtt-quickstart/src/main/resources/application.properties
+++ b/mqtt-quickstart/src/main/resources/application.properties
@@ -1,14 +1,14 @@
 
 
 # Configure the MQTT sink (we write to it)
-mp.messaging.outgoing.topic-price.type=smallrye-mqtt
+mp.messaging.outgoing.topic-price.connector=smallrye-mqtt
 mp.messaging.outgoing.topic-price.topic=prices
 mp.messaging.outgoing.topic-price.host=localhost
 mp.messaging.outgoing.topic-price.port=1883
 mp.messaging.outgoing.topic-price.auto-generated-client-id=true
 
 # Configure the MQTT source (we read from it)
-mp.messaging.incoming.prices.type=smallrye-mqtt
+mp.messaging.incoming.prices.connector=smallrye-mqtt
 mp.messaging.incoming.prices.topic=prices
 mp.messaging.incoming.prices.host=localhost
 mp.messaging.incoming.prices.port=1883


### PR DESCRIPTION
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


