### PR TITLE
Migrate deprecate @AccessToken annotation

### DIFF
--- a/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/RestClientWithTokenPropagationFilter.java
+++ b/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/RestClientWithTokenPropagationFilter.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.Produces;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.token.propagation.AccessToken;
+import io.quarkus.oidc.token.propagation.common.AccessToken;
 import io.smallrye.mutiny.Uni;
 
 @RegisterRestClient


### PR DESCRIPTION
This annotation has been deprecated in Quarkus 3.19 and we shouldn't use it as it is marked for removal.

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


