### PR TITLE
Bump io.quarkiverse.amazonservices:quarkus-amazon-services-bom from 2.18.1 to 2.20.1

### DIFF
--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-sqs-connector-quickstart/pom.xml
+++ b/amazon-sqs-connector-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+    <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -44,21 +44,12 @@
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.amazonservices</groupId>
-      <artifactId>quarkus-amazon-sqs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.smallrye.reactive</groupId>
-      <artifactId>smallrye-reactive-messaging-aws-sqs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>url-connection-client</artifactId>
+      <artifactId>quarkus-messaging-amazon-sqs</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>netty-nio-client</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>

--- a/amazon-sqs-connector-quickstart/src/main/resources/application.properties
+++ b/amazon-sqs-connector-quickstart/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-quarkus.sqs.aws.region=us-east-1
 # Set the SQS queue for the `requests` channel, as it's not the channel name
 mp.messaging.incoming.requests.queue=quote-requests
 mp.messaging.incoming.quotes-in.queue=quotes

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.20.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Use the new `quarkus-messaging-amazon-sqs` extension to simplify the `amazon-sqs-connector-quickstart`.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


