### PR TITLE
Bump build-reporter-maven-extension from 2.2.0 to 3.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
             <extension>
                 <groupId>io.quarkus.bot</groupId>
                 <artifactId>build-reporter-maven-extension</artifactId>
-                <version>2.2.0</version>
+                <version>3.13.1</version>
             </extension>
         </extensions>
     </build>


### PR DESCRIPTION
Bump build-reporter-maven-extension from 2.2.0 to 3.13.1

Your pull request:

- [x] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


