### PR TITLE
Use new configuration to set the native image test profile

### DIFF
--- a/security-openid-connect-client-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-client-quickstart/src/main/resources/application.properties
@@ -11,7 +11,7 @@ quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 
-quarkus.test.native-image-profile=test
+quarkus.test.integration-test-profile=test
 
 %prod.port=8080
 %dev.port=8080


### PR DESCRIPTION
Because of https://github.com/quarkusio/quarkus/pull/47759