### PR TITLE
Ensure the test passes even when JSON fields get swapped

### DIFF
--- a/infinispan-client-quickstart/src/test/java/org/acme/infinispan/client/InfinispanGreetingResourceTest.java
+++ b/infinispan-client-quickstart/src/test/java/org/acme/infinispan/client/InfinispanGreetingResourceTest.java
@@ -24,6 +24,7 @@ class InfinispanGreetingResourceTest {
                 .when().get("/greeting/quarkus")
                 .then()
                 .statusCode(200)
-                .body(is("{\"name\":\"Infinispan Client\",\"message\":\"Hello World, Infinispan is up!\"}"));
+                .body("name", is("Infinispan Client"))
+                .body("message", is("Hello World, Infinispan is up!"));
     }
 }


### PR DESCRIPTION

The Infinispan Quickstart seems no fail regularly to me locally as the JSON fields get swapped in the response; this seems an entirely valid response but the test doesn't seem to allow for this. Odd.
