### PR TITLE
Update Dockerfiles to install JDK 17 on Development branch

### DIFF
--- a/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-kms-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-kms-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-kms-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-kms-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-s3-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-s3-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-s3-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-s3-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-ses-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-ses-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-ses-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-ses-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-sns-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sns-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-sns-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sns-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-sqs-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sqs-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-sqs-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sqs-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-ssm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-ssm-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amazon-ssm-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-ssm-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amqp-quickstart/amqp-quickstart-processor/src/main/docker/Dockerfile.jvm
+++ b/amqp-quickstart/amqp-quickstart-processor/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amqp-quickstart/amqp-quickstart-processor/src/main/docker/Dockerfile.legacy-jar
+++ b/amqp-quickstart/amqp-quickstart-processor/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amqp-quickstart/amqp-quickstart-producer/src/main/docker/Dockerfile.jvm
+++ b/amqp-quickstart/amqp-quickstart-producer/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/amqp-quickstart/amqp-quickstart-producer/src/main/docker/Dockerfile.legacy-jar
+++ b/amqp-quickstart/amqp-quickstart-producer/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/awt-graphics-rest-quickstart/README.md
+++ b/awt-graphics-rest-quickstart/README.md
@@ -32,7 +32,7 @@ in native mode with:
 ```bash
 ./mvnw clean verify -Pnative
 ```
-To run native tests locally, a JDK 11.0.13+ with Mandrel (or GraalVM) 21.3+ is required.
+To run native tests locally, a JDK 17+ with Mandrel (or GraalVM) 21.3+ is required.
 Additionally, `freetype-devel` and `fontconfig` libraries must be installed. 
 
 # What the result looks like

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.jvm
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/awt-graphics-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/cache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/cache-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/cache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/cache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/config-quickstart/src/main/docker/Dockerfile.jvm
+++ b/config-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/config-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/config-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/context-propagation-quickstart/README.md
+++ b/context-propagation-quickstart/README.md
@@ -4,15 +4,15 @@
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 - Docker (and Docker Compose)
 - httpie (or curl)
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/context-propagation-quickstart/src/main/docker/Dockerfile.jvm
+++ b/context-propagation-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/context-propagation-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/context-propagation-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/funqy-quickstarts/funqy-http-quickstart/src/main/docker/Dockerfile.jvm
+++ b/funqy-quickstarts/funqy-http-quickstart/src/main/docker/Dockerfile.jvm
@@ -16,7 +16,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.5
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/funqy-quickstarts/funqy-knative-events-quickstart/src/main/docker/Dockerfile.jvm
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/src/main/docker/Dockerfile.jvm
@@ -16,7 +16,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.5
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/getting-started-async/src/main/docker/Dockerfile.jvm
+++ b/getting-started-async/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-async/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-async/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-command-mode/README.md
+++ b/getting-started-command-mode/README.md
@@ -10,13 +10,13 @@ Under the hood, this demo uses:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image-guide)
 for help setting up your environment.

--- a/getting-started-command-mode/src/main/docker/Dockerfile.jvm
+++ b/getting-started-command-mode/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-command-mode/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-command-mode/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-dev-services/README.md
+++ b/getting-started-dev-services/README.md
@@ -13,13 +13,13 @@ Under the hood, this demo uses:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - A container runtime, such as Docker or Podman
 
