### PR TITLE
Rename quarkus-webjars-locator to quarkus-web-dependency-locator

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -104,7 +104,7 @@
     <!-- UI -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-webjars-locator</artifactId>
+      <artifactId>quarkus-web-dependency-locator</artifactId>
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>


### PR DESCRIPTION
The `quarkus-webjars-locator` was renamed to `quarkus-web-dependency-locator`. See [https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.11#webjar-locator-extension-renamed-to-web-dependency-locator](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.11#webjar-locator-extension-renamed-to-web-dependency-locator)

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


