### PR TITLE
Avoid deprecated PgPool type in quickstarts

### DIFF
--- a/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/DBInit.java
+++ b/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/DBInit.java
@@ -1,7 +1,7 @@
 package org.acme.reactive.crud;
 
 import io.quarkus.runtime.StartupEvent;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -10,10 +10,10 @@ import jakarta.enterprise.event.Observes;
 @ApplicationScoped
 public class DBInit {
 
-    private final PgPool client;
+    private final Pool client;
     private final boolean schemaCreate;
 
-    public DBInit(PgPool client, @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") boolean schemaCreate) {
+    public DBInit(Pool client, @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") boolean schemaCreate) {
         this.client = client;
         this.schemaCreate = schemaCreate;
     }

--- a/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/Fruit.java
+++ b/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/Fruit.java
@@ -18,7 +18,7 @@ package org.acme.reactive.crud;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -42,29 +42,29 @@ public class Fruit {
         this.name = name;
     }
 
-    public static Multi<Fruit> findAll(PgPool client) {
+    public static Multi<Fruit> findAll(Pool client) {
         return client.query("SELECT id, name FROM fruits ORDER BY name ASC").execute()
                 .onItem().transformToMulti(set -> Multi.createFrom().iterable(set))
                 .onItem().transform(Fruit::from);
     }
 
-    public static Uni<Fruit> findById(PgPool client, Long id) {
+    public static Uni<Fruit> findById(Pool client, Long id) {
         return client.preparedQuery("SELECT id, name FROM fruits WHERE id = $1").execute(Tuple.of(id))
                 .onItem().transform(RowSet::iterator)
                 .onItem().transform(iterator -> iterator.hasNext() ? from(iterator.next()) : null);
     }
 
-    public Uni<Long> save(PgPool client) {
+    public Uni<Long> save(Pool client) {
         return client.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING id").execute(Tuple.of(name))
                 .onItem().transform(pgRowSet -> pgRowSet.iterator().next().getLong("id"));
     }
 
-    public Uni<Boolean> update(PgPool client) {
+    public Uni<Boolean> update(Pool client) {
         return client.preparedQuery("UPDATE fruits SET name = $1 WHERE id = $2").execute(Tuple.of(name, id))
                 .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }
 
-    public static Uni<Boolean> delete(PgPool client, Long id) {
+    public static Uni<Boolean> delete(Pool client, Long id) {
         return client.preparedQuery("DELETE FROM fruits WHERE id = $1").execute(Tuple.of(id))
                 .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }

--- a/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/FruitResource.java
+++ b/getting-started-reactive-crud/src/main/java/org/acme/reactive/crud/FruitResource.java
@@ -29,14 +29,14 @@ import jakarta.ws.rs.core.Response.Status;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("fruits")
 public class FruitResource {
 
-    private final PgPool client;
+    private final Pool client;
 
-    public FruitResource(PgPool client) {
+    public FruitResource(Pool client) {
         this.client = client;
     }
 

--- a/vertx-quickstart/src/main/java/org/acme/extra/Fruit.java
+++ b/vertx-quickstart/src/main/java/org/acme/extra/Fruit.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -28,7 +28,7 @@ public class Fruit {
         this.name = name;
     }
 
-    public static Uni<List<Fruit>> findAll(PgPool client) {
+    public static Uni<List<Fruit>> findAll(Pool client) {
         return client.query("SELECT id, name FROM fruits ORDER BY name ASC").execute()
                 .onItem().transform(pgRowSet -> {
                     List<Fruit> list = new ArrayList<>(pgRowSet.size());
@@ -39,23 +39,23 @@ public class Fruit {
                 });
     }
 
-    public static Uni<Fruit> findById(PgPool client, Long id) {
+    public static Uni<Fruit> findById(Pool client, Long id) {
         return client.preparedQuery("SELECT id, name FROM fruits WHERE id = $1").execute(Tuple.of(id))
                 .onItem().transform(RowSet::iterator)
                 .onItem().transform(iterator -> iterator.hasNext() ? from(iterator.next()) : null);
     }
 
-    public Uni<Long> save(PgPool client) {
+    public Uni<Long> save(Pool client) {
         return client.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING (id)").execute(Tuple.of(name))
                 .onItem().transform(pgRowSet -> pgRowSet.iterator().next().getLong("id"));
     }
 
-    public Uni<Boolean> update(PgPool client) {
+    public Uni<Boolean> update(Pool client) {
         return client.preparedQuery("UPDATE fruits SET name = $1 WHERE id = $2").execute(Tuple.of(name, id))
                 .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }
 
-    public static Uni<Boolean> delete(PgPool client, Long id) {
+    public static Uni<Boolean> delete(Pool client, Long id) {
         return client.preparedQuery("DELETE FROM fruits WHERE id = $1").execute(Tuple.of(id))
                 .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1);
     }

--- a/vertx-quickstart/src/main/java/org/acme/extra/FruitResource.java
+++ b/vertx-quickstart/src/main/java/org/acme/extra/FruitResource.java
@@ -16,15 +16,15 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("fruits")
 public class FruitResource {
 
-    private final PgPool client;
+    private final Pool client;
     private final boolean schemaCreate;
 
-    public FruitResource(PgPool client, @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") boolean schemaCreate) {
+    public FruitResource(Pool client, @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") boolean schemaCreate) {
         this.client = client;
         this.schemaCreate = schemaCreate;
     }


### PR DESCRIPTION
PgPool is deprecated in Vert.x 4 and is going away in Vert.x 5.

Quickstarts should use the base Pool type instead.


**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- ~makes sure the associated guide must not be updated~ (must be updated)
- [x] links the guide update pull request https://github.com/quarkusio/quarkus/pull/46015
- ~updates or creates the `README.md` file (with build and run instructions)~ (not applicable)
- ~for new quickstart, is located in the directory _component-quickstart_~ (not applicable)
- ~for new quickstart, is added to the root `pom.xml` and `README.md`~ (not applicable)


