### PR TITLE
PLANNER-2861 Upgrate to OptaPlanner 9

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <optaplanner-quarkus.version>8.29.0.Final</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>9.37.0.Final</optaplanner-quarkus.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
@@ -59,12 +59,6 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-quarkus</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss</groupId>
-          <artifactId>jandex</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Lesson.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/Lesson.java
@@ -22,10 +22,10 @@ public class Lesson {
     private String teacher;
     private String studentGroup;
 
-    @PlanningVariable(valueRangeProviderRefs = "timeslotRange")
+    @PlanningVariable
     @ManyToOne
     private Timeslot timeslot;
-    @PlanningVariable(valueRangeProviderRefs = "roomRange")
+    @PlanningVariable
     @ManyToOne
     private Room room;
 

--- a/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/TimeTable.java
+++ b/optaplanner-quickstart/src/main/java/org/acme/optaplanner/domain/TimeTable.java
@@ -14,10 +14,10 @@ import org.optaplanner.core.api.solver.SolverStatus;
 public class TimeTable {
 
     @ProblemFactCollectionProperty
-    @ValueRangeProvider(id = "timeslotRange")
+    @ValueRangeProvider
     private List<Timeslot> timeslotList;
     @ProblemFactCollectionProperty
-    @ValueRangeProvider(id = "roomRange")
+    @ValueRangeProvider
     private List<Room> roomList;
     @PlanningEntityCollectionProperty
     private List<Lesson> lessonList;

--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,7 @@
         <module>kafka-avro-schema-quickstart</module>
         <module>kafka-bare-quickstart</module>
         <module>kafka-streams-quickstart</module>
-        <!--
         <module>optaplanner-quickstart</module>
-        -->
         <module>lifecycle-quickstart</module>
         <module>micrometer-quickstart</module>
         <module>microprofile-fault-tolerance-quickstart</module>


### PR DESCRIPTION
Upgrades to OptaPlanner 9.37.0.Final that is compatible with Quarkus 3. 

Follows enabling OptaPlanner in the Quarkus 3 platform: https://github.com/quarkusio/quarkus-platform/pull/804.

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


