### PR TITLE
Enable Quarkus Observability Dev Services with Grafana LGTM in OpenTelemetry Quickstart

### DIFF
--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -48,6 +48,15 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-observability-devservices-lgtm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.micrometer.registry</groupId>
+      <artifactId>quarkus-micrometer-registry-otlp</artifactId>
+      <version>3.2.4</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/opentelemetry-quickstart/src/main/java/org/acme/opentelemetry/TracedResource.java
+++ b/opentelemetry-quickstart/src/main/java/org/acme/opentelemetry/TracedResource.java
@@ -1,8 +1,14 @@
 package org.acme.opentelemetry;
 
+import com.google.common.util.concurrent.AtomicDouble;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriInfo;
@@ -17,6 +23,20 @@ public class TracedResource {
 
     @Context
     UriInfo uriInfo;
+
+    @Inject
+    MeterRegistry registry;
+
+    private AtomicDouble xValue = new AtomicDouble(0.0);
+
+    @PostConstruct
+    public void init() {
+        Gauge.builder("service.xvalue", xValue, AtomicDouble::get)
+                .baseUnit("units")
+                .description("Current value of X in the service")
+                .tag("service", "TracedResource")
+                .register(registry);
+    }
 
     @GET
     @Path("/hello")
@@ -34,5 +54,18 @@ public class TracedResource {
                 .baseUri(uriInfo.getBaseUri())
                 .build(ResourceClient.class);
         return "chain -> " + resourceClient.hello();
+    }
+
+    @GET
+    @Path("/metrics/set")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String setMetric(@QueryParam("value") Double value) {
+        if (value == null) {
+            LOG.warn("Attempted to set metric without providing a value.");
+            return "{\"status\":\"failure\", \"message\":\"Value parameter is missing\"}";
+        }
+        xValue.set(value);
+        LOG.infof("Metric 'xvalue' set to: %f", value);
+        return "{\"status\":\"success\", \"xvalue\":" + value + "}";
     }
 }

--- a/opentelemetry-quickstart/src/main/resources/application.properties
+++ b/opentelemetry-quickstart/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 quarkus.application.name=myservice
-quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317
 quarkus.otel.exporter.otlp.traces.headers=Authorization=Bearer my_secret
 quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
 

--- a/opentelemetry-quickstart/src/test/java/org/acme/opentelemetry/TracedResourceTest.java
+++ b/opentelemetry-quickstart/src/test/java/org/acme/opentelemetry/TracedResourceTest.java
@@ -28,4 +28,17 @@ public class TracedResourceTest {
                 .body(is("chain -> hello"));
     }
 
+    @Test
+    public void testSetMetricEndpoint() {
+        Double testValue = 42.0;
+
+        given()
+                .queryParam("value", testValue)
+                .when().get("/metrics/set")
+                .then()
+                .statusCode(200)
+                .body("status", is("success"))
+                .body("xvalue", is(testValue.floatValue()));
+    }
+
 }


### PR DESCRIPTION

Resolve the issue that we discussed here: https://issues.redhat.com/browse/QUARKUS-4186 
I am adding support for automatic metrics and tracing in development mode.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


