### PR TITLE
[3.15] use swapi.tech, update graphql-client quickstart

### DIFF
--- a/microprofile-graphql-client-quickstart/src/main/resources/application.properties
+++ b/microprofile-graphql-client-quickstart/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # typesafe client config
-quarkus.smallrye-graphql-client.star-wars-typesafe.url=https://swapi-graphql.netlify.app/.netlify/functions/index
+quarkus.smallrye-graphql-client.star-wars-typesafe.url=https://swapi-graphql.netlify.app/graphql
 
 # dynamic client config
-quarkus.smallrye-graphql-client.star-wars-dynamic.url=https://swapi-graphql.netlify.app/.netlify/functions/index
+quarkus.smallrye-graphql-client.star-wars-dynamic.url=https://swapi-graphql.netlify.app/graphql

--- a/vertx-quickstart/src/main/java/org/acme/extra/ResourceUsingWebClient.java
+++ b/vertx-quickstart/src/main/java/org/acme/extra/ResourceUsingWebClient.java
@@ -16,7 +16,7 @@ public class ResourceUsingWebClient {
 
     public ResourceUsingWebClient(Vertx vertx) {
         this.client = WebClient.create(vertx,
-                new WebClientOptions().setDefaultHost("swapi.dev").setDefaultPort(443).setSsl(true)
+                new WebClientOptions().setDefaultHost("swapi.tech").setDefaultPort(443).setSsl(true)
                         .setTrustAll(true));
     }
 


### PR DESCRIPTION
Backports of:
 * https://github.com/quarkusio/quarkus-quickstarts/pull/1484
 * https://github.com/quarkusio/quarkus-quickstarts/pull/1486
 * https://github.com/quarkusio/quarkus-quickstarts/pull/1495

The last 2 backports are squashed together to limit the changes

The first backport could be dropped (swapi.dev is back online now) but I kept it in place to be in sync with changes in development branch