### PR TITLE
Fix spring-data-rest quickstart as spring-data-rest extension move to SB3

### DIFF
--- a/spring-data-rest-quickstart/src/main/java/org/acme/spring/data/rest/FruitsRepository.java
+++ b/spring-data-rest-quickstart/src/main/java/org/acme/spring/data/rest/FruitsRepository.java
@@ -1,6 +1,6 @@
 package org.acme.spring.data.rest;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FruitsRepository extends PagingAndSortingRepository<Fruit, Long> {
+public interface FruitsRepository extends JpaRepository<Fruit, Long> {
 }


### PR DESCRIPTION
As `spring-data-rest extension` was moved to Spring Boot 3 the quickstart `spring-data-rest` quickstart no longer work. Caused by `PagingAndSortingRepository` no longer extend `CrudRepository`. The [guide](https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/spring-data-rest.adoc#define-the-repository) show the usage of `CrudRepository`, which working.

Otherwise if you want I can adapt it to 

```
public interface FruitsRepository extends JpaRepository<Fruit, Long> {
}
```
or 
```
public interface FruitsRepository extends PagingAndSortingRepository<Fruit, Long>, CrudRepository<Fruit, Long> {
}
```

The `JpaRepository` extend the `CrudRepository` and `PagingAndSortingRepository` stop extending the `CrudRepository`.

I don't have strong preferences about this.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


