### PR TITLE
[3.15] Backport of `Set cache size to 0 to prevent cached response in tests`

### DIFF
--- a/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
+++ b/security-openid-connect-web-authentication-quickstart/src/test/java/org/acme/security/openid/connect/web/authentication/CodeFlowTest.java
@@ -156,6 +156,9 @@ public class CodeFlowTest {
         WebClient webClient = new WebClient();
 
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        // Setting the cache size to zero as webClient by default can store cached request,
+        // which causing the `testTokenTimeoutLogout` fail as the session cookie is not changed
+        webClient.getCache().setMaxSize(0);
 
         return webClient;
     }


### PR DESCRIPTION
Backport of:
- https://github.com/quarkusio/quarkus-quickstarts/pull/1480


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


