### PR TITLE
Bump jacoco-maven-plugin to 0.8.12 to fix warnings with Java 21

### DIFF
--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Bump jacoco-maven-plugin to 0.8.12 to fix warnings with Java 21

There were more than 100 warnings with stacktraces saying `java.lang.IllegalArgumentException: Unsupported class file major version 65`
Jacoco supports Java 21 starting with 0.8.11, experimental support was added in 0.8.9 - https://www.jacoco.org/jacoco/trunk/doc/changes.html

Quarkus platform BOM doesn't handle plugin management, so this version needs to be upgraded explicitly.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


