### PR TITLE
Enable microprofile-graphql-client-quickstart, update netlify URL

### DIFF
--- a/microprofile-graphql-client-quickstart/src/main/resources/application.properties
+++ b/microprofile-graphql-client-quickstart/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # typesafe client config
-quarkus.smallrye-graphql-client.star-wars-typesafe.url=https://swapi-graphql.netlify.app/.netlify/functions/index
+quarkus.smallrye-graphql-client.star-wars-typesafe.url=https://swapi-graphql.netlify.app/graphql
 
 # dynamic client config
-quarkus.smallrye-graphql-client.star-wars-dynamic.url=https://swapi-graphql.netlify.app/.netlify/functions/index
+quarkus.smallrye-graphql-client.star-wars-dynamic.url=https://swapi-graphql.netlify.app/graphql

--- a/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientIT.java
+++ b/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientIT.java
@@ -1,10 +1,8 @@
 package org.acme.microprofile.graphql.client;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import org.junit.jupiter.api.Disabled;
 
 @QuarkusIntegrationTest
-@Disabled("Blocked by https://github.com/quarkusio/quarkus/issues/45334")
 public class GraphQLClientIT extends GraphQLClientTest {
 
 }

--- a/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientTest.java
+++ b/microprofile-graphql-client-quickstart/src/test/java/org/acme/microprofile/graphql/client/GraphQLClientTest.java
@@ -1,7 +1,6 @@
 package org.acme.microprofile.graphql.client;
 
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,7 +9,6 @@ import static io.restassured.RestAssured.get;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-@Disabled("Blocked by https://github.com/quarkusio/quarkus/issues/45334")
 public class GraphQLClientTest {
 
     @Test


### PR DESCRIPTION
Enable microprofile-graphql-client-quickstart, update netlify URL

 * Server swapi.dev is up again so the netlify application works well again
 * Update of GrapQL endpoint to https://swapi-graphql.netlify.app/graphql


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


