### PR TITLE
Hibernate ORM guide examples / quickstart are more complex than they should be 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for how to build these examples.
 * [Hibernate Reactive Panache and RESTEasy Reactive](./hibernate-reactive-quickstart): Exposing a CRUD service over REST using Hibernate Reactive and Panache to connect to a PostgreSQL database
 * [Hibernate Reactive and RESTEasy](./hibernate-reactive-quickstart): Exposing a CRUD service over REST using Hibernate Reactive to connect to a PostgreSQL database
 * [Hibernate Reactive and Vert.x Web](./hibernate-reactive-routes-quickstart): Exposing a CRUD service with Reactive Routes using Hibernate Reactive to connect to a PostgreSQL database
+* [Hibernate Reactive with StatelessSession](./hibernate-reactive-stateless-quickstart): Exposing a CRUD service with Reactive Routes using Hibernate Reactive  using `StatelessSession` to connect to a PostgreSQL database
 * [Hibernate ORM and RESTEasy](./hibernate-orm-quickstart): Exposing a CRUD service over REST using Hibernate ORM to connect to a PostgreSQL database
 * [Hibernate ORM with Panache and RESTEasy](./hibernate-orm-panache-quickstart): Exposing a CRUD service over REST using Panache to connect to a PostgreSQL database
 * [Hibernate ORM with Panache and RESTEasy in Kotlin](./hibernate-orm-panache-kotlin-quickstart): Exposing a CRUD service over REST using Panache and kotlin to connect to a PostgreSQL database

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for how to build these examples.
 * [Hibernate ORM Multitenancy Database](./hibernate-orm-multi-tenancy-database-quickstart): Multitenant CRUD service over REST using Hibernate ORM to connect to multiple PostgreSQL databases (database approach)
 * [Hibernate ORM Multitenancy Schema](./hibernate-orm-multi-tenancy-schema-quickstart): Multitenant CRUD service over REST using Hibernate ORM to connect to a PostgreSQL database (schema approach)
 * [Hibernate Search + Elasticsearch](./hibernate-search-orm-elasticsearch-quickstart): Index your Hibernate entities in Elasticsearch to get full text search
+* [Hibernate Search Standalone + Elasticsearch](./hibernate-search-orm-elasticsearch-quickstart): Index your Hibernate entities in Elasticsearch without Hibernate ORM to get full text search
 * [Infinispan Client](./infinispan-client-quickstart): How to use Infinispan Client. Covers creating caches and simple get/put
 * [Artemis JMS](./jms-quickstart): How to use the Artemis JMS extension
 * [Kafka](./kafka-quickstart): Use MicroProfile Reactive Messaging to interact with Apache Kafka

--- a/hibernate-orm-multi-tenancy-database-quickstart/README.md
+++ b/hibernate-orm-multi-tenancy-database-quickstart/README.md
@@ -31,27 +31,76 @@ Launch the Maven build on the checked out sources of this demo:
 
 ## Running the demo
 
-### Start Quarkus in development mode
+### Live coding with Quarkus
 
-The Maven Quarkus plugin provides a development mode that supports live coding. To try this out:
+The Maven Quarkus plugin provides a development mode that supports
+live coding. To try this out:
 
 > ./mvnw quarkus:dev
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
-### Run Quarkus as native executable
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
 
-You can also create a native executable from this application without making any source code changes. A native executable removes the dependency on the JVM:
-everything needed to run the application on the target platform is included in the executable, allowing the application to run with minimal resource overhead.
+To access the database from the terminal, run:
 
-Compiling a native executable takes a bit longer, as GraalVM performs additional steps to remove unnecessary codepaths. Use the  `native` profile to compile  a native executable:
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
 
-> ./mvnw package -Pnative
+    Hot reload works even when modifying your JPA entities.
+    Try it! Even the database schema will be updated on the fly.
 
-After getting a cup of coffee, you'll be able to run this executable directly:
+### Run Quarkus in JVM mode
+
+When you're done iterating in developer mode, you can run the application as a
+conventional jar file.
+
+First compile it:
+
+> ./mvnw package
+
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
+
+> docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
+
+Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
+`src/main/resources/application.properties`.
+
+Then run it:
+
+> java -jar ./target/quarkus-app/quarkus-run.jar
+
+    Have a look at how fast it boots.
+    Or measure total native memory consumption...
+
+### Run Quarkus as a native application
+
+You can also create a native executable from this application without making any
+source code changes. A native executable removes the dependency on the JVM:
+everything needed to run the application on the target platform is included in
+the executable, allowing the application to run with minimal resource overhead.
+
+Compiling a native executable takes a bit longer, as GraalVM performs additional
+steps to remove unnecessary codepaths. Use the  `native` profile to compile a
+native executable:
+
+> ./mvnw package -Dnative
+
+After getting a cup of coffee, you'll be able to run this binary directly:
 
 > ./target/hibernate-orm-schema-multi-tenancy-quickstart-1.0.0-SNAPSHOT-runner
 
