### PR TITLE
getting-started: Clean up s2i/environment

### DIFF
--- a/getting-started/.s2i/environment
+++ b/getting-started/.s2i/environment
@@ -1,2 +1,1 @@
 JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
-AB_JOLOKIA_OFF=true

--- a/getting-started/.s2i/environment
+++ b/getting-started/.s2i/environment
@@ -1,1 +1,1 @@
-JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+JAVA_OPTS_APPEND=-Dquarkus.http.host=0.0.0.0

--- a/getting-started/.s2i/environment
+++ b/getting-started/.s2i/environment
@@ -1,5 +1,2 @@
-MAVEN_S2I_ARTIFACT_DIRS=target/quarkus-app
-S2I_SOURCE_DEPLOYMENTS_FILTER=app lib quarkus quarkus-run.jar
 JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
 AB_JOLOKIA_OFF=true
-JAVA_APP_JAR=/deployments/quarkus-run.jar


### PR DESCRIPTION
Here we remove some environment  variable definitions from `.s2i/environment` which used to be necessary for the Red Hat OpenJDK container images to work correctly with the default Quarkus "fast-jar" package type. The drawback of defining these variables is that the quickstart now only works for the fast-jar layout, and would break if the user specifies another via QUARKUS_PACKAGE_TYPE, unless they realise `.s2i/environment` (a hidden file) exists, and either alter it or override the other variables within.

The RH OpenJDK container image works with fast-jar OOTB since :1.17 (2023-08-28).

Whilst I was in there, I removed `AB_JOLOKIA_OFF`, which is not needed for the JDK17 or JDK21 images; and changed `JAVA_OPTIONS` to `JAVA_OPTS_APPEND`, which I think has the desired semantics. That last change in particular I would like some feedback on:

 * is the intention really to append to, and not override, the container run script's JVM tuning? (I'd recommend appending)
 * do you still need/want to specify `-Dquarkus.http.host=0.0.0.0`? If not, we could delete the file entirely, which would be nice because it's not very discoverable
 * are you concerned with any *other* containers or run scripts in an S2I context, besides the RH OpenJDK images?

**Check list**:

Your pull request:

- [X] targets the `development` branch
- [X] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [X] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- <s>[ ] updates or creates the `README.md` file (with build and run instructions)</s> *N/A*
- <s>[ ] for new quickstart, is located in the directory _component-quickstart_</s> *N/A*
- <s>[ ] for new quickstart, is added to the root `pom.xml` and `README.md`</s> *N/A*


