### PR TITLE
Update opts in Dockerfiles using ubi8 OpenJDK

### DIFF
--- a/elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -88,6 +88,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 

--- a/elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -85,5 +85,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/getting-started-dev-services/src/main/docker/Dockerfile.jvm
+++ b/getting-started-dev-services/src/main/docker/Dockerfile.jvm
@@ -90,6 +90,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 

--- a/getting-started-dev-services/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-dev-services/src/main/docker/Dockerfile.legacy-jar
@@ -87,5 +87,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/security-webauthn-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-webauthn-quickstart/src/main/docker/Dockerfile.jvm
@@ -89,6 +89,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 EXPOSE 8080
 USER 185
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 

--- a/security-webauthn-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-webauthn-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -86,5 +86,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 EXPOSE 8080
 USER 185
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"


### PR DESCRIPTION
The semantics of JAVA_OPTS env is that they remove any default tuning from the UBI 8 OpenJDK image. A better suggestion would be to only append the quarkus specific options to the JVM command line.

That can be done by using JAVA_OPTS_APPEND instead. Using that over JAVA_OPTS has the added benefit that users specifying JAVA_OPTS_APPEND in a deployment config would see their values show up. They wouldn't see them show up if they added an env JAVA_OPTS_APPEND, since JAVA_OPTS is specified in the Dockerfile (overriding any JAVA_OPTS_APPEND use).