### PR TITLE
Implement daily-aarch64-development.yml

### DIFF
--- a/.github/workflows/daily-aarch64-development.yml
+++ b/.github/workflows/daily-aarch64-development.yml
@@ -1,0 +1,128 @@
+---
+name: "Daily Build - Aarch64"
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  repository_dispatch:
+  workflow_dispatch:
+
+jobs:
+  generate-json-matrix:
+    name: Tests - Read JSON matrix
+    runs-on: ubuntu-latest
+    if: "github.repository == 'quarkusio/quarkus-quickstarts' || github.event_name == 'workflow_dispatch'"
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.ref || 'development' }}
+      - id: generate
+        run: |
+          json=$(.github/generate-native-matrix.sh | tr -d '\n')
+          echo "matrix=${json}" >> $GITHUB_OUTPUT
+
+  linux-build-native:
+    name: Linux - Native build
+    runs-on: ubuntu-24.04-arm
+    needs: [ generate-json-matrix ]
+    if: "github.repository == 'quarkusio/quarkus-quickstarts' || github.event_name == 'workflow_dispatch'"
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{fromJson(needs.generate-json-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.ref || 'development' }}
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: q2maven-native-aarch64-${{ steps.get-date.outputs.date }}
+
+      - name: Install JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          check-latest: true
+          cache: 'maven'
+
+      - name: Build Quarkus main
+        run: |
+          git clone https://github.com/quarkusio/quarkus.git
+          cd quarkus
+          ./mvnw -T1C -e -B --settings .github/mvn-settings.xml clean install -Dquickly-ci
+
+      - name: Test Quickstarts in Native mode
+        run: |
+          ./mvnw -e -B --settings .github/mvn-settings.xml clean install --fail-at-end -Dnative -Dstart-containers \
+            -Dquarkus.native.container-build=true -am -pl "${{ matrix.test-modules }}"
+
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              '**/target/*-reports/TEST-*.xml' \
+              '**/build/test-results/test/TEST-*.xml' \
+              'target/build-report.json' \
+              'target/gradle-build-scan-url.txt' \
+              LICENSE
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-Native Tests - ${{matrix.category}}"
+          path: |
+            build-reports.zip
+          retention-days: 7
+
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -rf ~/.m2/repository/org/acme
+  build-report:
+    runs-on: ubuntu-latest
+    name: Build report
+    needs: [ linux-build-native ]
+    if: always()
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: build-reports-artifacts
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Produce report and add it as job summary
+        uses: quarkusio/action-build-reporter@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          build-reports-artifacts-path: build-reports-artifacts
+  report:
+    name: Report
+    runs-on: ubuntu-latest
+    needs: [ linux-build-native ]
+    if: "always() && github.repository == 'quarkusio/quarkus-quickstarts'"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.ref || 'development' }}
+      - uses: quarkusio/report-status-in-issue@main
+        with:
+          github-token: ${{ secrets.GITHUB_API_TOKEN }}
+          status: ${{ needs.linux-build-native.result == 'success' && 'success' || 'failure' }}
+          issue-repository: quarkusio/quarkus
+          issue-number: 48241


### PR DESCRIPTION
## Summary
This PR extends the existing quickstarts CI workflows to include aarch64 runner support

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


