### PR TITLE
Fix LocalStack Dev Service failures on non-localhost Docker hosts for amazon-quickstarts

### DIFF
--- a/amazon-dynamodb-quickstart/src/test/resources/application.properties
+++ b/amazon-dynamodb-quickstart/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.aws.devservices.localstack.init-scripts-classpath=localstack-init
 quarkus.aws.devservices.localstack.init-completion-msg=#### Tests init completed
+quarkus.aws.devservices.localstack.container-properties.LOCALSTACK_HOST=127.0.0.1

--- a/amazon-kms-quickstart/src/test/resources/application.properties
+++ b/amazon-kms-quickstart/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.aws.devservices.localstack.init-scripts-classpath=localstack-init
 quarkus.aws.devservices.localstack.init-completion-msg=#### Tests init completed
+quarkus.aws.devservices.localstack.container-properties.LOCALSTACK_HOST=127.0.0.1

--- a/amazon-ses-quickstart/src/test/resources/application.properties
+++ b/amazon-ses-quickstart/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.aws.devservices.localstack.init-scripts-classpath=localstack-init
 quarkus.aws.devservices.localstack.init-completion-msg=#### Tests init completed
+quarkus.aws.devservices.localstack.container-properties.LOCALSTACK_HOST=127.0.0.1

--- a/amazon-sns-quickstart/src/test/resources/application.properties
+++ b/amazon-sns-quickstart/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.aws.devservices.localstack.init-scripts-classpath=localstack-init
 quarkus.aws.devservices.localstack.init-completion-msg=#### Tests init completed
+quarkus.aws.devservices.localstack.container-properties.LOCALSTACK_HOST=127.0.0.1


### PR DESCRIPTION
This PR fixes test failures in Quarkus Quickstarts (like amazon-dynamodb-quickstart, amazon-kms-quickstart,...) that use LocalStack Dev Services on Windows.

Failures were discovered in our Jenkins job rhbq-3.27-win22-jdk17-quickstarts-ts-jvm
When tests were running on a Windows machine using Quarkus Dev Services for LocalStack, these failed.
But the failures could occur in environments where the Docker host is configured on a non-localhost IP (e.g., when using Minikube).

The Java tests fail with ResourceNotFoundException, indicating that the init scripts never created the AWS resources (like DynamoDB tables):

```
[io.qua.ver.htt.run.QuarkusErrorHandler] (vert.x-eventloop-thread-0) HTTP Request to /async-fruits failed, error id: 91785ec3-3c1d-4fcb-9f24-4c60139a0320-2: software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException: Cannot do operations on a non-existent table (Service: DynamoDb, Status Code: 400, Request ID: 3fab99b0-c63f-442e-80c7-ca79219b5765) (SDK Attempt Count: 1)
        at software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException$BuilderImpl.build(ResourceNotFoundException.java:151)
```

The LocalStack container logs show the init scripts are executing, but the awslocal command fails with a connection error.
It is trying to connect to the external Docker Host IP (e.g., 192.168.0.10) from within the container, instead of using the container's internal localhost.
 
```
LocalStack version: 4.2.0
LocalStack build date: 2025-02-27
LocalStack build git hash: 2144203e0
++ awslocal kms create-key --query KeyMetadata.KeyId --output text
Could not connect to the endpoint URL: "http://192.168.0.10:4566/"
+ key_id=
2025-10-22T21:01:47.807 ERROR — [ady_monitor)] localstack.runtime.init    : Error while running script Script(path='/etc/localstack/init/ready.d/01_create_key.sh', stage=READY, state=ERROR): Script /etc/localstack/init/ready.d/01_create_key.sh returned a non-zero exit code 255
Tests init completed

```

Investigating seems related to a  breaking change introduced in quarkus-amazon-services 3.4.0 (PR #1557 https://github.com/quarkiverse/quarkus-amazon-services/pull/1557 ) 
Now in 3.4.0, the shared network is only configured when explicitly enabled via `quarkus.devservices.launch-on-shared-network=true`, but that on Linux environments would fail.

Adding the following property to src/test/resources/application.properties:
`quarkus.aws.devservices.localstack.container-properties.LOCALSTACK_HOST=127.0.0.1` ensures the init scripts run successfully on Windows and on the rest of the environments.
