### PR TITLE
swapi.dev is down, use swapi.tech

### DIFF
--- a/vertx-quickstart/src/main/java/org/acme/extra/ResourceUsingWebClient.java
+++ b/vertx-quickstart/src/main/java/org/acme/extra/ResourceUsingWebClient.java
@@ -16,7 +16,7 @@ public class ResourceUsingWebClient {
 
     public ResourceUsingWebClient(Vertx vertx) {
         this.client = WebClient.create(vertx,
-                new WebClientOptions().setDefaultHost("swapi.dev").setDefaultPort(443).setSsl(true)
+                new WebClientOptions().setDefaultHost("swapi.tech").setDefaultPort(443).setSsl(true)
                         .setTrustAll(true));
     }
 


### PR DESCRIPTION
swapi.dev is down, use swapi.tech

swapi-graphql change: https://github.com/graphql/swapi-graphql/commit/b340cf9a9aace4d7ee445ad94a9125548f80d682

Fixes vertx-quickstart failures in https://github.com/quarkusio/quarkus-quickstarts/actions/workflows/native-build-development.yml run

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


