### PR TITLE
Fix broken funqy gcp http link in Quickstarts

### DIFF
--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/README.md
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/README.md
@@ -1,1 +1,1 @@
-Quarkus guide: https://quarkus.io/guides/funqy-google-cloud-functions-http
+Quarkus guide: https://quarkus.io/guides/funqy-gcp-functions-http


### PR DESCRIPTION
**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


