### PR TITLE
Update docker-maven-plugin to 0.46.0

### DIFF
--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.version>3.24.4</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
-        <docker-plugin.version>0.28.0</docker-plugin.version>
+        <docker-plugin.version>0.46.0</docker-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/hibernate-orm-jakarta-data-quickstart/pom.xml
+++ b/hibernate-orm-jakarta-data-quickstart/pom.xml
@@ -178,7 +178,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -217,7 +217,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -161,7 +161,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -169,7 +169,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-orm-rest-data-panache-quickstart/pom.xml
+++ b/hibernate-orm-rest-data-panache-quickstart/pom.xml
@@ -161,7 +161,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -178,7 +178,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -180,7 +180,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -165,7 +165,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/hibernate-reactive-stateless-quickstart/pom.xml
+++ b/hibernate-reactive-stateless-quickstart/pom.xml
@@ -180,7 +180,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.24.4</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <docker-plugin.version>0.28.0</docker-plugin.version>
+    <docker-plugin.version>0.46.0</docker-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <optaplanner-quarkus.version>10.0.0</optaplanner-quarkus.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <docker-plugin.version>0.28.0</docker-plugin.version>
+    <docker-plugin.version>0.46.0</docker-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.version>3.24.4</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
-        <docker-plugin.version>0.28.0</docker-plugin.version>
+        <docker-plugin.version>0.46.0</docker-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -147,7 +147,7 @@
                                                     docker-maven-plugin
                                                 </artifactId>
                                                 <versionRange>
-                                                    [0.28.0,)
+                                                    [0.46.0,)
                                                 </versionRange>
                                                 <goals>
                                                     <goal>start</goal>


### PR DESCRIPTION
The old version doesn't work properly with Mac Silicons and Docker. Fails with:

```
could not get native definition for type: POINTER: java.lang.UnsatisfiedLinkError:
.
.
.
(fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or 'arm64'))
```