### PR TITLE
Upgrade jbang, picocli, github-api for NativeBuildReport to fix Report stage of daily runs

### DIFF
--- a/.github/NativeBuildReport.java
+++ b/.github/NativeBuildReport.java
@@ -1,7 +1,7 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.kohsuke:github-api:1.101
-//DEPS info.picocli:picocli:4.2.0
+//DEPS org.kohsuke:github-api:1.326
+//DEPS info.picocli:picocli:4.7.6
 
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;

--- a/.github/workflows/native-build-development.yml
+++ b/.github/workflows/native-build-development.yml
@@ -133,5 +133,5 @@ jobs:
           curl -s "https://get.sdkman.io" | bash
           source ~/.sdkman/bin/sdkman-init.sh
           sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
-          sdk install jbang 0.50.1
+          sdk install jbang 0.122.0
           jbang .github/NativeBuildReport.java token="${GITHUB_TOKEN}" status="${STATUS}" issueRepo="quarkusio/quarkus" issueNumber="6588" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"


### PR DESCRIPTION
Upgrade jbang, picocli, github-api for NativeBuildReport to fix Report stage of daily runs.

Fixes `InaccessibleObjectException` when closing GH issue

Currently the daily run can't close the GH issue, throwing `InaccessibleObjectException`, see https://github.com/quarkusio/quarkus-quickstarts/actions/runs/12682565687/job/35350789820

I think the issue is connected with newer JDK being used as a base, I was able to replicate the error with JDK 21 locally.
Upgrading picocli and github-api solved the issue, I tried locally and the GH issue was properly closed - https://github.com/quarkusio/quarkus/issues/6588#issuecomment-2579363689
I also updated jbang to the latest, that's also version I used locally.

```
java.io.UncheckedIOException: java.io.IOException: Failed to set the custom verb
	at Report.run(NativeBuildReport.java:88)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1769)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2150)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2144)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at Report.main(NativeBuildReport.java:97)
Caused by: java.io.IOException: Failed to set the custom verb
	at org.kohsuke.github.Requester.setRequestMethod(Requester.java:759)
	at org.kohsuke.github.Requester.setupConnection(Requester.java:745)
	at org.kohsuke.github.Requester._to(Requester.java:388)
	at org.kohsuke.github.Requester.to(Requester.java:336)
	at org.kohsuke.github.GHIssue.edit(GHIssue.java:239)
	at org.kohsuke.github.GHIssue.close(GHIssue.java:253)
	at Report.run(NativeBuildReport.java:71)
	... 8 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field protected java.lang.String java.net.HttpURLConnection.method accessible: module java.base does not "opens java.net" to unnamed module @6a463b3d
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at org.kohsuke.github.Requester.setRequestMethod(Requester.java:756)
	... 14 more
```

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


