### PR TITLE
Disable graphql-client quickstart tests for now

### DIFF
--- a/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientIT.java
+++ b/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientIT.java
@@ -1,8 +1,10 @@
 package org.acme.microprofile.graphql.client;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Disabled;
 
 @QuarkusIntegrationTest
+@Disabled("Blocked by https://github.com/quarkusio/quarkus/issues/45334")
 public class GraphQLClientIT extends GraphQLClientTest {
 
 }

--- a/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientTest.java
+++ b/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientTest.java
@@ -1,6 +1,7 @@
 package org.acme.microprofile.graphql.client;
 
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import static io.restassured.RestAssured.get;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
+@Disabled("Blocked by https://github.com/quarkusio/quarkus/issues/45334")
 public class GraphQLClientTest {
 
     @Test


### PR DESCRIPTION
Disable graphql-client quickstart tests for now

Blocked by https://github.com/quarkusio/quarkus/issues/45334

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