-### Configuring JDK 11+
+### Configuring JDK 17+
 
 Make sure that the `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 ### Live coding with Quarkus
 

--- a/getting-started-knative/src/main/docker/Dockerfile.jvm
+++ b/getting-started-knative/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-knative/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-knative/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-reactive-crud/src/main/docker/Dockerfile.jvm
+++ b/getting-started-reactive-crud/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-reactive-crud/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-reactive-crud/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-reactive/README.md
+++ b/getting-started-reactive/README.md
@@ -11,13 +11,13 @@ Under the hood, this demo uses:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image-guide)
 for help setting up your environment.

--- a/getting-started-reactive/src/main/docker/Dockerfile.jvm
+++ b/getting-started-reactive/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-reactive/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-reactive/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-testing/src/main/docker/Dockerfile.jvm
+++ b/getting-started-testing/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started-testing/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-testing/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -11,13 +11,13 @@ Under the hood, this demo uses:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image-guide)
 for help setting up your environment.

--- a/getting-started/src/main/docker/Dockerfile.jvm
+++ b/getting-started/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/getting-started/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.jvm
+++ b/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/google-cloud-functions-quickstart/src/main/docker/Dockerfile.jvm
+++ b/google-cloud-functions-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/google-cloud-functions-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/google-cloud-functions-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/grpc-plain-text-quickstart/src/main/docker/Dockerfile.jvm
+++ b/grpc-plain-text-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/grpc-plain-text-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/grpc-plain-text-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/grpc-tls-quickstart/src/main/docker/Dockerfile.jvm
+++ b/grpc-tls-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/grpc-tls-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/grpc-tls-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-multi-tenancy-quickstart/README.md
+++ b/hibernate-orm-multi-tenancy-quickstart/README.md
@@ -8,15 +8,15 @@ When serving multiple customers from a same application (e.g.: SaaS), each custo
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-orm-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-panache-kotlin-quickstart/README.md
+++ b/hibernate-orm-panache-kotlin-quickstart/README.md
@@ -16,15 +16,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-panache-quickstart/README.md
+++ b/hibernate-orm-panache-quickstart/README.md
@@ -16,15 +16,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-quickstart/README.md
+++ b/hibernate-orm-quickstart/README.md
@@ -16,15 +16,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-rest-data-panache-quickstart/README.md
+++ b/hibernate-orm-rest-data-panache-quickstart/README.md
@@ -12,15 +12,15 @@ Under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-panache-quickstart/README.md
+++ b/hibernate-reactive-panache-quickstart/README.md
@@ -13,15 +13,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-quickstart/README.md
+++ b/hibernate-reactive-quickstart/README.md
@@ -13,15 +13,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-routes-quickstart/README.md
+++ b/hibernate-reactive-routes-quickstart/README.md
@@ -13,15 +13,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-stateless-quickstart/README.md
+++ b/hibernate-reactive-stateless-quickstart/README.md
@@ -14,15 +14,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-search-orm-elasticsearch-quickstart/README.md
+++ b/hibernate-search-orm-elasticsearch-quickstart/README.md
@@ -17,15 +17,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.q
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/jms-quickstart/src/main/docker/Dockerfile.jvm
+++ b/jms-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/jms-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/jms-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-quickstart/processor/src/main/docker/Dockerfile.jvm
+++ b/kafka-quickstart/processor/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-quickstart/processor/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-quickstart/processor/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-quickstart/producer/src/main/docker/Dockerfile.jvm
+++ b/kafka-quickstart/producer/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-quickstart/producer/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-quickstart/producer/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-streams-quickstart/aggregator/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/aggregator/src/main/docker/Dockerfile.jvm
@@ -16,7 +16,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.5
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/kafka-streams-quickstart/producer/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/producer/src/main/docker/Dockerfile.jvm
@@ -16,7 +16,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.5
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/kafka-streams-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/kafka-streams-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-streams-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/liquibase-quickstart/src/main/docker/Dockerfile.jvm
+++ b/liquibase-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/liquibase-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/liquibase-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mailer-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mailer-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mailer-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mailer-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/micrometer-quickstart/src/main/docker/Dockerfile.jvm
+++ b/micrometer-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/micrometer-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/micrometer-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-graphql-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-graphql-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-graphql-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-graphql-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-metrics-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-metrics-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/microprofile-metrics-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-metrics-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mongodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mqtt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/mqtt-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/neo4j-quickstart/src/main/docker/Dockerfile.jvm
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/neo4j-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/opentelemetry-quickstart/src/main/docker/Dockerfile.jvm
+++ b/opentelemetry-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/opentelemetry-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/opentelemetry-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/optaplanner-quickstart/src/main/docker/Dockerfile.jvm
+++ b/optaplanner-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/optaplanner-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/optaplanner-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/pulsar-quickstart/pulsar-quickstart-processor/src/main/docker/Dockerfile.jvm
+++ b/pulsar-quickstart/pulsar-quickstart-processor/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/pulsar-quickstart/pulsar-quickstart-processor/src/main/docker/Dockerfile.legacy-jar
+++ b/pulsar-quickstart/pulsar-quickstart-processor/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/pulsar-quickstart/pulsar-quickstart-producer/src/main/docker/Dockerfile.jvm
+++ b/pulsar-quickstart/pulsar-quickstart-producer/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/pulsar-quickstart/pulsar-quickstart-producer/src/main/docker/Dockerfile.legacy-jar
+++ b/pulsar-quickstart/pulsar-quickstart-producer/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/quartz-quickstart/README.md
+++ b/quartz-quickstart/README.md
@@ -7,15 +7,15 @@ It exposes a REST API `tasks` to visualize the executed jobs which run every 10 
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/quartz-quickstart/src/main/docker/Dockerfile.jvm
+++ b/quartz-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/quartz-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/quartz-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/qute-quickstart/src/main/docker/Dockerfile.jvm
+++ b/qute-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/qute-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/qute-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/main/docker/Dockerfile.jvm
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/main/docker/Dockerfile.legacy-jar
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/src/main/docker/Dockerfile.jvm
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/src/main/docker/Dockerfile.legacy-jar
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/reactive-messaging-http-quickstart/src/main/docker/Dockerfile.jvm
+++ b/reactive-messaging-http-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/reactive-messaging-http-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/reactive-messaging-http-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/reactive-messaging-websockets-quickstart/src/main/docker/Dockerfile.fast-jar
+++ b/reactive-messaging-websockets-quickstart/src/main/docker/Dockerfile.fast-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/reactive-messaging-websockets-quickstart/src/main/docker/Dockerfile.jvm
+++ b/reactive-messaging-websockets-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/reactive-messaging-websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/reactive-messaging-websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
+++ b/reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/redis-quickstart/README.md
+++ b/redis-quickstart/README.md
@@ -11,15 +11,15 @@ While the code is surprisingly simple, under the hood this is using:
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a Redis database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/redis-quickstart/src/main/docker/Dockerfile.jvm
+++ b/redis-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/redis-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/redis-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/rest-json-quickstart/src/main/docker/Dockerfile.jvm
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/rest-json-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
+++ b/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/resteasy-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/resteasy-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/resteasy-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/resteasy-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/scheduler-quickstart/src/main/docker/Dockerfile.jvm
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/scheduler-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jpa-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jpa-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-keycloak-authorization-quickstart/README.md
+++ b/security-keycloak-authorization-quickstart/README.md
@@ -24,14 +24,14 @@ By using this example, you'll see that your application is completely decoupled 
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 - Keycloak
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-ldap-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-ldap-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-ldap-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-ldap-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-multi-tenancy-quickstart/README.md
+++ b/security-openid-connect-multi-tenancy-quickstart/README.md
@@ -8,14 +8,14 @@ When serving multiple customers from a same application (e.g.: SaaS), each custo
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 - Keycloak
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-web-authentication-quickstart/README.md
+++ b/security-openid-connect-web-authentication-quickstart/README.md
@@ -14,14 +14,14 @@ Once authenticated, the applications establishes a local session based on the in
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 - Keycloak
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/software-transactional-memory-quickstart/src/main/docker/Dockerfile.jvm
+++ b/software-transactional-memory-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/software-transactional-memory-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/software-transactional-memory-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-boot-properties-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-boot-properties-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-boot-properties-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-boot-properties-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-data-jpa-quickstart/README.md
+++ b/spring-data-jpa-quickstart/README.md
@@ -4,15 +4,15 @@
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/spring-data-jpa-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-data-jpa-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-data-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-data-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-data-rest-quickstart/README.md
+++ b/spring-data-rest-quickstart/README.md
@@ -4,15 +4,15 @@
 
 To compile and run this demo you will need:
 
-- JDK 11+
+- JDK 17+
 - GraalVM
 
 In addition, you will need either a PostgreSQL database, or Docker to run one.
 
-### Configuring GraalVM and JDK 11+
+### Configuring GraalVM and JDK 17+
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 11+ `java` command is on the path.
+been set, and that a JDK 17+ `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.fast-jar
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.fast-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-di-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-di-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-scheduled-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-scheduled-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-scheduled-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-scheduled-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-security-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-security-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-web-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/spring-web-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/tests-with-coverage-quickstart/README.md
+++ b/tests-with-coverage-quickstart/README.md
@@ -13,7 +13,7 @@ Please note that code coverage is not supported in native mode.
 
 You need:
 
-* JDK 11+ installed with JAVA_HOME configured appropriately
+* JDK 17+ installed with JAVA_HOME configured appropriately
 * Apache Maven 3.5.3+
 
 This way, the ```QuarkusTest``` instances will be executed as part of the ```integration-test``` build phase while the other JUnit tests will still be ran during the ```test``` phase.

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/tika-quickstart/src/main/docker/Dockerfile.jvm
+++ b/tika-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/tika-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/tika-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/validation-quickstart/src/main/docker/Dockerfile.jvm
+++ b/validation-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/validation-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/validation-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/vertx-quickstart/src/main/docker/Dockerfile.jvm
+++ b/vertx-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/vertx-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/vertx-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/websockets-quickstart/src/main/docker/Dockerfile.jvm
+++ b/websockets-quickstart/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script


### PR DESCRIPTION
Container images built with the current Dockerfiles do not run from the development branch. 
The quickstarts are compiled against JDK17, while the Dockerfiles install JDK11 in the images

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] updates or creates the `README.md` file (with build and run instructions)


