### PR TITLE
Update Kotlin version to 2.1.20 in hibernate-orm-panache-kotlin-quickstart

### DIFF
--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.version>3.19.4</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <kotlin.version>1.9.23</kotlin.version>
+        <kotlin.version>2.1.0</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.version>3.19.4</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <kotlin.version>2.1.0</kotlin.version>
+        <kotlin.version>2.1.20</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
This PR updates the Kotlin version of the ´hibernate-orm-panache-kotlin-quickstart`. This is in preparation for the Quarkus PR to update to Kotlin 2.1.0 https://github.com/quarkusio/quarkus/pull/45470. 


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


