### PR TITLE
Remove Kogito from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ See [CONTRIBUTING](CONTRIBUTING.md) for how to build these examples.
 * [Kafka and Hibernate Reactive with Panache](./kafka-panache-reactive-quickstart): Shows how to combine Kafka and Hibernate Reactive with Panache
 * [Kafka Streams](./kafka-streams-quickstart): Use the Apache Kafka Streams API to implement stream processing applications based on Apache Kafka
 * [Bare Kafka](./kafka-bare-quickstart): How to use the Apache Kafka and Kafka Vert.x clients in Quarkus
-* [Kogito](./kogito-quickstart): How to use Kogito for business process automation with Drools and jBPM
-* [Kogito](./kogito-dmn-quickstart): How to use Kogito for decision automation with Drools DMN Engine
 * [Liquibase](./liquibase-quickstart): How to use Liquibase to manage you schema migrations
 * [Liquibase MongoDB](./liquibase-mongodb-quickstart): How to use Liquibase MongoDB extension to manage you MongoDB migrations
 * [Micrometer](./micrometer-quickstart): How to use Micrometer to gather metrics


### PR DESCRIPTION
There are no more kogito examples in this repo, so references have been removed.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- ~uses the `999-SNAPSHOT` version of Quarkus~
- ~has tests (`mvn clean test`)~
- ~works in native (`mvn clean package -Pnative`)~
- ~has integration/native tests (`mvn clean verify -Pnative`)~
- ~makes sure the associated guide must not be updated~
- ~links the guide update pull request (if needed)~
- [x] updates or creates the `README.md` file (with build and run instructions)
- ~for new quickstart, is located in the directory _component-quickstart_~
- ~for new quickstart, is added to the root `pom.xml` and `README.md`~


