### PR TITLE
Fix security web authentication on windows

### DIFF
--- a/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
+++ b/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
@@ -156,6 +156,9 @@ public class CodeFlowTest {
         WebClient webClient = new WebClient();
 
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        // Setting the cache size to zero as webClient by default can store cached request,
+        // which causing the `testTokenTimeoutLogout` fail as the session cookie is not changed
+        webClient.getCache().setMaxSize(0);
 
         return webClient;
     }


### PR DESCRIPTION
We (QE) found out that on our windows machine the `security-openid-connect-web-authentication-quickstart` one test failing. After looking into it I see that for some reason the `HtmlUnit` `WebClient` caching the request/response. So setting the max size of cache to 0. Maybe this can happen on other machines then win, it's probably depends on setting of machine and jvm

**Also can tis be backported to 3.15 branch**

**Check list**

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


