### PR TITLE
Stream S3 file data instead of fetching entire content with toBytes

### DIFF
--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.0.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.3.0</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
+++ b/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
@@ -1,7 +1,9 @@
 package org.acme.s3;
 
+import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -13,10 +15,15 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.RestMulti;
+import org.reactivestreams.Publisher;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.buffer.Buffer;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -55,13 +62,15 @@ public class S3AsyncClientResource extends CommonResource {
     @GET
     @Path("download/{objectKey}")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public Uni<Response> downloadFile(String objectKey) {
-        return Uni.createFrom()
-                .completionStage(() -> s3.getObject(buildGetRequest(objectKey), AsyncResponseTransformer.toBytes()))
-                .onItem()
-                .transform(object -> Response.ok(object.asUtf8String())
-                        .header("Content-Disposition", "attachment;filename=" + objectKey)
-                        .header("Content-Type", object.response().contentType()).build());
+    public RestMulti<Buffer> downloadFile(String objectKey) {
+
+        return RestMulti.fromUniResponse(Uni.createFrom()
+                .completionStage(() -> s3.getObject(buildGetRequest(objectKey),
+                        AsyncResponseTransformer.toPublisher())),
+                response -> Multi.createFrom().safePublisher(AdaptersToFlow.publisher((Publisher<ByteBuffer>) response))
+                        .map(S3AsyncClientResource::toBuffer),
+                response -> Map.of("Content-Disposition", List.of("attachment;filename=" + objectKey), "Content-Type",
+                        List.of(response.response().contentType())));
     }
 
     @GET
@@ -72,6 +81,12 @@ public class S3AsyncClientResource extends CommonResource {
 
         return Uni.createFrom().completionStage(() -> s3.listObjects(listRequest))
                 .onItem().transform(result -> toFileItems(result));
+    }
+
+    private static Buffer toBuffer(ByteBuffer bytebuffer) {
+        byte[] result = new byte[bytebuffer.remaining()];
+        bytebuffer.get(result);
+        return Buffer.buffer(result);
     }
 
     private List<FileObject> toFileItems(ListObjectsResponse objects) {

--- a/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
+++ b/amazon-s3-quickstart/src/main/java/org/acme/s3/S3AsyncClientResource.java
@@ -17,7 +17,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import mutiny.zero.flow.adapters.AdaptersToFlow;
 
-import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.RestMulti;
 import org.reactivestreams.Publisher;
 
@@ -38,7 +37,7 @@ public class S3AsyncClientResource extends CommonResource {
     @POST
     @Path("upload")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Uni<Response> uploadFile(@MultipartForm FormData formData) throws Exception {
+    public Uni<Response> uploadFile(FormData formData) throws Exception {
 
         if (formData.filename == null || formData.filename.isEmpty()) {
             return Uni.createFrom().item(Response.status(Status.BAD_REQUEST).build());

--- a/amazon-s3-quickstart/src/main/java/org/acme/s3/S3SyncClientResource.java
+++ b/amazon-s3-quickstart/src/main/java/org/acme/s3/S3SyncClientResource.java
@@ -3,6 +3,7 @@ package org.acme.s3;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -13,7 +14,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.Response.Status;
-import org.jboss.resteasy.reactive.MultipartForm;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -30,7 +30,7 @@ public class S3SyncClientResource extends CommonResource {
     @POST
     @Path("upload")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response uploadFile(@MultipartForm FormData formData) throws Exception {
+    public Response uploadFile(FormData formData) throws Exception {
 
         if (formData.filename == null || formData.filename.isEmpty()) {
             return Response.status(Status.BAD_REQUEST).build();

--- a/amazon-s3-quickstart/src/main/resources/META-INF/resources/async-s3.html
+++ b/amazon-s3-quickstart/src/main/resources/META-INF/resources/async-s3.html
@@ -121,7 +121,7 @@
         <div class="col-4">Size</div>
     </div>
     <div class="row" ng-repeat="file in files">
-        <div class="col-8"><a href="{{ '/s3/download/' + file.objectKey }}">{{ file.objectKey }}</a></div>
+        <div class="col-8"><a href="{{ '/async-s3/download/' + file.objectKey }}">{{ file.objectKey }}</a></div>
         <div class="col-4">{{ file.size }} B</div>
     </div>
 </div>


### PR DESCRIPTION
guide update PR : https://github.com/quarkiverse/quarkus-amazon-services/pull/770
Require Quarkus 3.1.0.Final

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


