### PR TITLE
Fix security-oauth2-quickstart test

### DIFF
--- a/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceTest.java
+++ b/security-oauth2-quickstart/src/test/java/org/acme/security/oauth2/TokenSecuredResourceTest.java
@@ -17,7 +17,7 @@ class TokenSecuredResourceTest {
     void testPermitAll() {
         RestAssured.given()
                 .when()
-                .header("Authorization", "Bearer: " + BEARER_TOKEN)
+                .header("Authorization", "Bearer " + BEARER_TOKEN)
                 .get("/secured/permit-all")
                 .then()
                 .statusCode(200)
@@ -28,7 +28,7 @@ class TokenSecuredResourceTest {
     void testRolesAllowed() {
         RestAssured.given()
                 .when()
-                .header("Authorization", "Bearer: " + BEARER_TOKEN)
+                .header("Authorization", "Bearer " + BEARER_TOKEN)
                 .get("/secured/roles-allowed")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
The change is needed because of https://github.com/quarkusio/quarkus/pull/42595


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


