### PR TITLE
Updates to the OpenTelemetry quickstart ahead of Quarkus 3.19

### DIFF
--- a/opentelemetry-quickstart/README.md
+++ b/opentelemetry-quickstart/README.md
@@ -1,9 +1,17 @@
-Quarkus guide: https://quarkus.io/guides/opentelemetry
+# Quarkus quickstart example for OpenTelemetry
 
-In this opentelemetry-quickstart is implemented OpenTelemetry Metrics detailed in the guide: https://quarkus.io/guides/opentelemetry-metrics .
+This example provides a simple Quarkus application instrumented with OpenTelemetry, and allows telemetry data to be seen in a local Grafana LGTM DevService instance.
 
-Additionally, it integrates the LGTM DevService for telemetry visualization by adding the `quarkus-observability-devservices-lgtm` dependency.
+For detailed instructions the [Quarkus OpenTelemetry guide](https://quarkus.io/guides/opentelemetry) is available. 
 
-Usage and configuration are explained in the guide: https://quarkus.io/guides/opentelemetry-tracing#grafana-otel-lgtm-option
+There are signal specific guides for:
+* [Tracing](https://quarkus.io/guides/opentelemetry-tracing)
+* [Metrics](https://quarkus.io/guides/opentelemetry-metrics)
+* [Logs](https://quarkus.io/guides/opentelemetry-logging)
 
+## See telemetry
+
+The project includes the Grafana LGTM DevService for telemetry visualization. This is provided by the `quarkus-observability-devservices-lgtm` dependency.
+
+Usage and configuration are explained in the [Grafana LGTM guide](https://quarkus.io/guides/observability-devservices-lgtm).
 

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -32,6 +32,21 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client</artifactId>
+    </dependency>
+    <!-- For Dev Mode  -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-observability-devservices-lgtm</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Test Dependencies   -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
@@ -39,18 +54,6 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-opentelemetry</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-observability-devservices-lgtm</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/opentelemetry-quickstart/src/main/resources/application.properties
+++ b/opentelemetry-quickstart/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 quarkus.application.name=myservice
+# OTel metrics off by default
 quarkus.otel.metrics.enabled=true
+# OTel logs off by default
+quarkus.otel.logs.enabled=true
 quarkus.otel.exporter.otlp.traces.headers=Authorization=Bearer my_secret
 quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
-# jfr must be enabled if you need OpenTelemetry metrics on native mode.
-quarkus.native.monitoring=jfr
+# Don't run the Grafana LGTM dev service during tests
+%test.quarkus.observability.enabled=false


### PR DESCRIPTION
- Update the README
- Remove JFR config because it's not needed anymore
- Refactor dependencies to place tests at the end.
- Highlight that the `quarkus-observability-devservices-lgtm` dependency is provided.
