### PR TITLE
[3.15] Enable WebAuth callback endpoint

### DIFF
--- a/security-webauthn-quickstart/src/main/resources/application.properties
+++ b/security-webauthn-quickstart/src/main/resources/application.properties
@@ -6,3 +6,4 @@
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.webauthn.login-page=/
+quarkus.webauthn.enable-callback-endpoint=true

--- a/security-webauthn-reactive-quickstart/src/main/resources/application.properties
+++ b/security-webauthn-reactive-quickstart/src/main/resources/application.properties
@@ -6,3 +6,4 @@
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.webauthn.login-page=/
+quarkus.webauthn.enable-callback-endpoint=true


### PR DESCRIPTION
Since 3.15.4 it is disabled by default

See this [issue](https://github.com/quarkusio/quarkus/issues/46889) for details

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


