### PR TITLE
Add missing documentation and enhance test coverage for getting-started-reactive-crud

### DIFF
--- a/getting-started-reactive-crud/README.md
+++ b/getting-started-reactive-crud/README.md
@@ -1,0 +1,117 @@
+# Getting started with Quarkus
+
+This is a CRUD service exposing endpoints over REST. These endpoints are used for get, add, update
+and
+remove entries from database.
+
+## Requirements
+
+To compile and run this demo you will need:
+
+- JDK 11+
+- GraalVM
+- httpie (or curl)
+
+### Configuring GraalVM and JDK 11+
+
+Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have been set, and that
+a JDK 11+ `java` command is on the path.
+
+See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image-guide)
+for help setting up your environment.
+
+## Building the application
+
+Launch the Maven build on the checked out sources of this demo:
+
+> ./mvnw package
+
+### Running the demo
+
+The Maven Quarkus plugin provides a development mode that supports live coding. To try this out:
+
+> ./mvnw quarkus:dev
+
+This command will leave Quarkus running in the foreground listening on port 8080.
+
+Launch the second terminal which will be used to send a request.
+
+To get list of all fruits visit [http://127.0.0.1:8080/fruits](http://127.0.0.1:8080/fruits) and all
+fruit in database should be returned or you can use terminal and get all fruits by one of these
+commands:
+> http :8080/fruits
+>
+> curl 127.0.0.1:8080/fruits
+
+The output of these command should display same content as browser.
+
+You can also get fruit by id. In this example used id is equal to 1. Get fruit by id is
+possible either by using browser or by terminal. To get fruit by browser
+visit [http://127.0.0.1:8080/fruits/1](http://127.0.0.1:8080/fruits/1) and info about kiwi fruit
+should be displayed. To get fruit by terminal:
+> http :8080/fruits/1
+>
+> curl 127.0.0.1:8080/fruits/1
+
+The output of these command should display same content as browser.
+
+Next we add lemon fruit. To add fruit the POST request needs to be sent. This request must contain
+key-value pair. In this case `name={fruitName}`. To add fruit send request from terminal:
+> http POST :8080/fruits name=Lemon
+>
+> curl -X POST http://localhost:8080/fruits -H 'Content-Type: application/json' -d '{"name":"Lemon"}'
+
+This request create fruit with name `Lemon`. Now you can check all fruits and the newly added fruit
+should be visible.
+
+To update name of fruit the PUT request needs to be sent. This request must contain two key-value
+pairs. In this case `id={fruitId}` and `name={newFruitName}`. In this example used id is equal to 1.
+To update fruit name send request from terminal:
+> http PUT :8080/fruits/1 id=1 name=Pitaya
+>
+> curl -X PUT http://localhost:8080/fruits/1 -H "Content-Type: application/json" -d '{"id":1,
+> "name":"Pitaya"}'
+
+This request update name of fruit with index 1 to `Pitaya`. Now you can check all fruits and fruit
+with index 1 should be updated.
+
+Now as you know how to show, add and update fruits last step will be to delete fruit. To delete
+fruit you need to know its id. In case of this example the fruit with id equal to 1 will be
+deleted. To delete fruit the DELETE request needs to be sent. To delete fruit send request from
+terminal:
+> http DELETE :8080/fruits/1
+>
+> curl -X DELETE http://localhost:8080/fruits/1
+
+Check that fruit with id 1 is not existing anymore.
+
+### Run Quarkus in JVM mode
+
+When you're done iterating in developer mode, you can run the application as a conventional jar
+file.
+
+First compile it:
+
+> ./mvnw package
+
+Then run it:
+
+> java -jar ./target/quarkus-app/quarkus-run.jar
+
+Have a look at how fast it boots, or measure the total native memory consumption.
+
+### Run Quarkus as a native executable
+
+You can also create a native executable from this application without making any source code
+changes. A native executable removes the dependency on the JVM: everything needed to run the
+application on the target platform is included in the executable, allowing the application to run
+with minimal resource overhead.
+
+Compiling a native executable takes a bit longer, as GraalVM performs additional steps to remove
+unnecessary codepaths. Use the `native` profile to compile a native executable:
+
+> ./mvnw package -Dnative
+
+After getting a cup of coffee, you'll be able to run this executable directly:
+
+> ./target/getting-started-reactive-rest-1.0.0-SNAPSHOT-runner

--- a/getting-started-reactive-crud/src/test/java/org/acme/reactive/crud/FruitResourceTest.java
+++ b/getting-started-reactive-crud/src/test/java/org/acme/reactive/crud/FruitResourceTest.java
@@ -4,15 +4,22 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsNot.not;
 
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class FruitResourceTest {
+    private static String newFruit = "Lemon";
+    private static String updatedFruit = "Pitaya";
 
     @Test
-    public void testListAllFruits() {
+    @Order(1)
+    public void testAddFruit() {
         //List all, should have all 4 fruits the database has initially:
         given()
                 .when().get("/fruits")
@@ -24,22 +31,113 @@ class FruitResourceTest {
                         containsString("Pomelo"),
                         containsString("Lychee"));
 
-        //Delete the Kiwi:
+        // Add new fruit
         given()
-                .when().delete("/fruits/1")
+                .when().contentType("application/json")
+                .body("{\"name\":\"" + newFruit + "\"}")
+                .post("/fruits")
                 .then()
-                .statusCode(204);
+                .statusCode(201);
 
-        //List all, Kiwi should be missing now:
+        //List all, should have 4 fruits the database has initially and 1 added fruit:
         given()
                 .when().get("/fruits")
                 .then()
                 .statusCode(200)
                 .body(
-                        not(containsString("Kiwi")),
+                        containsString("Kiwi"),
                         containsString("Durian"),
                         containsString("Pomelo"),
-                        containsString("Lychee"));
+                        containsString("Lychee"),
+                        containsString(newFruit));
+    }
+
+    @Test
+    @Order(2)
+    public void testUpdateFruit() {
+        //List all, should have 4 fruits the database has initially and 1 added fruit:
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Kiwi"),
+                        containsString("Durian"),
+                        containsString("Pomelo"),
+                        containsString("Lychee"),
+                        containsString(newFruit));
+
+        // Update name of added fruit
+        given()
+                .when().contentType("application/json")
+                .body("{\"id\":5, \"name\":\"" + updatedFruit + "\"}")
+                .put("/fruits/5")
+                .then()
+                .statusCode(200);
+
+        //List all, should have 4 fruits the database has initially and 1 updated fruit:
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Kiwi"),
+                        containsString("Durian"),
+                        containsString("Pomelo"),
+                        containsString("Lychee"),
+                        containsString(updatedFruit));
+    }
+
+    @Test
+    @Order(3)
+    public void testListAllFruits() {
+        //List all, should have 5 fruits the database has initially:
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Kiwi"),
+                        containsString("Durian"),
+                        containsString("Pomelo"),
+                        containsString("Lychee"),
+                        containsString(updatedFruit));
+
+        //Delete the Pitaya:
+        given()
+                .when().delete("/fruits/5")
+                .then()
+                .statusCode(204);
+
+        //List all, Pitaya should be missing now:
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Kiwi"),
+                        containsString("Durian"),
+                        containsString("Pomelo"),
+                        containsString("Lychee"),
+                        not(containsString(updatedFruit)));
+    }
+
+    @Test
+    public void testNotFoundForDelete() {
+        given()
+                .when().delete("/fruits/3939")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testNotFoundForUpdate() {
+        given()
+                .when().contentType("application/json")
+                .body("{\"id\":3939, \"name\":\"" + updatedFruit + "\"}")
+                .put("/fruits/3939")
+                .then()
+                .statusCode(404);
     }
 
 }


### PR DESCRIPTION
Hi, this PR add documentation and additional tests to getting-started-reactive-crud.
As for the documentation whole readme was missing and I wasn't able to find any guide on [quarkus.io/](https://quarkus.io/version/main/guides/) so I wrote some steps for this as I was looking how it's work.
The test only included 2 things (get all and delete). I added coverage for testing add and update fruit as it can be useful for people who are looking how to send these request.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


