### PR TITLE
Add all-open option for Kotlin panache

### DIFF
--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -145,6 +145,7 @@
                     <pluginOptions>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
                         <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                         <option>all-open:annotation=io.quarkus.test.junit.QuarkusTest</option>
                     </pluginOptions>
                 </configuration>


### PR DESCRIPTION
The kotlin-maven-allopen plugin needs to be configured for entity classes.

The quickstart fails with this if this is not done:

```
2023-10-19 14:16:55,283 WARN  [io.qua.hib.orm.run.pro.ProxyDefinitions] (Quarkus Main Thread) Could not generate an enhanced proxy for entity 'org.acme.hibernate.orm.panache.Fruit' (class='org.acme.hibernate.orm.panache.Fruit') as it's final. Your application might perform better if we're allowed to extend it.
2023-10-19 14:16:55,742 WARN  [org.hib.met.int.EntityRepresentationStrategyPojoStandard] (JPA Startup Thread) HHH000305: Could not create proxy factory for:org.acme.hibernate.orm.panache.Fruit: org.hibernate.HibernateException: Getter methods of lazy classes cannot be final: org.acme.hibernate.orm.panache.Fruit#getName
	at org.hibernate.proxy.pojo.ProxyFactoryHelper.validateGetterSetterMethodProxyability(ProxyFactoryHelper.java:80)
	at org.hibernate.metamodel.internal.EntityRepresentationStrategyPojoStandard.createProxyFactory(EntityRepresentationStrategyPojoStandard.java:229)
	at org.hibernate.metamodel.internal.EntityRepresentationStrategyPojoStandard.<init>(EntityRepresentationStrategyPojoStandard.java:147)
	at org.hibernate.metamodel.internal.ManagedTypeRepresentationResolverStandard.resolveStrategy(ManagedTypeRepresentationResolverStandard.java:62)
	at org.hibernate.persister.entity.AbstractEntityPersister.<init>(AbstractEntityPersister.java:510)
	at org.hibernate.persister.entity.SingleTableEntityPersister.<init>(SingleTableEntityPersister.java:140)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:92)
	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:75)
	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.processBootEntities(MappingMetamodelImpl.java:247)
	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.finishInitialization(MappingMetamodelImpl.java:185)
	at org.hibernate.internal.SessionFactoryImpl.initializeMappingModel(SessionFactoryImpl.java:321)
	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:271)
	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:84)
	at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:74)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:80)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:55)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:156)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:64)
	at java.base/java.lang.Thread.run(Thread.java:833)
```


**Check list**:

Your pull request:

- [ X ] targets the `development` branch
- [ X ] uses the `999-SNAPSHOT` version of Quarkus
- [ X ] has tests (`mvn clean test`)
- [ X ] works in native (`mvn clean package -Pnative`)
- [ X ] has integration/native tests (`mvn clean verify -Pnative`)
- [ X ] makes sure the associated guide must not be updated
- [ X ] links the guide update pull request (if needed)
- [ X ] updates or creates the `README.md` file (with build and run instructions)
- [ X ] for new quickstart, is located in the directory _component-quickstart_
- [ X ] for new quickstart, is added to the root `pom.xml` and `README.md`


