### PR TITLE
Renamed quarkus.hibernate-orm.database.generation to quarkus.hibernate-orm.schema-management.strategy

### DIFF
--- a/context-propagation-quickstart/src/main/resources/application.properties
+++ b/context-propagation-quickstart/src/main/resources/application.properties
@@ -5,5 +5,5 @@
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.log.sql=true

--- a/hibernate-orm-jakarta-data-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-jakarta-data-quickstart/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create
 
 %dev.quarkus.hibernate-orm.log.sql=true
 

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 
 quarkus.hibernate-orm.multitenant=DATABASE
 quarkus.hibernate-orm.datasource=base

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 
 quarkus.hibernate-orm.multitenant=SCHEMA
 

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/resources/application.properties
@@ -4,5 +4,5 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create
 

--- a/hibernate-orm-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-panache-quickstart/src/main/resources/application.properties
@@ -4,4 +4,4 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create

--- a/hibernate-orm-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-quickstart/src/main/resources/application.properties
@@ -4,4 +4,4 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/resources/application.properties
@@ -4,4 +4,4 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create

--- a/hibernate-reactive-panache-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-panache-quickstart/src/main/resources/application.properties
@@ -5,4 +5,4 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create

--- a/hibernate-reactive-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-quickstart/src/main/resources/application.properties
@@ -5,4 +5,4 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create

--- a/hibernate-reactive-routes-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-routes-quickstart/src/main/resources/application.properties
@@ -5,4 +5,4 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create

--- a/hibernate-reactive-stateless-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-stateless-quickstart/src/main/resources/application.properties
@@ -5,4 +5,4 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/resources/application.properties
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/resources/application.properties
@@ -11,5 +11,5 @@ quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
-%prod.quarkus.hibernate-orm.database.generation=create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create
 %prod.quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:9200

--- a/kafka-panache-quickstart/src/main/resources/application.properties
+++ b/kafka-panache-quickstart/src/main/resources/application.properties
@@ -14,5 +14,5 @@ mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serializ
 
 %prod.kafka.bootstrap.servers=localhost:9092
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 

--- a/kafka-panache-reactive-quickstart/src/main/resources/application.properties
+++ b/kafka-panache-reactive-quickstart/src/main/resources/application.properties
@@ -9,5 +9,5 @@ mp.messaging.outgoing.generated-price.topic=prices
 
 %prod.kafka.bootstrap.servers=localhost:9092
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 

--- a/optaplanner-quickstart/src/main/resources/application.properties
+++ b/optaplanner-quickstart/src/main/resources/application.properties
@@ -34,7 +34,7 @@ quarkus.log.category."org.optaplanner".level=DEBUG
 # "jdbc:h2:mem" doesn't work in native mode, but native mode uses %prod properties
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:school-timetabling;DB_CLOSE_DELAY=-1
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 ########################
 # Test overrides

--- a/quartz-quickstart/src/main/resources/application.properties
+++ b/quartz-quickstart/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.quartz.clustered=true
 %prod.quarkus.datasource.password=quarkus_test
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
 
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=no-file
 

--- a/security-jpa-quickstart/src/main/resources/application.properties
+++ b/security-jpa-quickstart/src/main/resources/application.properties
@@ -3,4 +3,4 @@
 %prod.quarkus.datasource.password=quarkus
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/security-jpa-reactive-quickstart/src/main/resources/application.properties
+++ b/security-jpa-reactive-quickstart/src/main/resources/application.properties
@@ -3,5 +3,5 @@
 %prod.quarkus.datasource.password=quarkus
 %prod.quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost:5431/elytron_security_jpa
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/security-webauthn-quickstart/src/main/resources/application.properties
+++ b/security-webauthn-quickstart/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 %prod.quarkus.datasource.password=quarkus
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_webauthn
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.webauthn.login-page=/
 quarkus.webauthn.enable-login-endpoint=true

--- a/security-webauthn-reactive-quickstart/src/main/resources/application.properties
+++ b/security-webauthn-reactive-quickstart/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 %prod.quarkus.datasource.password=quarkus
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_webauthn
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.webauthn.login-page=/
 quarkus.webauthn.enable-login-endpoint=true

--- a/spring-data-jpa-quickstart/src/main/resources/application.properties
+++ b/spring-data-jpa-quickstart/src/main/resources/application.properties
@@ -5,5 +5,5 @@
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/spring-data-rest-quickstart/src/main/resources/application.properties
+++ b/spring-data-rest-quickstart/src/main/resources/application.properties
@@ -4,4 +4,4 @@
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql:quarkus_test
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create


### PR DESCRIPTION
After this change in Quarkus

https://github.com/quarkusio/quarkus/commit/18bd56189d9806750e3f8bd90a938ab880a132d5


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