+    Please brace yourself: don't choke on that fresh cup of coffee you just got.
+    
+    Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
+    
+    Next, maybe you're ready to measure how much memory this service is consuming.
+
+N.B. This implies all dependencies have been compiled to native;
+that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM
+applies to your entities, to the lower level essential components such as the PostgreSQL JDBC driver, the Undertow webserver.
 
 ## See the demo in your browser
 

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
@@ -5,18 +5,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "known_fruits")
+@Table
 @NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name")
 @NamedQuery(name = "Fruits.findByName", query = "SELECT f FROM Fruit f WHERE f.name=:name")
 public class Fruit {
 
     @Id
-    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(generator = "fruitsSequence")
+    @GeneratedValue
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/application.properties
@@ -7,14 +7,14 @@ quarkus.hibernate-orm.datasource=base
 quarkus.datasource.base.db-kind=postgresql
 quarkus.datasource.base.username=quarkus_test
 quarkus.datasource.base.password=quarkus_test
-%prod.quarkus.datasource.base.jdbc.url=jdbc:postgresql://localhost:5432/quarkus_test
 quarkus.flyway.base.locations=classpath:database/base
 quarkus.flyway.base.migrate-at-start=true
+%prod.quarkus.datasource.base.jdbc.url=jdbc:postgresql://localhost:5432/quarkus_test
 
 # Tenant 'mycompany'
 quarkus.datasource.mycompany.db-kind=postgresql
 quarkus.datasource.mycompany.username=mycompany
 quarkus.datasource.mycompany.password=mycompany
-%prod.quarkus.datasource.mycompany.jdbc.url=jdbc:postgresql://localhost:5433/mycompany
 quarkus.flyway.mycompany.locations=classpath:database/mycompany
 quarkus.flyway.mycompany.migrate-at-start=true
+%prod.quarkus.datasource.mycompany.jdbc.url=jdbc:postgresql://localhost:5433/mycompany

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/database/base/V1.0.0__create_fruits.sql
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/database/base/V1.0.0__create_fruits.sql
@@ -1,10 +1,11 @@
-CREATE SEQUENCE known_fruits_id_seq;
-SELECT setval('known_fruits_id_seq', 3);
-CREATE TABLE known_fruits
+CREATE SEQUENCE fruit_seq INCREMENT BY 50; -- 50 is quarkus default
+SELECT setval('fruit_seq', 3);
+CREATE TABLE fruit
 (
-  id   INT,
-  name VARCHAR(40)
+    id   INT,
+    name VARCHAR(40)
 );
-INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
-INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
-INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');
+INSERT INTO fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO fruit(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE fruit_seq RESTART WITH 4;

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/database/mycompany/V1.0.0__create_fruits.sql
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/database/mycompany/V1.0.0__create_fruits.sql
@@ -1,10 +1,11 @@
-CREATE SEQUENCE known_fruits_id_seq;
-SELECT setval('known_fruits_id_seq', 3);
-CREATE TABLE known_fruits
+CREATE SEQUENCE fruit_seq INCREMENT BY 50; -- 50 is quarkus default
+SELECT setval('fruit_seq', 3);
+CREATE TABLE fruit
 (
   id   INT,
   name VARCHAR(40)
 );
-INSERT INTO known_fruits(id, name) VALUES (1, 'Avocado');
-INSERT INTO known_fruits(id, name) VALUES (2, 'Apricots');
-INSERT INTO known_fruits(id, name) VALUES (3, 'Blackberries');
+INSERT INTO fruit(id, name) VALUES (1, 'Avocado');
+INSERT INTO fruit(id, name) VALUES (2, 'Apricots');
+INSERT INTO fruit(id, name) VALUES (3, 'Blackberries');
+ALTER SEQUENCE fruit_seq RESTART WITH 4;

--- a/hibernate-orm-multi-tenancy-schema-quickstart/README.md
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/README.md
@@ -28,28 +28,79 @@ for help setting up your environment.
 Launch the Maven build on the checked out sources of this demo:
 
 > ./mvnw package
+
 ## Running the demo
 
-### Start Quarkus in development mode (Profile 'development')
+### Live coding with Quarkus
 
-The Maven Quarkus plugin provides a development mode that supports live coding. To try this out:
+The Maven Quarkus plugin provides a development mode that supports
+live coding. To try this out:
 
 > ./mvnw quarkus:dev
+
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
-### Run Quarkus as native executable
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
 
-You can also create a native executable from this application without making any source code changes. A native executable removes the dependency on the JVM:
-everything needed to run the application on the target platform is included in the executable, allowing the application to run with minimal resource overhead.
+To access the database from the terminal, run:
 
-Compiling a native executable takes a bit longer, as GraalVM performs additional steps to remove unnecessary codepaths. Use the  `native` profile to compile a
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
+    Hot reload works even when modifying your JPA entities.
+    Try it! Even the database schema will be updated on the fly.
+
+### Run Quarkus in JVM mode
+
+When you're done iterating in developer mode, you can run the application as a
+conventional jar file.
+
+First compile it:
+
+> ./mvnw package
+
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
+
+> docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
+
+Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
+`src/main/resources/application.properties`.
+
+Then run it:
+
+> java -jar ./target/quarkus-app/quarkus-run.jar
+
+    Have a look at how fast it boots.
+    Or measure total native memory consumption...
+
+### Run Quarkus as a native application
+
+You can also create a native executable from this application without making any
+source code changes. A native executable removes the dependency on the JVM:
+everything needed to run the application on the target platform is included in
+the executable, allowing the application to run with minimal resource overhead.
+
+Compiling a native executable takes a bit longer, as GraalVM performs additional
+steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw package -Pnative
+> ./mvnw package -Dnative
 
-After getting a cup of coffee, you'll be able to run this executable directly:
+After getting a cup of coffee, you'll be able to run this binary directly:
 
 > ./target/hibernate-orm-schema-multi-tenancy-quickstart-1.0.0-SNAPSHOT-runner
+
+    Please brace yourself: don't choke on that fresh cup of coffee you just got.
+    
+    Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
+    
+    Next, maybe you're ready to measure how much memory this service is consuming.
+
+N.B. This implies all dependencies have been compiled to native;
+that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM
+applies to your entities, to the lower level essential components such as the PostgreSQL JDBC driver, the Undertow webserver.
 
 ## See the demo in your browser
 

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
@@ -5,18 +5,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "known_fruits")
+@Table
 @NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name")
 @NamedQuery(name = "Fruits.findByName", query = "SELECT f FROM Fruit f WHERE f.name=:name")
 public class Fruit {
 
     @Id
-    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(generator = "fruitsSequence")
+    @GeneratedValue
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/resources/schema/V1.0.0__create_fruits.sql
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/resources/schema/V1.0.0__create_fruits.sql
@@ -1,21 +1,22 @@
-CREATE SEQUENCE base.known_fruits_id_seq;
-SELECT setval('base."known_fruits_id_seq"', 3);
-CREATE TABLE base.known_fruits
+CREATE SEQUENCE base.fruit_seq INCREMENT BY 50; -- 50 is quarkus default
+SELECT setval('base."fruit_seq"', 3);
+CREATE TABLE base.fruit
 (
-  id   INT,
-  name VARCHAR(40)
+    id   INT,
+    name VARCHAR(40)
 );
-INSERT INTO base.known_fruits(id, name) VALUES (1, 'Cherry');
-INSERT INTO base.known_fruits(id, name) VALUES (2, 'Apple');
-INSERT INTO base.known_fruits(id, name) VALUES (3, 'Banana');
+INSERT INTO base.fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO base.fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO base.fruit(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE base.fruit_seq RESTART WITH 4;
 
-CREATE SEQUENCE mycompany.known_fruits_id_seq;
-SELECT setval('mycompany."known_fruits_id_seq"', 3);
-CREATE TABLE mycompany.known_fruits
+CREATE SEQUENCE mycompany.fruit_seq INCREMENT BY 50; -- 50 is quarkus default
+SELECT setval('mycompany."fruit_seq"', 3);
+CREATE TABLE mycompany.fruit
 (
   id   INT,
   name VARCHAR(40)
 );
-INSERT INTO mycompany.known_fruits(id, name) VALUES (1, 'Avocado');
-INSERT INTO mycompany.known_fruits(id, name) VALUES (2, 'Apricots');
-INSERT INTO mycompany.known_fruits(id, name) VALUES (3, 'Blackberries');
+INSERT INTO mycompany.fruit(id, name) VALUES (1, 'Avocado');
+INSERT INTO mycompany.fruit(id, name) VALUES (2, 'Apricots');
+INSERT INTO mycompany.fruit(id, name) VALUES (3, 'Blackberries');

--- a/hibernate-orm-panache-kotlin-quickstart/README.md
+++ b/hibernate-orm-panache-kotlin-quickstart/README.md
@@ -48,6 +48,14 @@ live coding. To try this out:
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
     Hot reload works even when modifying your JPA entities.
     Try it! Even the database schema will be updated on the fly.
 
@@ -60,7 +68,8 @@ First compile it:
 
 > ./mvnw package
 
-Next we need to make sure you have a PostgreSQL instance running (Quarkus automatically starts one for dev and test mode). To set up a PostgreSQL database with Docker:
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
 
 > docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
 

--- a/hibernate-orm-panache-kotlin-quickstart/README.md
+++ b/hibernate-orm-panache-kotlin-quickstart/README.md
@@ -12,6 +12,8 @@ While the code is surprisingly simple, under the hood this is using:
  - Infinispan based caching
  - All safely coordinated by the Narayana Transaction Manager
 
+These examples show how to call methods directly on the entity (`FruitEntity`). For the repository example, see the `hibernate-orm-panache-quickstart`.
+
 ## Requirements
 
 To compile and run this demo you will need:

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/resources/application.properties
@@ -1,10 +1,8 @@
-%prod.quarkus.datasource.db-kind=postgresql
-%prod.quarkus.datasource.username=quarkus_test
-%prod.quarkus.datasource.password=quarkus_test
-%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.datasource.jdbc.max-size=8
-%prod.quarkus.datasource.jdbc.min-size=2
-
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+%prod.quarkus.datasource.username=quarkus_test
+%prod.quarkus.datasource.password=quarkus_test
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
+

--- a/hibernate-orm-panache-quickstart/README.md
+++ b/hibernate-orm-panache-quickstart/README.md
@@ -12,6 +12,8 @@ While the code is surprisingly simple, under the hood this is using:
  - Infinispan based caching
  - All safely coordinated by the Narayana Transaction Manager
 
+This shows two ways to use Panache: one by calling methods directly on the entity (`FruitEntity`), and the other by using a separate repository.
+
 ## Requirements
 
 To compile and run this demo you will need:
@@ -46,6 +48,14 @@ live coding. To try this out:
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
     Hot reload works even when modifying your JPA entities.
     Try it! Even the database schema will be updated on the fly.
 
@@ -58,7 +68,8 @@ First compile it:
 
 > ./mvnw package
 
-Next we need to make sure you have a PostgreSQL instance running (Quarkus automatically starts one for dev and test mode). To set up a PostgreSQL database with Docker:
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
 
 > docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
 

--- a/hibernate-orm-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-panache-quickstart/src/main/resources/application.properties
@@ -1,10 +1,8 @@
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.sql-load-script=import.sql
+
 %prod.quarkus.datasource.db-kind=postgresql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.datasource.jdbc.max-size=8
-%prod.quarkus.datasource.jdbc.min-size=2
-
-quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.sql-load-script=import.sql

--- a/hibernate-orm-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-panache-quickstart/src/main/resources/application.properties
@@ -1,8 +1,7 @@
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql
 
-%prod.quarkus.datasource.db-kind=postgresql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
+%prod.quarkus.hibernate-orm.database.generation=create

--- a/hibernate-orm-quickstart/README.md
+++ b/hibernate-orm-quickstart/README.md
@@ -46,6 +46,14 @@ live coding. To try this out:
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
 Hot reload works even when modifying your JPA entities.
 Try it! Even the database schema will be updated on the fly.
 
@@ -58,7 +66,8 @@ First compile it:
 
 > ./mvnw package
 
-Next we need to make sure you have a PostgreSQL instance running (Quarkus automatically starts one for dev and test mode). To set up a PostgreSQL database with Docker:
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
 
 > docker run --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
 

--- a/hibernate-orm-quickstart/README.md
+++ b/hibernate-orm-quickstart/README.md
@@ -78,8 +78,8 @@ Then run it:
 
 > java -jar ./target/quarkus-app/quarkus-run.jar
 
-Have a look at how fast it boots.
-Or measure total native memory consumption...
+    Have a look at how fast it boots.
+    Or measure total native memory consumption...
 
 ### Run Quarkus as a native application
 
@@ -98,11 +98,11 @@ After getting a cup of coffee, you'll be able to run this binary directly:
 
 > ./target/hibernate-orm-quickstart-1.0.0-SNAPSHOT-runner
 
-Please brace yourself: don't choke on that fresh cup of coffee you just got.
+    Please brace yourself: don't choke on that fresh cup of coffee you just got.
     
-Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
+    Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
     
-Next, maybe you're ready to measure how much memory this service is consuming.
+    Next, maybe you're ready to measure how much memory this service is consuming.
 
 N.B. This implies all dependencies have been compiled to native;
 that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM

--- a/hibernate-orm-quickstart/README.md
+++ b/hibernate-orm-quickstart/README.md
@@ -54,8 +54,8 @@ To access the database from the terminal, run:
 docker exec -it <container-name> psql -U quarkus
 ```
 
-Hot reload works even when modifying your JPA entities.
-Try it! Even the database schema will be updated on the fly.
+    Hot reload works even when modifying your JPA entities.
+    Try it! Even the database schema will be updated on the fly.
 
 ### Run Quarkus in JVM mode
 
@@ -69,7 +69,7 @@ First compile it:
 Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
 To set up a PostgreSQL database with Docker:
 
-> docker run --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
+> docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
 
 Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
 `src/main/resources/application.properties`.

--- a/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
+++ b/hibernate-orm-quickstart/src/main/java/org/acme/hibernate/orm/Fruit.java
@@ -1,24 +1,19 @@
 package org.acme.hibernate.orm;
 
-import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.QueryHint;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "known_fruits")
-@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
-@Cacheable
+@Table
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name")
 public class Fruit {
 
     @Id
-    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(generator = "fruitsSequence")
+    @GeneratedValue
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-orm-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-quickstart/src/main/resources/application.properties
@@ -1,10 +1,7 @@
-%prod.quarkus.datasource.db-kind=postgresql
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.sql-load-script=import.sql
+
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.datasource.jdbc.max-size=8
-%prod.quarkus.datasource.jdbc.min-size=2
 %prod.quarkus.hibernate-orm.database.generation=create
-
-quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.sql-load-script=import.sql

--- a/hibernate-orm-quickstart/src/main/resources/import.sql
+++ b/hibernate-orm-quickstart/src/main/resources/import.sql
@@ -1,4 +1,4 @@
-INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
-INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
-INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');
-ALTER SEQUENCE known_fruits_id_seq RESTART WITH 4;
+INSERT INTO fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO fruit(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE fruit_seq RESTART WITH 4;

--- a/hibernate-orm-rest-data-panache-quickstart/README.md
+++ b/hibernate-orm-rest-data-panache-quickstart/README.md
@@ -42,8 +42,16 @@ live coding. To try this out:
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
-Hot reload works even when modifying your JPA entities.
-Try it! Even the database schema will be updated on the fly.
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
+    Hot reload works even when modifying your JPA entities.
+    Try it! Even the database schema will be updated on the fly.
 
 ### Run Quarkus in JVM mode
 
@@ -54,9 +62,10 @@ First compile it:
 
 > ./mvnw package
 
-Next we need to make sure you have a PostgreSQL instance running (Quarkus automatically starts one for dev and test mode). To set up a PostgreSQL database with Docker:
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
 
-> docker run --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
+> docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
 
 Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
 `src/main/resources/application.properties`.
@@ -65,8 +74,8 @@ Then run it:
 
 > java -jar ./target/quarkus-app/quarkus-run.jar
 
-Have a look at how fast it boots.
-Or measure total native memory consumption...
+    Have a look at how fast it boots.
+    Or measure total native memory consumption...
 
 ### Run Quarkus as a native application
 
@@ -85,11 +94,11 @@ After getting a cup of coffee, you'll be able to run this binary directly:
 
 > ./target/hibernate-orm-rest-data-panache-quickstart-1.0.0-SNAPSHOT-runner
 
-Please brace yourself: don't choke on that fresh cup of coffee you just got.
+    Please brace yourself: don't choke on that fresh cup of coffee you just got.
     
-Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
+    Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
     
-Next, maybe you're ready to measure how much memory this service is consuming.
+    Next, maybe you're ready to measure how much memory this service is consuming.
 
 N.B. This implies all dependencies have been compiled to native;
 that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/resources/application.properties
@@ -1,9 +1,6 @@
-%prod.quarkus.datasource.db-kind=postgresql
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.sql-load-script=import.sql
+
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.datasource.jdbc.max-size=8
-%prod.quarkus.datasource.jdbc.min-size=2
-
-quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.hibernate-orm.sql-load-script=import.sql

--- a/hibernate-reactive-panache-quickstart/README.md
+++ b/hibernate-reactive-panache-quickstart/README.md
@@ -9,6 +9,8 @@ While the code is surprisingly simple, under the hood this is using:
  - A PostgreSQL database; see below to run one via Docker
  - ArC, the CDI inspired dependency injection tool with zero overhead
 
+These examples show how to call methods directly on the entity (`FruitEntity`). For the repository example, see the `hibernate-orm-panache-quickstart`.
+
 ## Requirements
 
 To compile and run this demo you will need:
@@ -34,15 +36,6 @@ Launch the Maven build on the checked out sources of this demo:
 
 ## Running the demo
 
-### Prepare a PostgreSQL instance
-
-Make sure you have a PostgreSQL instance running. To set up a PostgreSQL database with Docker:
-
-> docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
-
-Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
-`src/main/resources/application.properties`.
-
 ### Live coding with Quarkus
 
 The Maven Quarkus plugin provides a development mode that supports
@@ -51,6 +44,14 @@ live coding. To try this out:
 > ./mvnw quarkus:dev
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
+
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
 
     Hot reload works even when modifying your JPA entities.
     Try it! Even the database schema will be updated on the fly.
@@ -63,6 +64,14 @@ conventional jar file.
 First compile it:
 
 > ./mvnw package
+
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
+
+> docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
+
+Connection properties for the Agroal datasource are defined in the standard Quarkus configuration file,
+`src/main/resources/application.properties`.
 
 Then run it:
 

--- a/hibernate-reactive-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-panache-quickstart/src/main/resources/application.properties
@@ -1,10 +1,8 @@
-%prod.quarkus.datasource.db-kind=postgresql
-%prod.quarkus.datasource.username=quarkus_test
-%prod.quarkus.datasource.password=quarkus_test
-
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql
 
 # Reactive config
+%prod.quarkus.datasource.username=quarkus_test
+%prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
+%prod.quarkus.datasource.db-kind=postgresql

--- a/hibernate-reactive-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-panache-quickstart/src/main/resources/application.properties
@@ -5,4 +5,3 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
-%prod.quarkus.datasource.db-kind=postgresql

--- a/hibernate-reactive-quickstart/README.md
+++ b/hibernate-reactive-quickstart/README.md
@@ -43,8 +43,16 @@ live coding. To try this out:
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
-Hot reload works even when modifying your JPA entities.
-Try it! Even the database schema will be updated on the fly.
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
+    Hot reload works even when modifying your JPA entities.
+    Try it! Even the database schema will be updated on the fly.
 
 ### Run Quarkus in JVM mode
 
@@ -55,7 +63,8 @@ First compile it:
 
 > ./mvnw package
 
-Next we need to make sure you have a PostgreSQL instance running (Quarkus automatically starts one for dev and test mode). To set up a PostgreSQL database with Docker:
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
 
 > docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
 
@@ -66,8 +75,8 @@ Then run it:
 
 > java -jar ./target/quarkus-app/quarkus-run.jar
 
-Have a look at how fast it boots.
-Or measure total native memory consumption...
+    Have a look at how fast it boots.
+    Or measure total native memory consumption...
 
 ### Run Quarkus as a native application
 
@@ -86,11 +95,11 @@ After getting a cup of coffee, you'll be able to run this binary directly:
 
 > ./target/hibernate-reactive-quickstart-1.0.0-SNAPSHOT-runner
 
-Please brace yourself: don't choke on that fresh cup of coffee you just got.
+    Please brace yourself: don't choke on that fresh cup of coffee you just got.
     
-Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
+    Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
     
-Next, maybe you're ready to measure how much memory this service is consuming.
+    Next, maybe you're ready to measure how much memory this service is consuming.
 
 N.B. This implies all dependencies have been compiled to native;
 that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM

--- a/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
+++ b/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
@@ -5,9 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.QueryHint;
-import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
 
 @Entity
 @NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name")

--- a/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
+++ b/hibernate-reactive-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
@@ -10,13 +10,11 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "known_fruits")
 @NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name")
 public class Fruit {
 
     @Id
-    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(generator = "fruitsSequence")
+    @GeneratedValue
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-reactive-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-quickstart/src/main/resources/application.properties
@@ -1,10 +1,8 @@
-%prod.quarkus.datasource.db-kind=postgresql
-%prod.quarkus.datasource.username=quarkus_test
-%prod.quarkus.datasource.password=quarkus_test
-
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql
 
 # Reactive config
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
+%prod.quarkus.datasource.db-kind=postgresql
+%prod.quarkus.datasource.username=quarkus_test
+%prod.quarkus.datasource.password=quarkus_test

--- a/hibernate-reactive-quickstart/src/main/resources/import.sql
+++ b/hibernate-reactive-quickstart/src/main/resources/import.sql
@@ -1,4 +1,4 @@
-INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
-INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
-INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');
-ALTER SEQUENCE known_fruits_id_seq RESTART WITH 4;
+INSERT INTO fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO fruit(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE fruit_seq RESTART WITH 4;

--- a/hibernate-reactive-routes-quickstart/README.md
+++ b/hibernate-reactive-routes-quickstart/README.md
@@ -43,8 +43,16 @@ live coding. To try this out:
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
-Hot reload works even when modifying your JPA entities.
-Try it! Even the database schema will be updated on the fly.
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
+    Hot reload works even when modifying your JPA entities.
+    Try it! Even the database schema will be updated on the fly.
 
 ### Run Quarkus in JVM mode
 
@@ -55,7 +63,8 @@ First compile it:
 
 > ./mvnw package
 
-Next we need to make sure you have a PostgreSQL instance running (Quarkus automatically starts one for dev and test mode). To set up a PostgreSQL database with Docker:
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
 
 > docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.3
 
@@ -66,8 +75,8 @@ Then run it:
 
 > java -jar ./target/quarkus-app/quarkus-run.jar
 
-Have a look at how fast it boots.
-Or measure total native memory consumption...
+    Have a look at how fast it boots.
+    Or measure total native memory consumption...
 
 ### Run Quarkus as a native application
 
@@ -86,11 +95,11 @@ After getting a cup of coffee, you'll be able to run this binary directly:
 
 > ./target/hibernate-reactive-routes-quickstart-1.0.0-SNAPSHOT-runner
 
-Please brace yourself: don't choke on that fresh cup of coffee you just got.
+    Please brace yourself: don't choke on that fresh cup of coffee you just got.
     
-Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
+    Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
     
-Next, maybe you're ready to measure how much memory this service is consuming.
+    Next, maybe you're ready to measure how much memory this service is consuming.
 
 N.B. This implies all dependencies have been compiled to native;
 that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM

--- a/hibernate-reactive-routes-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
+++ b/hibernate-reactive-routes-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
@@ -5,18 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "known_fruits")
-@NamedQuery(name = Fruit.FIND_ALL, query = "SELECT f FROM Fruit f ORDER BY f.name")
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name")
 public class Fruit {
     public static final String FIND_ALL = "Fruits.findAll";
 
     @Id
-    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
-    @GeneratedValue(generator = "fruitsSequence")
+    @GeneratedValue
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-reactive-routes-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-routes-quickstart/src/main/resources/application.properties
@@ -1,10 +1,8 @@
-%prod.quarkus.datasource.db-kind=postgresql
-%prod.quarkus.datasource.username=quarkus_test
-%prod.quarkus.datasource.password=quarkus_test
-
-quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql
 
 # Reactive config
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
+%prod.quarkus.datasource.db-kind=postgresql
+%prod.quarkus.datasource.username=quarkus_test
+%prod.quarkus.datasource.password=quarkus_test

--- a/hibernate-reactive-routes-quickstart/src/main/resources/import.sql
+++ b/hibernate-reactive-routes-quickstart/src/main/resources/import.sql
@@ -1,4 +1,4 @@
-INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
-INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
-INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');
-ALTER SEQUENCE known_fruits_id_seq RESTART WITH 4;
+INSERT INTO fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO fruit(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE fruit_seq RESTART WITH 4;

--- a/hibernate-reactive-stateless-quickstart/README.md
+++ b/hibernate-reactive-stateless-quickstart/README.md
@@ -31,7 +31,7 @@ for help setting up your environment.
 
 Launch the Maven build on the checked out sources of this demo:
 
-> ./mvnw install
+> ./mvnw package
 
 ## Running the demo
 
@@ -44,8 +44,16 @@ live coding. To try this out:
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
 
-Hot reload works even when modifying your JPA entities.
-Try it! Even the database schema will be updated on the fly.
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
+
+    Hot reload works even when modifying your JPA entities.
+    Try it! Even the database schema will be updated on the fly.
 
 ### Run Quarkus in JVM mode
 
@@ -54,9 +62,10 @@ conventional jar file.
 
 First compile it:
 
-> ./mvnw install
+> ./mvnw package
 
-Next we need to make sure you have a PostgreSQL instance running (Quarkus automatically starts one for dev and test mode). To set up a PostgreSQL database with Docker:
+Next, make sure you have a PostgreSQL database running. In production, Quarkus does not start a container for you like it does in Dev Mode.
+To set up a PostgreSQL database with Docker:
 
 > docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:11.5
 
@@ -67,8 +76,8 @@ Then run it:
 
 > java -jar ./target/quarkus-app/quarkus-run.jar
 
-Have a look at how fast it boots.
-Or measure total native memory consumption...
+    Have a look at how fast it boots.
+    Or measure total native memory consumption...
 
 ### Run Quarkus as a native application
 
@@ -81,17 +90,17 @@ Compiling a native executable takes a bit longer, as GraalVM performs additional
 steps to remove unnecessary codepaths. Use the  `native` profile to compile a
 native executable:
 
-> ./mvnw install -Dnative
+> ./mvnw package -Dnative
 
 After getting a cup of coffee, you'll be able to run this binary directly:
 
 > ./target/hibernate-reactive-stateless-quickstart-1.0.0-SNAPSHOT-runner
 
-Please brace yourself: don't choke on that fresh cup of coffee you just got.
+    Please brace yourself: don't choke on that fresh cup of coffee you just got.
     
-Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
+    Now observe the time it took to boot, and remember: that time was mostly spent to generate the tables in your database and import the initial data.
     
-Next, maybe you're ready to measure how much memory this service is consuming.
+    Next, maybe you're ready to measure how much memory this service is consuming.
 
 N.B. This implies all dependencies have been compiled to native;
 that's a whole lot of stuff: from the bytecode enhancements that Hibernate ORM

--- a/hibernate-reactive-stateless-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
+++ b/hibernate-reactive-stateless-quickstart/src/main/java/org/acme/hibernate/reactive/Fruit.java
@@ -8,12 +8,11 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "known_fruits")
+@Table
 public class Fruit {
 
     @Id
-    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 10, initialValue = 10)
-    @GeneratedValue(generator = "fruitsSequence")
+    @GeneratedValue
     private Integer id;
 
     @Column(length = 40, unique = true)

--- a/hibernate-reactive-stateless-quickstart/src/main/resources/import.sql
+++ b/hibernate-reactive-stateless-quickstart/src/main/resources/import.sql
@@ -1,4 +1,4 @@
-INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
-INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
-INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');
-alter sequence known_fruits_id_seq RESTART WITH 4;
+INSERT INTO fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO fruit(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE fruit_seq RESTART WITH 4;

--- a/hibernate-search-orm-elasticsearch-quickstart/README.md
+++ b/hibernate-search-orm-elasticsearch-quickstart/README.md
@@ -45,9 +45,17 @@ Note that running this command will start an Elasticsearch cluster, start a Post
 The Maven Quarkus plugin provides a development mode that supports
 live coding. To try this out:
 
->  ./mvnw quarkus:dev
+> ./mvnw quarkus:dev
 
 In this mode you can make changes to the code and have the changes immediately applied, by just refreshing your browser.
+
+Dev Mode automatically starts a Docker container with a Postgres database. This feature is called ["Dev Services."](https://quarkus.io/guides/dev-services)
+
+To access the database from the terminal, run:
+
+```sh
+docker exec -it <container-name> psql -U quarkus
+```
 
     Hot reload works even when modifying your JPA entities.
     Try it! Even the database schema and the Elasticsearch mapping will be updated on the fly.
@@ -64,7 +72,8 @@ First compile it:
 Note that this command will start a PostgreSQL instance and an Elasticsearch cluster to execute the tests.
 Thus your PostgreSQL and Elasticsearch containers need to be stopped.
 
-Next we need to make sure you have a PostgreSQL instance and Elasticsearch instance running
+Next, make sure you have a PostgreSQL database running and an ElasticSearch instance. 
+In production, Quarkus does not start a container for you like it does in Dev Mode.
 (Quarkus automatically starts one of each for dev and test mode, but not for prod mode).
 
 To set up a PostgreSQL database using Docker:


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/45715

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


