### PR TITLE
Fix join message in websocket quickstart

### DIFF
--- a/websockets-quickstart/src/main/java/org/acme/websockets/ChatSocket.java
+++ b/websockets-quickstart/src/main/java/org/acme/websockets/ChatSocket.java
@@ -24,6 +24,7 @@ public class ChatSocket {
 
     @OnOpen
     public void onOpen(Session session, @PathParam("username") String username) {
+        broadcast("User " + username + " joined");
         sessions.put(username, session);
     }
 
@@ -42,11 +43,7 @@ public class ChatSocket {
 
     @OnMessage
     public void onMessage(String message, @PathParam("username") String username) {
-        if (message.equalsIgnoreCase("_ready_")) {
-            broadcast("User " + username + " joined");
-        } else {
-            broadcast(">> " + username + ": " + message);
-        }
+        broadcast(">> " + username + ": " + message);
     }
 
     private void broadcast(String message) {


### PR DESCRIPTION
There should be a "joined" message on user joining, but no message is acctually sent.

No "ready" message is generated on user joining,
so move this message to user incoming.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


