### PR TITLE
Rework security-jpa-quickstart

### DIFF
--- a/security-jpa-quickstart/README.md
+++ b/security-jpa-quickstart/README.md
@@ -1,29 +1,40 @@
-Quarkus Elytron Security with JPA
+Quarkus Security with JPA
 ========================
 
 This guide demonstrates how your Quarkus application can use a database and JPA to store your user identities.
 
-## Start the database
+## Run quickstart in developer mode
 
-You need a database to store the user identities/roles. Here, we are using [PostgreSQL](https://www.postgresql.org).
-To ease the setup, we have provided a `docker-compose.yml` file which start a PostgreSQL container, bind the network ports
-and finally creates the users and their credentials by importing the `import.sql` file.
-
-The database can be started using:
- ```bash
- docker-compose up
- ```  
-
-Once the database is up you can start your Quarkus application.
-
-Note you do not need to start the database when running your application in dev mode or testing. It will be started automatically as a Dev Service.
-
-## Start the application
-
-The application can be started using: 
+Quarkus provides developer mode, in which you can try this example. Just try:
 
 ```bash
-mvn compile quarkus:dev
+mvn quarkus:dev
+```
+
+Now the application will listen on `localhost:8080`.
+In developer mode quarkus will also start its own postgres database.
+
+## Run quickstart in JVM mode
+
+### Start the database
+
+Now we need to start a [PostgreSQL](https://www.postgresql.org) database on our own.
+To set it up with docker:
+
+```bash
+docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus -e POSTGRES_PASSWORD=quarkus -e POSTGRES_DB=quarkus -p 5432:5432 postgres:15.3
+```
+
+Once the database is up, you can start your Quarkus application.
+Application will fill in the users and their credentials on `StartupEvent`.
+
+### Start the application
+
+The application can be build & started using: 
+
+```bash
+mvn clean package
+java -jar target/quarkus-app/quarkus-run.jar 
 ```  
 
 ## Test the application
@@ -34,7 +45,7 @@ The application exposes 3 endpoints:
 * `/api/admin`
 * `/api/users/me`
 
-You can try these endpoints with an http client (`curl`, `HTTPie`, etc).
+You can try these endpoints with a http client (`curl`, `HTTPie`, etc).
 Here you have some examples to check the security configuration:
 
 ```bash
@@ -44,8 +55,6 @@ curl -i -X GET -u admin:admin http://localhost:8080/api/admin # 'admin'
 curl -i -X GET http://localhost:8080/api/users/me # 'unauthorized'
 curl -i -X GET -u user:user http://localhost:8080/api/users/me # 'user'
 ```
-
-_NOTE:_ Stop the database using: `docker-compose down; docker-compose rm`
 
 ### Integration testing
 

--- a/security-jpa-quickstart/docker-compose.yml
+++ b/security-jpa-quickstart/docker-compose.yml
@@ -1,9 +1,0 @@
-version: "3"
-services:
-  database:
-    image: "postgres:10.5"
-    container_name: "elytron-security-jpa-database"
-    ports:
-      - "5432:5432"
-    volumes:
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/security-jpa-quickstart/init.sql
+++ b/security-jpa-quickstart/init.sql
@@ -1,5 +1,0 @@
-CREATE ROLE quarkus WITH LOGIN PASSWORD 'quarkus';
-CREATE DATABASE elytron_security_jpa;
-GRANT ALL PRIVILEGES ON DATABASE elytron_security_jpa TO quarkus;
-\c elytron_security_jpa
-

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -9,8 +9,8 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
+        <compiler-plugin.version>3.11.0</compiler-plugin.version>
+        <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/security-jpa-quickstart/src/main/resources/application.properties
+++ b/security-jpa-quickstart/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 %prod.quarkus.datasource.db-kind=postgresql
 %prod.quarkus.datasource.username=quarkus
 %prod.quarkus.datasource.password=quarkus
-%prod.quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_jpa
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus
 
 quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
Old version's readme didn't describe how to connect to postgres in JVM mode, also old app was not able to properly connect to postgres. Postgres' docker container was started in overcomplicated way.

Update dependencies.

Remove files, which are no longer necessary.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


