### PR TITLE
Artifacts need to be readable/executable as part of the root group in…

### DIFF
--- a/getting-started/src/main/docker/Dockerfile.jvm
+++ b/getting-started/src/main/docker/Dockerfile.jvm
@@ -36,17 +36,17 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
     && chmod "g+rwX" /deployments \
     && chown 1001:root /deployments \
     && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
-    && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
+    && chown 1001:0 /deployments/run-java.sh \
+    && chmod 550 /deployments/run-java.sh \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001 target/quarkus-app/*.jar /deployments/
-COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
-COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=1001:0 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001:0 target/quarkus-app/*.jar /deployments/
+COPY --chown=1001:0 target/quarkus-app/app/ /deployments/app/
+COPY --chown=1001:0 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
… order to be used on an openshift container by default.


**Check list**:

Your pull request:

- [x ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`

Currently, if you try to use this docker file on Openshift you get a permissions error when trying to run `run-java.sh`. This is because the root group does not have access to execute that file. I don't think giving the root group access hurts the usage on other platforms but it will reduce the work for people trying to deploy onto Openshift.
