### PR TITLE
Updates to enable quickstarts on aarch64 platform

### DIFF
--- a/context-propagation-quickstart/src/test/java/org/acme/context/prices/KafkaResource.java
+++ b/context-propagation-quickstart/src/test/java/org/acme/context/prices/KafkaResource.java
@@ -9,7 +9,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class KafkaResource implements QuarkusTestResourceLifecycleManager {
 
-    private final KafkaContainer kafka = new KafkaContainer();
+    private final KafkaContainer kafka = new KafkaContainer("7.7.0");
 
     @Override
     public Map<String, String> start() {

--- a/infinispan-cache-quickstart/src/main/resources/testcontainers.properties
+++ b/infinispan-cache-quickstart/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.image=testcontainers/ryuk:0.8.1

--- a/infinispan-client-quickstart/src/main/resources/testcontainers.properties
+++ b/infinispan-client-quickstart/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.image=testcontainers/ryuk:0.8.1

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/KafkaResource.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/KafkaResource.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public class KafkaResource implements QuarkusTestResourceLifecycleManager {
 
-    private final static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+    private final static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.7.0"));
 
     @Override
     public Map<String, String> start() {


### PR DESCRIPTION
Updates to enable quickstarts on aarch64 platform

 * Bump confluentinc/cp-kafka image to 7.7.0 for aarch64 support
 * Use official ryuk instead of quay.io/infinispan-test/ryuk

quay.io/infinispan-test/ryuk has issues on RHEL8 aarch 64, override was introduced in https://github.com/infinispan/infinispan/pull/8905

Fixes failures in 
 * context-propagation-quickstart:
 * kafka-streams-quickstart
 * infinispan-client-quickstart
 * infinispan-cache-quickstart 

CC @mjurc

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


