### PR TITLE
Fix the OIDC tenancy test

### DIFF
--- a/security-openid-connect-multi-tenancy-quickstart/src/main/java/org/acme/quickstart/oidc/CustomTenantResolver.java
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/java/org/acme/quickstart/oidc/CustomTenantResolver.java
@@ -8,6 +8,7 @@ import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -17,7 +18,7 @@ public class CustomTenantResolver implements TenantConfigResolver {
     @Override 
     public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
         String path = context.request().path();
-        
+
         if (path.startsWith("/tenant-a")) {
         
 	        String keycloakUrl = ConfigProvider.getConfig().getValue("keycloak.url", String.class);
@@ -30,7 +31,7 @@ public class CustomTenantResolver implements TenantConfigResolver {
 	        config.setApplicationType(ApplicationType.HYBRID);
 	        return Uni.createFrom().item(config);
         } else {
-        	// resolve to default tenant config
+            context.put(OidcUtils.TENANT_ID_ATTRIBUTE, OidcUtils.DEFAULT_TENANT_ID);
             return Uni.createFrom().nullItem();
         }
     }

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # Default Tenant Configuration
 %prod.keycloak.url=http://localhost:8180
-%prodquarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+%prod.quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=multi-tenant-client
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app

--- a/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
+++ b/security-openid-connect-multi-tenancy-quickstart/src/test/java/org/acme/quickstart/oidc/CodeFlowTest.java
@@ -20,7 +20,7 @@ import io.restassured.RestAssured;
 @QuarkusTest
 public class CodeFlowTest {
 
-	KeycloakTestClient keycloakClient = new KeycloakTestClient();
+    KeycloakTestClient keycloakClient = new KeycloakTestClient();
 	
     @Test
     public void testLogInDefaultTenant() throws IOException {
@@ -37,6 +37,8 @@ public class CodeFlowTest {
             page = loginForm.getInputByName("login").click();
 
             assertTrue(page.asText().contains("tenant"));
+
+            webClient.getCookieManager().clearCookies();
         }
     }
 
@@ -55,6 +57,7 @@ public class CodeFlowTest {
             page = loginForm.getInputByName("login").click();
 
             assertTrue(page.asText().contains("alice@tenant-a.org"));
+            webClient.getCookieManager().clearCookies();
         }
     }
     
@@ -96,6 +99,8 @@ public class CodeFlowTest {
             page = loginForm.getInputByName("login").click();
 
             assertTrue(page.asText().contains("alice@keycloak.org"));
+
+            webClient.getCookieManager().clearCookies();
         }
     }
 

--- a/security-openid-connect-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-quickstart/src/main/resources/application.properties
@@ -4,7 +4,6 @@
 quarkus.oidc.client-id=backend-service
 quarkus.oidc.credentials.secret=secret
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
-quarkus.keycloak.devservices.grant.type=client
 
 # DEBUG console logging
 quarkus.log.console.enable=true

--- a/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties
@@ -5,6 +5,6 @@ quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app
 quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
-quarkus.http.auth.permission.public.paths=/q/dev/*
+quarkus.http.auth.permission.public.paths=/q*
 quarkus.http.auth.permission.public.policy=permit
 quarkus.log.category."com.gargoylesoftware.htmlunit.DefaultCssErrorHandler".level=ERROR


### PR DESCRIPTION
This PR fixes the test failure spotted in #1402 and fixes minor issues with other security quickstarts (client grant for the oidc quickstart was added by mistake, our tutorial does not know about it). I'll rerun #1402 later