### PR TITLE
Upgrade tika to 2.0.3 in 3.8 branch

### DIFF
--- a/tika-quickstart/pom.xml
+++ b/tika-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <quarkus-tika.version>2.0.2</quarkus-tika.version>
+        <quarkus-tika.version>2.0.3</quarkus-tika.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Otherwise, it fails in Native mode
See https://github.com/quarkiverse/quarkus-tika/pull/169 for details Backport of https://github.com/quarkusio/quarkus-quickstarts/commit/aa095b4e1a160ca013959dbb3d6fbb7200789e3e


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


