### PR TITLE
AWT Quickstart Dockerfile to be compatible both with 22.x and 23.x

### DIFF
--- a/awt-graphics-rest-quickstart/.dockerignore
+++ b/awt-graphics-rest-quickstart/.dockerignore
@@ -1,5 +1,6 @@
 *
 !target/*-runner
+!target/*.so
 !target/*-runner.jar
 !target/lib/*
 !target/quarkus-app/

--- a/awt-graphics-rest-quickstart/.dockerignore
+++ b/awt-graphics-rest-quickstart/.dockerignore
@@ -1,6 +1,7 @@
 *
 !target/*-runner
 !target/*.so
+!target/*.properties
 !target/*-runner.jar
 !target/lib/*
 !target/quarkus-app/

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.jvm
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/awt-graphics-rest-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/awt-graphics-rest-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
@@ -28,8 +28,7 @@ RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
 # Shared objects to be dynamically loaded at runtime as needed,
-# uncomment for Mandrel 23+ / GraalVM 23+ (as per June 2023 release)
-COPY --chown=1001:root target/*.so /work/
+COPY --chown=1001:root target/*.properties target/*.so /work/
 COPY --chown=1001:root target/*-runner /work/application
 # Permissions fix for Windows
 RUN chmod "ugo+x" /work/application

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native
@@ -7,7 +7,7 @@
 #
 # or
 #
-# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
+# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
 #
 # If you don't have necessary libraries installed locally.
 #
@@ -27,6 +27,9 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
+# Shared objects to be dynamically loaded at runtime as needed,
+# uncomment for Mandrel 23+ / GraalVM 23+ (as per June 2023 release)
+COPY --chown=1001:root target/*.so /work/
 COPY --chown=1001:root target/*-runner /work/application
 # Permissions fix for Windows
 RUN chmod "ugo+x" /work/application

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
@@ -18,7 +18,7 @@
 #
 # or use the builder image if your host is not CentOS/Fedora based:
 #
-# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17
+# ./mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
 #
 # Then, build the image with:
 #
@@ -29,7 +29,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/awt-graphics-rest-quickstart
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as nativelibs
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as nativelibs
 RUN microdnf install freetype fontconfig
 
 FROM quay.io/quarkus/quarkus-micro-image:2.0
@@ -62,10 +62,14 @@ COPY --from=nativelibs \
 COPY --from=nativelibs \
      /etc/fonts /etc/fonts
 
-COPY target/*-runner /application
+RUN mkdir /work
+# Shared objects to be dynamically loaded at runtime as needed,
+# uncomment for Mandrel 23+ / GraalVM 23+ (as per June 2023 release)
+COPY target/*.so /work/
+COPY target/*-runner /work/application
 # Permissions fix for Windows
 RUN chmod "ugo+x" /work/application
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./work/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.native-micro
@@ -64,8 +64,7 @@ COPY --from=nativelibs \
 
 RUN mkdir /work
 # Shared objects to be dynamically loaded at runtime as needed,
-# uncomment for Mandrel 23+ / GraalVM 23+ (as per June 2023 release)
-COPY target/*.so /work/
+COPY target/*.properties target/*.so /work/
 COPY target/*-runner /work/application
 # Permissions fix for Windows
 RUN chmod "ugo+x" /work/application


### PR DESCRIPTION
It works both with 

```
mvnw package -Dnative -Dquarkus.native.container-build=true -Dquarkus.platform.version=3.1.2.Final
```

and

```
mvnw package -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17 -Dquarkus.platform.version=3.2.0.CR1
```

I workarounded the issue of not existing .so files for 22.3 by copying a property file.