### PR TITLE
Ensure annotation processor respects depmgmt with Jakarta Data

### DIFF
--- a/hibernate-orm-jakarta-data-quickstart/pom.xml
+++ b/hibernate-orm-jakarta-data-quickstart/pom.xml
@@ -78,6 +78,8 @@
                 <configuration>
                     <!-- the parameters=true option is critical so that RESTEasy works fine -->
                     <parameters>true</parameters>
+                    <!-- for the annotation processor transitive dependencies to be managed by Quarkus, we need this setting -->
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     <!-- the hibernate annotation processor provides both static metamodel and Jakarta Data capabilities: -->
                     <annotationProcessorPaths>
                         <path>


### PR DESCRIPTION
* Adding configuration to Maven compiler plugin to ensure that annotation processor dependency resolution respects dependency management of the project rather than dependencies of the processor for hibernate-orm-jakarta-data quickstart.

Also see https://github.com/quarkusio/quarkus/pull/50243

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


