### PR TITLE
Bump localstack version to 1.4.0 + change localstack port configuration to 4566 

### DIFF
--- a/amazon-sqs-quickstart/README.md
+++ b/amazon-sqs-quickstart/README.md
@@ -5,7 +5,7 @@ This example showcases how to use the AWS SQS client with Quarkus. As a prerequi
 # AWS SQS local instance
 
 Just run it as follows in order to start SQS locally:
-`docker run --rm --name local-sqs -p 8010:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1`
+`docker run --rm --name local-sqs -p 8010:4566 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:1.4.0`
 SQS listens on `localhost:8010` for REST endpoints.
 
 Create an AWS profile for your local instance using AWS CLI:
@@ -77,14 +77,14 @@ Stop your localstack container you started at the beginning
 `docker stop local-sqs`
 
 Start localstack and connect to the network
-`docker run --rm --network=localstack --name localstack -p 8010:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1`
+`docker run --rm --network=localstack --name localstack -p 8010:4566 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:1.4.0`
 
 Create queue
 ```
 $> QUEUE_URL=`aws sqs create-queue --queue-name=ColliderQueue --profile localstack --endpoint-url=http://localhost:8010`
 ```
 Run quickstart container connected to that network (note that we're using internal port of the localstack)
-`docker run -i --rm --network=localstack -p 8080:8080 quarkus/amazon-sqs-quickstart -Dquarkus.sqs.endpoint-override=http://localstack:4576`
+`docker run -i --rm --network=localstack -p 8080:8080 quarkus/amazon-sqs-quickstart -Dquarkus.sqs.endpoint-override=http://localstack:4566`
 
 Send messsage
 ```

--- a/amazon-sqs-quickstart/src/main/docker/docker-compose.yml
+++ b/amazon-sqs-quickstart/src/main/docker/docker-compose.yml
@@ -2,9 +2,9 @@ version: '2.1'
 
 services:
   local-sqs:
-    image: localstack/localstack:0.11.1
+    image: localstack/localstack:1.4.0
     ports:
-      - "8010:4576"
+      - "8010:4566"
     environment:
       - SERVICES=sqs
       - START_WEB=0
@@ -13,5 +13,5 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - QUARKUS_SQS_ENDPOINT_OVERRIDE=http://local-sqs:4576
+      - QUARKUS_SQS_ENDPOINT_OVERRIDE=http://local-sqs:4566
       - QUEUE_URL=${QUEUE_URL}


### PR DESCRIPTION
1) Used localstack version was very old
2) Localstack default port has been changed to 4566

Existing examples could confuse people when using the old 4576 port config.
PR for thr guide: https://github.com/quarkiverse/quarkus-amazon-services/pull/648

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


