### PR TITLE
Relaxes font rendering test to pass on contemporary Windows

### DIFF
--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
@@ -28,7 +28,8 @@ RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
 COPY --chown=1001:root target/*-runner /work/application
-
+# Permissions fix for Windows
+RUN chmod "ugo+x" /work/application
 EXPOSE 8080
 USER 1001
 

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
@@ -63,7 +63,8 @@ COPY --from=nativelibs \
      /etc/fonts /etc/fonts
 
 COPY target/*-runner /application
-
+# Permissions fix for Windows
+RUN chmod "ugo+x" /work/application
 EXPOSE 8080
 USER 1001
 

--- a/awt-graphics-rest-quickstart/src/test/java/org/acme/awt/rest/ImageResourceTest.java
+++ b/awt-graphics-rest-quickstart/src/test/java/org/acme/awt/rest/ImageResourceTest.java
@@ -47,12 +47,14 @@ public class ImageResourceTest {
                 String.format("Image's expected dimension is %d x %d, but was %d x %d.",
                         836, 379, image.getWidth(), image.getHeight()));
         final int[] pixel = new int[4]; //4BYTE RGBA
+        // ImageIO.write(image, "PNG", new File("/tmp/test_image.png"));
         image.getData().getPixel(800, 311, pixel);
-        Assertions.assertTrue(pixel[0] > 100, "There should have been more red. Watermark failed.");
+        Assertions.assertTrue(pixel[0] > 100, "[800, 311] There should have been more red. Watermark failed.");
         image.getData().getPixel(770, 366, pixel);
-        Assertions.assertTrue(pixel[2] > 100, "There should have been more blue. Watermark failed.");
-        image.getData().getPixel(65, 51, pixel);
-        Assertions.assertTrue(pixel[0] > 100, "There should have been more red. Watermark failed.");
+        Assertions.assertTrue(pixel[2] > 100, "[770, 366] There should have been more blue. Watermark failed.");
+        image.getData().getPixel(64, 56, pixel);
+        Assertions.assertTrue(pixel[0] > 100, "[64, 56] There should have been more red. Watermark failed.");
     }
 
 }
+


### PR DESCRIPTION
See #1277 