### PR TITLE
[3.8] Fix enpoint path to match character starwars data API

### DIFF
--- a/vertx-quickstart/src/main/java/org/acme/extra/ResourceUsingWebClient.java
+++ b/vertx-quickstart/src/main/java/org/acme/extra/ResourceUsingWebClient.java
@@ -9,21 +9,21 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
-@Path("/fruit-data")
+@Path("/character-data")
 public class ResourceUsingWebClient {
 
     private final WebClient client;
 
     public ResourceUsingWebClient(Vertx vertx) {
         this.client = WebClient.create(vertx,
-                new WebClientOptions().setDefaultHost("fruityvice.com").setDefaultPort(443).setSsl(true)
+                new WebClientOptions().setDefaultHost("swapi.dev").setDefaultPort(443).setSsl(true)
                         .setTrustAll(true));
     }
 
     @GET
-    @Path("/{name}")
-    public Uni<JsonObject> getFruitData(String name) {
-        return client.get("/api/fruit/" + name)
+    @Path("/{id}")
+    public Uni<JsonObject> getStarWarsData(String id) {
+        return client.get("/api/people/" + id)
                 .send()
                 .map(resp -> {
                     if (resp.statusCode() == 200) {

--- a/vertx-quickstart/src/test/java/org/acme/extra/ResourceUsingWebClientTest.java
+++ b/vertx-quickstart/src/test/java/org/acme/extra/ResourceUsingWebClientTest.java
@@ -11,12 +11,13 @@ import io.quarkus.test.junit.QuarkusTest;
 class ResourceUsingWebClientTest {
 
     @Test
-    void testBananaData() {
+    void testStarWarsData() {
         given()
-                .when().get("/fruit-data/banana")
+                .when().get("/character-data/1")
                 .then()
                 .statusCode(200)
-                .body(containsString("Musaceae"));
+                .body(containsString("Luke Skywalker"));
+
     }
 
 }


### PR DESCRIPTION
Backport of https://github.com/quarkusio/quarkus-quickstarts/pull/1468 for 3.8 branch

Fix enpoint path to match character starwars data API

(cherry picked from commit ff646f7bab8fe03c7d70cf19c70846d2dde049f1)


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


