### PR TITLE
[3.2] Remove invalid QuoteProcessorIT

### DIFF
--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorIT.java
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorIT.java
@@ -1,8 +1,0 @@
-package org.acme.rabbitmq.processor;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest
-public class QuoteProcessorIT extends QuoteProcessorTest {
-
-}


### PR DESCRIPTION
Remove invalid QuoteProcessorIT

This test does not work because injection into ITs is not supported

Backport of Remove invalid QuoteProcessorIT into 3.2 branch

CC @geoand 