### PR TITLE
Remove reference to nonexistent v1 dev UI from quickstart

### DIFF
--- a/getting-started-dev-services/src/main/resources/META-INF/resources/index.html
+++ b/getting-started-dev-services/src/main/resources/META-INF/resources/index.html
@@ -255,22 +255,11 @@
                     <p>App configuration: <code>src/main/resources/application.properties</code></p>
                     <p>Static assets: <code>src/main/resources/META-INF/resources/</code></p>
                     <p>Code: <code>src/main/java</code></p>
-                    <p>Dev UI V1: <a href="/q/dev-v1/">/q/dev-v1</a></p>
-                    <p>Generated starter code:</p>
-                    <ul class="provided-code">
-                                <li class="provided-code">
-            <b>RESTEasy Reactive</b>&nbsp;Easily start your Reactive RESTful Web Services
-            <br />&rsaquo; <code>@Path: <a href="/hello" class="path-link" target="_blank">/hello</a></code>
-            <br />&rsaquo; <a href="https://quarkus.io/guides/getting-started-reactive#reactive-jax-rs-resources" class="guide-link" target="_blank">Related guide</a>
         </li>
 
                     </ul>
                 </div>
                 <div class="right-column">
-                    <h3>Selected extensions</h3>
-                    <ul>
-                        <li title="A Jakarta REST implementation utilizing build time processing and Vert.x. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.">RESTEasy Reactive (<a href="https://quarkus.io/guides/resteasy-reactive" target="_blank">guide</a>)</li>
-                    </ul>
                     <h5><a href="https://quarkus.io/guides/">Documentation</a></h5>
                     <p>Practical step-by-step guides to help you achieve a specific goal. Use them to help get your work
                         done.</p>


### PR DESCRIPTION
While I was looking at the index html, I noticed it's out of date in a few other ways (references to reactive, etc) so I've tidied those up as well.

