### PR TITLE
Re-enable jms quickstart tests

### DIFF
--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -19,8 +19,8 @@
         <quarkus-artemis.version>3.8.0</quarkus-artemis.version>
 
         <!-- Tests are unstable -->
-        <skipTests>true</skipTests>
-        <skipITs>true</skipITs>
+        <skipTests>false</skipTests>
+        <skipITs>false</skipITs>
     </properties>
 
     <dependencyManagement>

--- a/jms-quickstart/src/main/java/org/acme/jms/PriceProducer.java
+++ b/jms-quickstart/src/main/java/org/acme/jms/PriceProducer.java
@@ -27,7 +27,7 @@ public class PriceProducer implements Runnable {
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     void onStart(@Observes StartupEvent ev) {
-        scheduler.scheduleWithFixedDelay(this, 0L, 5L, TimeUnit.SECONDS);
+        scheduler.scheduleWithFixedDelay(this, 1L, 5L, TimeUnit.SECONDS);
     }
 
     void onStop(@Observes ShutdownEvent ev) {


### PR DESCRIPTION
Scheduing the test message to be published after small delay appears to get around randomness of commented out tests

**Check list**:

Your pull request:

- [ x] targets the `development` branch
- [ x] uses the `999-SNAPSHOT` version of Quarkus
- [ x] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


