### PR TITLE
Adapt QuickStarts for remote Docker agent on a same network

### DIFF
--- a/mqtt-quickstart/src/main/resources/application.properties
+++ b/mqtt-quickstart/src/main/resources/application.properties
@@ -3,13 +3,13 @@
 # Configure the MQTT sink (we write to it)
 mp.messaging.outgoing.topic-price.connector=smallrye-mqtt
 mp.messaging.outgoing.topic-price.topic=prices
-mp.messaging.outgoing.topic-price.host=localhost
+mp.messaging.outgoing.topic-price.host=${MQTT_HOST:localhost}
 mp.messaging.outgoing.topic-price.port=1883
 mp.messaging.outgoing.topic-price.auto-generated-client-id=true
 
 # Configure the MQTT source (we read from it)
 mp.messaging.incoming.prices.connector=smallrye-mqtt
 mp.messaging.incoming.prices.topic=prices
-mp.messaging.incoming.prices.host=localhost
+mp.messaging.incoming.prices.host=${MQTT_HOST:localhost}
 mp.messaging.incoming.prices.port=1883
 mp.messaging.incoming.prices.auto-generated-client-id=true

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorTest.java
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorTest.java
@@ -19,6 +19,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DeliverCallback;
 
 import org.acme.rabbitmq.model.Quote;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -26,6 +27,8 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 public class QuoteProcessorTest {
 
+    @ConfigProperty(name = "rabbitmq-host") String host;
+    @ConfigProperty(name = "rabbitmq-port") int port;
     ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
@@ -63,8 +66,8 @@ public class QuoteProcessorTest {
 
     Channel getChannel() throws Exception {
         ConnectionFactory connectionFactory = new ConnectionFactory();
-        connectionFactory.setHost("localhost");
-        connectionFactory.setPort(5672);
+        connectionFactory.setHost(host);
+        connectionFactory.setPort(port);
         connectionFactory.setUsername("guest");
         connectionFactory.setPassword("guest");
         connectionFactory.setChannelRpcTimeout((int) SECONDS.toMillis(3));

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -49,16 +49,6 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/security-jdbc-quickstart/src/main/resources/application.properties
+++ b/security-jdbc-quickstart/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=quarkus
-quarkus.datasource.password=quarkus
-quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_jdbc
+%prod.quarkus.datasource.username=quarkus
+%prod.quarkus.datasource.password=quarkus
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_jdbc
 
 quarkus.security.jdbc.enabled=true
 quarkus.security.jdbc.principal-query.sql=SELECT u.password, u.role FROM test_user u WHERE u.username=?
@@ -9,3 +9,5 @@ quarkus.security.jdbc.principal-query.clear-password-mapper.enabled=true
 quarkus.security.jdbc.principal-query.clear-password-mapper.password-index=1
 quarkus.security.jdbc.principal-query.attribute-mappings.0.index=2
 quarkus.security.jdbc.principal-query.attribute-mappings.0.to=groups
+
+%test.quarkus.datasource.devservices.init-script-path=test_user.sql

--- a/security-jdbc-quickstart/src/test/java/org/acme/security/jdbc/JdbcSecurityRealmTest.java
+++ b/security-jdbc-quickstart/src/test/java/org/acme/security/jdbc/JdbcSecurityRealmTest.java
@@ -9,31 +9,12 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 
 import io.quarkus.test.junit.QuarkusTest;
 
-@Testcontainers
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class JdbcSecurityRealmTest {
-
-    @Container
-    public static final PostgreSQLContainer DATABASE = new PostgreSQLContainer<>()
-            .withDatabaseName("elytron_security_jdbc")
-            .withUsername("quarkus")
-            .withPassword("quarkus")
-            .withExposedPorts(5432)
-            .withCreateContainerCmdModifier(cmd -> cmd
-                    .withHostName("localhost")
-                    .withPortBindings(new PortBinding(Ports.Binding.bindPort(5432), new ExposedPort(5432))))
-            .withInitScript("test_user.sql");
 
     @Test
     @Order(1)


### PR DESCRIPTION
I need to run Quarkus Quickstarts on a remote Docker agent (in order to test Quarkus on Windows). That means everywhere that is hardcoded `localhost` doesn't work for me. This PR enables overriding host. This is important especially on Windows when using Docker Desktop alternatives as some of them use different Docker host. Fixed ports are no issue for me (I use NAT) and it would take much harder work to make it work for remote Docker agents that can be exposed on random computer port (f.e. with TestContainers Cloud).

Changes should be self-explanatory except for `mqtt-quickstart`. I can't set `mp.messaging.outgoing.topic-price.host` and `mp.messaging.incoming.prices.host` directly for it breaks `pulsar-quickstart-producer`. Allowing override host that is already done elsewhere (f.e. `hibernate-orm-multi-tenancy-quickstart` with `DB_HOST_TENANT_BASE` and `DB_HOST_TENANT_MYCOMPANY`) makes sense to me.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


