### PR TITLE
AWT: Windows/Linux fonts, adjusted testing

### DIFF
--- a/awt-graphics-rest-quickstart/src/test/java/org/acme/awt/rest/ImageResourceTest.java
+++ b/awt-graphics-rest-quickstart/src/test/java/org/acme/awt/rest/ImageResourceTest.java
@@ -52,8 +52,10 @@ public class ImageResourceTest {
         Assertions.assertTrue(pixel[0] > 100, "[800, 311] There should have been more red. Watermark failed.");
         image.getData().getPixel(770, 366, pixel);
         Assertions.assertTrue(pixel[2] > 100, "[770, 366] There should have been more blue. Watermark failed.");
-        image.getData().getPixel(64, 56, pixel);
-        Assertions.assertTrue(pixel[0] > 100, "[64, 56] There should have been more red. Watermark failed.");
+        // We check the "M" in "Mandrel" for our own font MyFreeSerif.
+        // Relying on system fonts is fragile, changes across OS versions.
+        image.getData().getPixel(64, 41, pixel);
+        Assertions.assertTrue(pixel[0] > 100, "[64, 41] There should have been more red. Watermark failed.");
     }
 
 }


### PR DESCRIPTION
I am sorry for the noise. I am preparing a Windows/Podman related blogpost and the system fonts just make it all convoluted. This is much better. We test only text we rendered using our own free type font. 