### PR TITLE
Switch from @2 to @4 for key GH Actions

### DIFF
--- a/.github/workflows/build-pr-development.yml
+++ b/.github/workflows/build-pr-development.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           echo -n ${{ github.event.number }} > pull-request-number
       - name: Upload pull request number
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pull-request-number-${{ github.event.number }}
           path: pull-request-number
@@ -37,7 +37,7 @@ jobs:
       matrix:
         java: [ 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get Date
         id: get-date
         run: |
@@ -45,7 +45,7 @@ jobs:
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           # refresh cache every month to avoid unlimited growth
@@ -58,7 +58,7 @@ jobs:
             exit 1
           fi
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: rm -rf ~/.m2/repository/org/acme
       - name: Upload build reports (if build failed)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-reports-Build - JDK ${{ matrix.java }}"

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -47,14 +47,14 @@ jobs:
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           # refresh cache every month to avoid unlimited growth
           key: q2maven-native-${{ steps.get-date.outputs.date }}
 
       - name: Install JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
@@ -117,7 +117,7 @@ jobs:
     needs: [build-with-native]
     if: "always() && github.repository == 'quarkusio/quarkus-quickstarts'"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.ref || 'development' }}
       - name: Report


### PR DESCRIPTION
Switch from @2 to @4 for key GH Actions

Triggered by CI failure in https://github.com/quarkusio/quarkus-quickstarts/pull/1449

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


