### PR TITLE
Add dev-console-spi as it's removed in vertx

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -46,6 +46,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
We are in the process removing the old Dev UI, that removed `dev-console-spi`. This SPI was pulled in here transitively, but now needs to be pulled in directly 