### PR TITLE
Update deprecated `@QuarkusTestResource` to `@WithTestResource`

### DIFF
--- a/context-propagation-quickstart/src/test/java/org/acme/context/prices/PriceIT.java
+++ b/context-propagation-quickstart/src/test/java/org/acme/context/prices/PriceIT.java
@@ -1,10 +1,10 @@
 package org.acme.context.prices;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KafkaResource.class)
+@WithTestResource(KafkaResource.class)
 public class PriceIT extends PriceTest {
 
 }

--- a/context-propagation-quickstart/src/test/java/org/acme/context/prices/PriceTest.java
+++ b/context-propagation-quickstart/src/test/java/org/acme/context/prices/PriceTest.java
@@ -15,13 +15,13 @@ import org.acme.context.Price;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaResource.class)
+@WithTestResource(KafkaResource.class)
 public class PriceTest {
 
     private static final String PRICES_SSE_ENDPOINT = "http://localhost:8081/prices";

--- a/jms-quickstart/src/test/java/org/acme/jms/PriceTest.java
+++ b/jms-quickstart/src/test/java/org/acme/jms/PriceTest.java
@@ -5,14 +5,14 @@ import static org.awaitility.Awaitility.await;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 import java.time.Duration;
 
 @QuarkusTest
-@QuarkusTestResource(ArtemisTestResource.class)
+@WithTestResource(ArtemisTestResource.class)
 public class PriceTest {
 
     @Test

--- a/kafka-panache-quickstart/src/test/java/org/acme/panache/PriceResourceTest.java
+++ b/kafka-panache-quickstart/src/test/java/org/acme/panache/PriceResourceTest.java
@@ -1,6 +1,5 @@
 package org.acme.panache;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 

--- a/kafka-panache-reactive-quickstart/src/test/java/org/acme/panache/PriceResourceTest.java
+++ b/kafka-panache-reactive-quickstart/src/test/java/org/acme/panache/PriceResourceTest.java
@@ -1,6 +1,5 @@
 package org.acme.panache;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/AggregatorIT.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/AggregatorIT.java
@@ -4,7 +4,7 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 /**
  * Native tests execute with prod profile, not test. cf https://github.com/quarkusio/quarkus/issues/4371
- * Since we extend the Hotspot tests and share the QuarkusTestResource,
+ * Since we extend the Hotspot tests and share the WithTestResource,
  * this means broker test port MUST be the same as production port.
  */
 @QuarkusIntegrationTest

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/AggregatorTest.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/AggregatorTest.java
@@ -33,14 +33,14 @@ import org.junit.jupiter.api.Timeout;
 
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
  * Integration testing of the application with an embedded broker.
  */
 @QuarkusTest
-@QuarkusTestResource(KafkaResource.class)
+@WithTestResource(KafkaResource.class)
 public class AggregatorTest {
 
     KafkaProducer<Integer, String> temperatureProducer;

--- a/mongodb-panache-quickstart/src/test/java/org/acme/mongodb/panache/PersonResourceTest.java
+++ b/mongodb-panache-quickstart/src/test/java/org/acme/mongodb/panache/PersonResourceTest.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
@@ -23,7 +23,7 @@ import io.restassured.http.ContentType;
 import io.restassured.parsing.Parser;
 
 @QuarkusTest
-@QuarkusTestResource(MongoDbResource.class)
+@WithTestResource(MongoDbResource.class)
 class PersonResourceTest {
 
     @BeforeAll

--- a/mongodb-quickstart/src/test/java/org/acme/mongodb/FruitResourceTest.java
+++ b/mongodb-quickstart/src/test/java/org/acme/mongodb/FruitResourceTest.java
@@ -1,6 +1,6 @@
 package org.acme.mongodb;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import org.apache.http.HttpStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,7 +12,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(MongoDbResource.class)
+@WithTestResource(MongoDbResource.class)
 public class FruitResourceTest {
 
     @ParameterizedTest

--- a/neo4j-quickstart/src/test/java/org/acme/neo4j/FruitsEndpointTest.java
+++ b/neo4j-quickstart/src/test/java/org/acme/neo4j/FruitsEndpointTest.java
@@ -14,11 +14,11 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(Neo4jResource.class)
+@WithTestResource(Neo4jResource.class)
 class FruitsEndpointTest {
 
     private static final Map<String, String> fruitIdMap = new HashMap<>();

--- a/optaplanner-quickstart/src/test/java/org/acme/optaplanner/TestResources.java
+++ b/optaplanner-quickstart/src/test/java/org/acme/optaplanner/TestResources.java
@@ -1,9 +1,9 @@
 package org.acme.optaplanner;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 
 }

--- a/rest-client-quickstart/src/test/java/org/acme/rest/client/ExtensionsResourceTest.java
+++ b/rest-client-quickstart/src/test/java/org/acme/rest/client/ExtensionsResourceTest.java
@@ -1,6 +1,6 @@
 package org.acme.rest.client;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 import org.acme.rest.client.resources.WireMockExtensions;
@@ -12,7 +12,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockExtensions.class)
+@WithTestResource(WireMockExtensions.class)
 public class ExtensionsResourceTest {
 
     @Test

--- a/resteasy-client-quickstart/src/test/java/org/acme/rest/client/ExtensionsResourceTest.java
+++ b/resteasy-client-quickstart/src/test/java/org/acme/rest/client/ExtensionsResourceTest.java
@@ -8,11 +8,11 @@ import static org.hamcrest.Matchers.greaterThan;
 import org.acme.rest.client.resources.WireMockExtensions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockExtensions.class)
+@WithTestResource(WireMockExtensions.class)
 public class ExtensionsResourceTest {
 
     @Test

--- a/security-ldap-quickstart/pom.xml
+++ b/security-ldap-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>3.2.9.Final</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest</artifactId>
+      <artifactId>quarkus-resteasy-reactive</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceTest.java
+++ b/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceTest.java
@@ -1,6 +1,6 @@
 package org.acme.security.oauth2;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@QuarkusTestResource(MockAuthorizationServerTestResource.class)
+@WithTestResource(MockAuthorizationServerTestResource.class)
 class TokenSecuredResourceTest {
     // use whatever token you want as the mock OAuth server will accept all tokens
     private static final String BEARER_TOKEN = "337aab0f-b547-489b-9dbd-a54dc7bdf20d";

--- a/stork-dns-quickstart/src/test/java/org/acme/FrontendApiIT.java
+++ b/stork-dns-quickstart/src/test/java/org/acme/FrontendApiIT.java
@@ -1,10 +1,10 @@
 package org.acme;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(DnsTestResource.class)
+@WithTestResource(DnsTestResource.class)
 public class FrontendApiIT extends FrontendApiTest {
 
 }

--- a/stork-dns-quickstart/src/test/java/org/acme/FrontendApiTest.java
+++ b/stork-dns-quickstart/src/test/java/org/acme/FrontendApiTest.java
@@ -1,6 +1,6 @@
 package org.acme;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Assertions;
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @QuarkusTest
-@QuarkusTestResource(DnsTestResource.class)
+@WithTestResource(DnsTestResource.class)
 public class FrontendApiTest {
 
     @Test

--- a/stork-quickstart/src/test/java/org/acme/FrontendApiIT.java
+++ b/stork-quickstart/src/test/java/org/acme/FrontendApiIT.java
@@ -1,10 +1,10 @@
 package org.acme;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(ConsulTestResource.class)
+@WithTestResource(ConsulTestResource.class)
 public class FrontendApiIT extends FrontendApiTest {
 
 }

--- a/stork-quickstart/src/test/java/org/acme/FrontendApiTest.java
+++ b/stork-quickstart/src/test/java/org/acme/FrontendApiTest.java
@@ -1,6 +1,6 @@
 package org.acme;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Assertions;
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @QuarkusTest
-@QuarkusTestResource(ConsulTestResource.class)
+@WithTestResource(ConsulTestResource.class)
 public class FrontendApiTest {
 
     @Test


### PR DESCRIPTION
Updating deprecated `@QuarkusTestResource` to `@WithTestResource`  as it's new in 3.13.0 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.13#quarkustestresource-replaced-by-withtestresource-gear-white_check_mark

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


