### PR TITLE
Fix links to GraphQL guides

### DIFF
--- a/microprofile-graphql-client-quickstart/README.md
+++ b/microprofile-graphql-client-quickstart/README.md
@@ -1,1 +1,1 @@
-Quarkus guide: https://quarkus.io/guides/microprofile-graphql-client
+Quarkus guide: https://quarkus.io/guides/smallrye-graphql-client

--- a/microprofile-graphql-quickstart/README.md
+++ b/microprofile-graphql-quickstart/README.md
@@ -1,1 +1,1 @@
-Quarkus guide: https://quarkus.io/guides/microprofile-graphql
+Quarkus guide: https://quarkus.io/guides/smallrye-graphql


### PR DESCRIPTION
https://quarkus.io/guides/microprofile-graphql somehow works and redirects to https://quarkus.io/guides/smallrye-graphql, but https://quarkus.io/guides/microprofile-graphql-client doesn't work at all. Let's unify both on the `smallrye` variant