### PR TITLE
[3.15] Aarch64 related backports

### DIFF
--- a/context-propagation-quickstart/src/test/java/org/acme/context/prices/KafkaResource.java
+++ b/context-propagation-quickstart/src/test/java/org/acme/context/prices/KafkaResource.java
@@ -9,7 +9,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class KafkaResource implements QuarkusTestResourceLifecycleManager {
 
-    private final KafkaContainer kafka = new KafkaContainer();
+    private final KafkaContainer kafka = new KafkaContainer("7.7.0");
 
     @Override
     public Map<String, String> start() {

--- a/infinispan-cache-quickstart/src/main/resources/testcontainers.properties
+++ b/infinispan-cache-quickstart/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.image=testcontainers/ryuk:0.8.1

--- a/infinispan-client-quickstart/src/main/resources/testcontainers.properties
+++ b/infinispan-client-quickstart/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.image=testcontainers/ryuk:0.8.1

--- a/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/KafkaResource.java
+++ b/kafka-streams-quickstart/aggregator/src/test/java/org/acme/kafka/streams/aggregator/streams/KafkaResource.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public class KafkaResource implements QuarkusTestResourceLifecycleManager {
 
-    private final static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+    private final static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.7.0"));
 
     @Override
     public Map<String, String> start() {

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.15.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Backports of:
 * https://github.com/quarkusio/quarkus-quickstarts/pull/1449
 * https://github.com/quarkusio/quarkus-quickstarts/pull/1453

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


