### PR TITLE
Fix tests in REST client quickstart for the native SSL guide

### DIFF
--- a/rest-client-quickstart/src/test/java/org/acme/rest/client/ExtensionsResourceTest.java
+++ b/rest-client-quickstart/src/test/java/org/acme/rest/client/ExtensionsResourceTest.java
@@ -18,12 +18,12 @@ public class ExtensionsResourceTest {
     @Test
     public void testExtensionsIdEndpoint() {
         given()
-            .when().get("/extension/id/io.quarkus:quarkus-rest-client-reactive")
+            .when().get("/extension/id/io.quarkus:quarkus-rest-client")
             .then()
             .statusCode(200)
             .body("$.size()", is(1),
-                "[0].id", is("io.quarkus:quarkus-rest-client-reactive"),
-                "[0].name", is("REST Client Reactive"),
+                "[0].id", is("io.quarkus:quarkus-rest-client"),
+                "[0].name", is("REST Client"),
                 "[0].keywords.size()", greaterThan(1),
                 "[0].keywords", hasItem("rest-client"));
     }
@@ -31,12 +31,12 @@ public class ExtensionsResourceTest {
     @Test
     public void testExtensionIdAsyncEndpoint() {
         given()
-            .when().get("/extension/id-async/io.quarkus:quarkus-rest-client-reactive")
+            .when().get("/extension/id-async/io.quarkus:quarkus-rest-client")
             .then()
             .statusCode(200)
             .body("$.size()", is(1),
-                "[0].id", is("io.quarkus:quarkus-rest-client-reactive"),
-                "[0].name", is("REST Client Reactive"),
+                "[0].id", is("io.quarkus:quarkus-rest-client"),
+                "[0].name", is("REST Client"),
                 "[0].keywords.size()", greaterThan(1),
                 "[0].keywords", hasItem("rest-client"));
     }
@@ -44,12 +44,12 @@ public class ExtensionsResourceTest {
     @Test
     public void testExtensionIdMutinyEndpoint() {
         given()
-            .when().get("/extension/id-uni/io.quarkus:quarkus-rest-client-reactive")
+            .when().get("/extension/id-uni/io.quarkus:quarkus-rest-client")
             .then()
             .statusCode(200)
             .body("$.size()", is(1),
-                "[0].id", is("io.quarkus:quarkus-rest-client-reactive"),
-                "[0].name", is("REST Client Reactive"),
+                "[0].id", is("io.quarkus:quarkus-rest-client"),
+                "[0].name", is("REST Client"),
                 "[0].keywords.size()", greaterThan(1),
                 "[0].keywords", hasItem("rest-client"));
     }

--- a/rest-client-quickstart/src/test/resources/extensions.json
+++ b/rest-client-quickstart/src/test/resources/extensions.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "io.quarkus:quarkus-rest-client-reactive",
+    "id": "io.quarkus:quarkus-rest-client",
     "keywords": [
       "call",
       "microprofile-rest-client",
-      "quarkus-rest-client-reactive",
+      "quarkus-rest-client",
       "reactively",
       "rest",
       "rest-client",
@@ -12,8 +12,8 @@
       "services",
       "web-client"
     ],
-    "name": "REST Client Reactive",
-    "shortName": "REST Client Reactive"
+    "name": "REST Client",
+    "shortName": "REST Client"
   },
   {
     "id": "io.quarkus:quarkus-resteasy",


### PR DESCRIPTION
In [Native SSL guide](https://quarkus.io/guides/native-and-ssl) we start by downloading REST client and removing WireMock, but these tests use the old names of the rest-client-reactive extensions and they fail when we remove WireMock. This will fix the Native SSL guide.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [x] for new quickstart, is located in the directory _component-quickstart_
- [x] for new quickstart, is added to the root `pom.xml` and `README.md`


