### PR TITLE
[3.8] Enable microprofile-graphql-client-quickstart, update netlify URL

### DIFF
--- a/microprofile-graphql-client-quickstart/src/main/resources/application.properties
+++ b/microprofile-graphql-client-quickstart/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # typesafe client config
-quarkus.smallrye-graphql-client.star-wars-typesafe.url=https://swapi-graphql.netlify.app/.netlify/functions/index
+quarkus.smallrye-graphql-client.star-wars-typesafe.url=https://swapi-graphql.netlify.app/graphql
 
 # dynamic client config
-quarkus.smallrye-graphql-client.star-wars-dynamic.url=https://swapi-graphql.netlify.app/.netlify/functions/index
+quarkus.smallrye-graphql-client.star-wars-dynamic.url=https://swapi-graphql.netlify.app/graphql


### PR DESCRIPTION
Backport of https://github.com/quarkusio/quarkus-quickstarts/pull/1495 for 3.8 branch


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


