### PR TITLE
Update versions of Amazon tools to make them work on Java 21

### DIFF
--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.5.2</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.12.2</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.5.2</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.12.2</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.5.2</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.12.2</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.5.2</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.12.2</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.5.2</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.12.2</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -16,8 +16,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.5.2</quarkus-amazon-services.version>
-        <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
+        <quarkus-amazon-services.version>2.12.2</quarkus-amazon-services.version>
+        <awssdk.testcontainers.version>1.12.694</awssdk.testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
+++ b/amazon-sqs-quickstart/src/test/java/org/acme/sqs/SqsResource.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 public class SqsResource implements QuarkusTestResourceLifecycleManager {
 
     private static final DockerImageName LOCALSTACK_IMAGE_NAME = DockerImageName.parse("localstack/localstack")
-            .withTag("0.12.17");
+            .withTag("3.3");
 
     public final static String QUEUE_NAME = "Quarkus";
 

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus-amazon-services.version>2.5.2</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.12.2</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 


### PR DESCRIPTION
Older versions hang, see https://github.com/quarkusio/quarkus-quickstarts/issues/1406
Also update localstack for SQS, otherwise it fails during connection


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


