### PR TITLE
Fix jaeger exporter config in otel-quickstart docker compose setup

### DIFF
--- a/opentelemetry-quickstart/otel-collector-config.yaml
+++ b/opentelemetry-quickstart/otel-collector-config.yaml
@@ -9,8 +9,8 @@ receivers:
         endpoint: otel-collector:55680
 
 exporters:
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
+  otlp/jaeger: # Jaeger supports OTLP directly. The default port for OTLP/gRPC is 4317
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 
@@ -26,5 +26,5 @@ service:
     traces:
       receivers: [otlp,otlp/2]
       processors: [batch]
-      exporters: [jaeger]
+      exporters: [otlp/jaeger]
 


### PR DESCRIPTION
Fixes:
- `docker compose up -d`
- `docker logs -f otel-collector`
- > opentelemetry-quickstart-otel-collector-1  | * error decoding 'exporters': unknown type: "jaeger" for id: "jaeger" (valid values: [prometheusremotewrite zipkin debug logging otlphttp kafka prometheus otlp file opencensus])

See also: https://opentelemetry.io/blog/2023/jaeger-exporter-collector-migration/#switch-to-otlp-exporter

