### PR TITLE
Use MCF & bcrypt password mapper for securityjdbc-quickstart

### DIFF
--- a/security-jdbc-quickstart/README.md
+++ b/security-jdbc-quickstart/README.md
@@ -38,9 +38,9 @@ Here you have some examples to check the security configuration:
 ```bash
 curl -i -X GET http://localhost:8080/api/public  # 'public'
 curl -i -X GET http://localhost:8080/api/admin  # unauthorized
-curl -i -X GET -u admin:admin http://localhost:8080/api/admin # 'admin'
+curl -i -X GET -u admin:password http://localhost:8080/api/admin # 'admin'
 curl -i -X GET http://localhost:8080/api/users/me # 'unauthorized'
-curl -i -X GET -u user:user http://localhost:8080/api/users/me # 'user'
+curl -i -X GET -u user:password http://localhost:8080/api/users/me # 'user'
 ```
 
 _NOTE:_ Stop the database using: `docker-compose down; docker-compose rm`

--- a/security-jdbc-quickstart/import.sql
+++ b/security-jdbc-quickstart/import.sql
@@ -10,5 +10,5 @@ CREATE TABLE test_user (
     role VARCHAR(255)
 );
 GRANT ALL PRIVILEGES ON TABLE  test_user TO quarkus;
-INSERT INTO test_user (id, username, password, role) VALUES (1, 'admin', 'admin', 'admin');
-INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','user', 'user');
+INSERT INTO test_user (id, username, password, role) VALUES (1, 'admin', '$2a$10$Uc.SZ0hvGJQlYdsAp7be1.lFjmOnc7aAr4L0YY3/VN3oK.F8zJHRG', 'admin');
+INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','$2a$10$Uc.SZ0hvGJQlYdsAp7be1.lFjmOnc7aAr4L0YY3/VN3oK.F8zJHRG', 'user');

--- a/security-jdbc-quickstart/src/main/resources/application.properties
+++ b/security-jdbc-quickstart/src/main/resources/application.properties
@@ -5,8 +5,10 @@ quarkus.datasource.db-kind=postgresql
 
 quarkus.security.jdbc.enabled=true
 quarkus.security.jdbc.principal-query.sql=SELECT u.password, u.role FROM test_user u WHERE u.username=?
-quarkus.security.jdbc.principal-query.clear-password-mapper.enabled=true
-quarkus.security.jdbc.principal-query.clear-password-mapper.password-index=1
+quarkus.security.jdbc.principal-query.bcrypt-password-mapper.enabled=true
+quarkus.security.jdbc.principal-query.bcrypt-password-mapper.password-index=1
+quarkus.security.jdbc.principal-query.bcrypt-password-mapper.salt-index=-1
+quarkus.security.jdbc.principal-query.bcrypt-password-mapper.iteration-count-index=-1
 quarkus.security.jdbc.principal-query.attribute-mappings.0.index=2
 quarkus.security.jdbc.principal-query.attribute-mappings.0.to=groups
 

--- a/security-jdbc-quickstart/src/test/java/org/acme/security/jdbc/JdbcSecurityRealmTest.java
+++ b/security-jdbc-quickstart/src/test/java/org/acme/security/jdbc/JdbcSecurityRealmTest.java
@@ -38,7 +38,7 @@ public class JdbcSecurityRealmTest {
     @Order(3)
     void shouldAccessAdminWhenAdminAuthenticated() {
         given()
-                .auth().preemptive().basic("admin", "admin")
+                .auth().preemptive().basic("admin", "password")
                 .when()
                 .get("/api/admin")
                 .then()
@@ -50,7 +50,7 @@ public class JdbcSecurityRealmTest {
     @Order(4)
     void shouldNotAccessUserWhenAdminAuthenticated() {
         given()
-                .auth().preemptive().basic("admin", "admin")
+                .auth().preemptive().basic("admin", "password")
                 .when()
                 .get("/api/users/me")
                 .then()
@@ -61,7 +61,7 @@ public class JdbcSecurityRealmTest {
     @Order(5)
     void shouldAccessUserAndGetIdentityWhenUserAuthenticated() {
         given()
-                .auth().preemptive().basic("user", "user")
+                .auth().preemptive().basic("user", "password")
                 .when()
                 .get("/api/users/me")
                 .then()

--- a/security-jdbc-quickstart/src/test/resources/test_user.sql
+++ b/security-jdbc-quickstart/src/test/resources/test_user.sql
@@ -5,5 +5,5 @@ CREATE TABLE test_user (
     role VARCHAR(255)
 );
 
-INSERT INTO test_user (id, username, password, role) VALUES (1, 'admin', 'admin', 'admin');
-INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','user', 'user');
+INSERT INTO test_user (id, username, password, role) VALUES (1, 'admin', '$2a$10$Uc.SZ0hvGJQlYdsAp7be1.lFjmOnc7aAr4L0YY3/VN3oK.F8zJHRG', 'admin');
+INSERT INTO test_user (id, username, password, role) VALUES (2, 'user', '$2a$10$Uc.SZ0hvGJQlYdsAp7be1.lFjmOnc7aAr4L0YY3/VN3oK.F8zJHRG', 'user');


### PR DESCRIPTION
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [x] for new quickstart, is located in the directory _component-quickstart_
- [x] for new quickstart, is added to the root `pom.xml` and `README.md`


