### PR TITLE
Bump quarkus-amazon-services to 3.12.1 to fix Windows CI

### DIFF
--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
         <awssdk.testcontainers.version>1.12.57</awssdk.testcontainers.version>
     </properties>
 

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-sqs-connector-quickstart/pom.xml
+++ b/amazon-sqs-connector-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+    <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus-amazon-services.version>3.11.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>3.12.1</quarkus-amazon-services.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Summary
We are currently experiencing blocking failures in our Windows CI environment regarding the Amazon Quickstarts. 
The issue is related to how LocalStack networking is resolved on Windows.

Bumps [io.quarkiverse.amazonservices:quarkus-amazon-services-bom](https://github.com/quarkiverse/quarkus-amazon-services) from 3.11.0 to 3.12.1.
- [Release notes](https://github.com/quarkiverse/quarkus-amazon-services/releases)
- [Commits](https://github.com/quarkiverse/quarkus-amazon-services/compare/3.11.0...3.12.1)

---
updated-dependencies:
- dependency-name: io.quarkiverse.amazonservices:quarkus-amazon-services-bom dependency-version: 3.12.1 dependency-type: direct:production update-type: version-update:semver-minor ...


(cherry picked from commit 7e096fa4689a5a4d6bb3a00669d4934c8f32f682)



