### PR TITLE
Update surefire plugin

### DIFF
--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-dynamodb-quickstart/pom.xml
+++ b/amazon-dynamodb-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-dynamodb-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-dynamodb-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-kms-quickstart/pom.xml
+++ b/amazon-kms-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-kms-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-kms-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-kms-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-kms-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-kms-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-kms-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-kms-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-kms-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-kms-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-kms-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-kms-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-s3-quickstart/pom.xml
+++ b/amazon-s3-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-s3-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-s3-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-s3-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-s3-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-s3-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-s3-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-s3-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-s3-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-s3-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-s3-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-s3-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-ses-quickstart/pom.xml
+++ b/amazon-ses-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-ses-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-ses-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ses-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-ses-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ses-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-ses-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ses-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-ses-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ses-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-ses-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-ses-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-sns-quickstart/pom.xml
+++ b/amazon-sns-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-sns-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sns-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sns-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sns-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sns-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sns-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sns-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sns-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sns-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-sns-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-sns-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amazon-sqs-connector-quickstart/pom.xml
+++ b/amazon-sqs-connector-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-sqs-connector-quickstart/pom.xml
+++ b/amazon-sqs-connector-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-sqs-connector-quickstart/pom.xml
+++ b/amazon-sqs-connector-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-sqs-connector-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-sqs-connector-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-sqs-quickstart/pom.xml
+++ b/amazon-sqs-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-sqs-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sqs-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-sqs-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sqs-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-sqs-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-sqs-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-sqs-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-sqs-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/amazon-ssm-quickstart/pom.xml
+++ b/amazon-ssm-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/amazon-ssm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-ssm-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ssm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/amazon-ssm-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ssm-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-ssm-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ssm-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/amazon-ssm-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/amazon-ssm-quickstart/src/main/docker/Dockerfile.native
+++ b/amazon-ssm-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/amazon-ssm-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/amqp-quickstart/amqp-quickstart-processor/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-processor/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/amqp-quickstart/amqp-quickstart-producer/pom.xml
+++ b/amqp-quickstart/amqp-quickstart-producer/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/awt-graphics-rest-quickstart/pom.xml
+++ b/awt-graphics-rest-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/cache-quickstart/pom.xml
+++ b/cache-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/cache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/cache-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/cache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/cache-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/cache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/cache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/cache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/cache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/cache-quickstart/src/main/docker/Dockerfile.native
+++ b/cache-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/cache-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/config-quickstart/pom.xml
+++ b/config-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/config-quickstart/src/main/docker/Dockerfile.jvm
+++ b/config-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/config-quickstart/src/main/docker/Dockerfile.jvm
+++ b/config-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/config-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/config-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/config-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/config-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/config-quickstart/src/main/docker/Dockerfile.native
+++ b/config-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/config-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>quarkus</packaging>
     <properties>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/context-propagation-quickstart/pom.xml
+++ b/context-propagation-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/context-propagation-quickstart/src/main/docker/Dockerfile.jvm
+++ b/context-propagation-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/context-propagation-quickstart/src/main/docker/Dockerfile.jvm
+++ b/context-propagation-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/context-propagation-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/context-propagation-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/context-propagation-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/context-propagation-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/context-propagation-quickstart/src/main/docker/Dockerfile.native
+++ b/context-propagation-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/context-propagation-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/elasticsearch-quickstart/pom.xml
+++ b/elasticsearch-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/elasticsearch-quickstart/pom.xml
+++ b/elasticsearch-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>

--- a/elasticsearch-quickstart/pom.xml
+++ b/elasticsearch-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>

--- a/elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/elasticsearch-quickstart/src/main/docker/Dockerfile.native
+++ b/elasticsearch-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/elasticsearch-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-http-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-amazon-lambda-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-http-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-google-cloud-functions-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-http-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-http-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
+++ b/funqy-quickstarts/funqy-knative-events-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/pom.xml
+++ b/getting-started-async/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-async/src/main/docker/Dockerfile.jvm
+++ b/getting-started-async/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-async/src/main/docker/Dockerfile.jvm
+++ b/getting-started-async/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-async/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-async/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-async/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-async/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-async/src/main/docker/Dockerfile.native
+++ b/getting-started-async/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-async
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/pom.xml
+++ b/getting-started-command-mode/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-command-mode/src/main/docker/Dockerfile.jvm
+++ b/getting-started-command-mode/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-command-mode/src/main/docker/Dockerfile.jvm
+++ b/getting-started-command-mode/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-command-mode/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-command-mode/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-command-mode/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-command-mode/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-command-mode/src/main/docker/Dockerfile.native
+++ b/getting-started-command-mode/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-command-mode
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/getting-started-dev-services/pom.xml
+++ b/getting-started-dev-services/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-dev-services/pom.xml
+++ b/getting-started-dev-services/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-dev-services/src/main/docker/Dockerfile.jvm
+++ b/getting-started-dev-services/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-dev-services/src/main/docker/Dockerfile.jvm
+++ b/getting-started-dev-services/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-dev-services/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-dev-services/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-dev-services/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-dev-services/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-dev-services/src/main/docker/Dockerfile.native
+++ b/getting-started-dev-services/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-dev-services
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/getting-started-dev-services/src/main/resources/META-INF/resources/index.html
+++ b/getting-started-dev-services/src/main/resources/META-INF/resources/index.html
@@ -238,7 +238,7 @@
                                 <li>GroupId: <code>org.acme</code></li>
                                 <li>ArtifactId: <code>code-with-quarkus</code></li>
                                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
+                                <li>Quarkus Version: <code>3.32.1</code></li>
                             </ul>
                         </div>
                     </div>

--- a/getting-started-dev-services/src/main/resources/META-INF/resources/index.html
+++ b/getting-started-dev-services/src/main/resources/META-INF/resources/index.html
@@ -238,7 +238,7 @@
                                 <li>GroupId: <code>org.acme</code></li>
                                 <li>ArtifactId: <code>code-with-quarkus</code></li>
                                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                                <li>Quarkus Version: <code>3.1.2.Final</code></li>
+                                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
                             </ul>
                         </div>
                     </div>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -14,8 +14,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/getting-started-knative/pom.xml
+++ b/getting-started-knative/pom.xml
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>

--- a/getting-started-knative/src/main/docker/Dockerfile.jvm
+++ b/getting-started-knative/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-knative/src/main/docker/Dockerfile.jvm
+++ b/getting-started-knative/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-knative/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-knative/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-knative/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-knative/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-knative/src/main/docker/Dockerfile.native
+++ b/getting-started-knative/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-knative
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>

--- a/getting-started-reactive-crud/pom.xml
+++ b/getting-started-reactive-crud/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/getting-started-reactive-crud/src/main/docker/Dockerfile.jvm
+++ b/getting-started-reactive-crud/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive-crud/src/main/docker/Dockerfile.jvm
+++ b/getting-started-reactive-crud/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive-crud/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-reactive-crud/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive-crud/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-reactive-crud/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive-crud/src/main/docker/Dockerfile.native
+++ b/getting-started-reactive-crud/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-reactive-crud
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/pom.xml
+++ b/getting-started-reactive/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-reactive/src/main/docker/Dockerfile.jvm
+++ b/getting-started-reactive/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive/src/main/docker/Dockerfile.jvm
+++ b/getting-started-reactive/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-reactive/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-reactive/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-reactive/src/main/docker/Dockerfile.native
+++ b/getting-started-reactive/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-reactive
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/pom.xml
+++ b/getting-started-testing/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started-testing/src/main/docker/Dockerfile.jvm
+++ b/getting-started-testing/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-testing/src/main/docker/Dockerfile.jvm
+++ b/getting-started-testing/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-testing/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-testing/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-testing/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started-testing/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started-testing/src/main/docker/Dockerfile.native
+++ b/getting-started-testing/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-testing
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/pom.xml
+++ b/getting-started/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/getting-started/src/main/docker/Dockerfile.jvm
+++ b/getting-started/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started/src/main/docker/Dockerfile.jvm
+++ b/getting-started/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started/src/main/docker/Dockerfile.legacy-jar
+++ b/getting-started/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/getting-started/src/main/docker/Dockerfile.native
+++ b/getting-started/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/google-cloud-functions-http-quickstart/pom.xml
+++ b/google-cloud-functions-http-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.jvm
+++ b/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.jvm
+++ b/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.native
+++ b/google-cloud-functions-http-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/google-cloud-functions-http-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/google-cloud-functions-quickstart/pom.xml
+++ b/google-cloud-functions-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/google-cloud-functions-quickstart/src/main/docker/Dockerfile.jvm
+++ b/google-cloud-functions-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-quickstart/src/main/docker/Dockerfile.jvm
+++ b/google-cloud-functions-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/google-cloud-functions-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/google-cloud-functions-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/google-cloud-functions-quickstart/src/main/docker/Dockerfile.native
+++ b/google-cloud-functions-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/google-cloud-functions-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <assertj.version>3.27.7</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <assertj.version>3.27.7</assertj.version>

--- a/grpc-plain-text-quickstart/pom.xml
+++ b/grpc-plain-text-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <assertj.version>3.27.7</assertj.version>
 

--- a/grpc-plain-text-quickstart/src/main/docker/Dockerfile.jvm
+++ b/grpc-plain-text-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-plain-text-quickstart/src/main/docker/Dockerfile.jvm
+++ b/grpc-plain-text-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-plain-text-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/grpc-plain-text-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-plain-text-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/grpc-plain-text-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-plain-text-quickstart/src/main/docker/Dockerfile.native
+++ b/grpc-plain-text-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/grpc-plain-text-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <assertj.version>3.27.7</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <assertj.version>3.27.7</assertj.version>

--- a/grpc-tls-quickstart/pom.xml
+++ b/grpc-tls-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <assertj.version>3.27.7</assertj.version>
 

--- a/grpc-tls-quickstart/src/main/docker/Dockerfile.jvm
+++ b/grpc-tls-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-tls-quickstart/src/main/docker/Dockerfile.jvm
+++ b/grpc-tls-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-tls-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/grpc-tls-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-tls-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/grpc-tls-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/grpc-tls-quickstart/src/main/docker/Dockerfile.native
+++ b/grpc-tls-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/grpc-tls-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-jakarta-data-quickstart/pom.xml
+++ b/hibernate-orm-jakarta-data-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-jakarta-data-quickstart/pom.xml
+++ b/hibernate-orm-jakarta-data-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-orm-jakarta-data-quickstart/pom.xml
+++ b/hibernate-orm-jakarta-data-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-jakarta-data-quickstart
 #
-# The ` registry.access.redhat.com/ubi8/ubi-minimal:8.10` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.native-micro
+++ b/hibernate-orm-jakarta-data-quickstart/src/main/docker/Dockerfile.native-micro
@@ -16,10 +16,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-jakarta-data-quickstart
 #
-# The `quay.io/quarkus/quarkus-micro-image:2.0` base image is based on UBI 9.
+# The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.
 ###
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-multi-tenancy-database-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-database-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-multi-tenancy-database-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-database-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-orm-multi-tenancy-database-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-database-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-multi-tenancy-database-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-multi-tenancy-database-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-multi-tenancy-schema-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-multi-tenancy-schema-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-orm-multi-tenancy-schema-quickstart/pom.xml
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-multi-tenancy-schema-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-multi-tenancy-schema-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <kotlin.version>2.3.0</kotlin.version>

--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <kotlin.version>2.3.0</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-kotlin-quickstart/pom.xml
+++ b/hibernate-orm-panache-kotlin-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <kotlin.version>2.3.0</kotlin.version>

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-panache-kotlin-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-panache-kotlin-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-orm-panache-quickstart/pom.xml
+++ b/hibernate-orm-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-panache-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-panache-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-orm-quickstart/pom.xml
+++ b/hibernate-orm-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-orm-rest-data-panache-quickstart/pom.xml
+++ b/hibernate-orm-rest-data-panache-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-rest-data-panache-quickstart/pom.xml
+++ b/hibernate-orm-rest-data-panache-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-orm-rest-data-panache-quickstart/pom.xml
+++ b/hibernate-orm-rest-data-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-orm-rest-data-panache-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-orm-rest-data-panache-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-reactive-panache-quickstart/pom.xml
+++ b/hibernate-reactive-panache-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-reactive-panache-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-reactive-panache-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-reactive-quickstart/pom.xml
+++ b/hibernate-reactive-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-reactive-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-reactive-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-reactive-routes-quickstart/pom.xml
+++ b/hibernate-reactive-routes-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-reactive-routes-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-reactive-routes-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-reactive-stateless-quickstart/pom.xml
+++ b/hibernate-reactive-stateless-quickstart/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-stateless-quickstart/pom.xml
+++ b/hibernate-reactive-stateless-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-reactive-stateless-quickstart/pom.xml
+++ b/hibernate-reactive-stateless-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-reactive-stateless-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-reactive-stateless-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
 
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
 
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-orm-elasticsearch-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
 
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-search-orm-elasticsearch-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-search-orm-elasticsearch-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/hibernate-search-standalone-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-standalone-elasticsearch-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
 
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/hibernate-search-standalone-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-standalone-elasticsearch-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
 
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/hibernate-search-standalone-elasticsearch-quickstart/pom.xml
+++ b/hibernate-search-standalone-elasticsearch-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
 
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
+++ b/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.native
+++ b/hibernate-search-standalone-elasticsearch-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/hibernate-search-standalone-elasticsearch-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/infinispan-cache-quickstart/pom.xml
+++ b/infinispan-cache-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/infinispan-cache-quickstart/pom.xml
+++ b/infinispan-cache-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/infinispan-cache-quickstart/pom.xml
+++ b/infinispan-cache-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/infinispan-cache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/infinispan-cache-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-cache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/infinispan-cache-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-cache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/infinispan-cache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-cache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/infinispan-cache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-cache-quickstart/src/main/docker/Dockerfile.native
+++ b/infinispan-cache-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/infinispan-cache-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/infinispan-client-quickstart/pom.xml
+++ b/infinispan-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/infinispan-client-quickstart/src/main/docker/Dockerfile.native
+++ b/infinispan-client-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/infinispan-client-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/pom.xml
+++ b/jms-quickstart/pom.xml
@@ -12,8 +12,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/jms-quickstart/src/main/docker/Dockerfile.jvm
+++ b/jms-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/jms-quickstart/src/main/docker/Dockerfile.jvm
+++ b/jms-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/jms-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/jms-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/jms-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/jms-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/jms-quickstart/src/main/docker/Dockerfile.native
+++ b/jms-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/jms-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jta-quickstart/pom.xml
+++ b/jta-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/kafka-avro-schema-quickstart/pom.xml
+++ b/kafka-avro-schema-quickstart/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-bare-quickstart/pom.xml
+++ b/kafka-bare-quickstart/pom.xml
@@ -9,8 +9,8 @@
   <properties>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-panache-quickstart/pom.xml
+++ b/kafka-panache-quickstart/pom.xml
@@ -9,8 +9,8 @@
   <properties>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-quickstart/src/main/docker/Dockerfile.native
+++ b/kafka-panache-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/kafka-panache-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/pom.xml
+++ b/kafka-panache-reactive-quickstart/pom.xml
@@ -9,8 +9,8 @@
   <properties>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.native
+++ b/kafka-panache-reactive-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/kafka-panache-reactive-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -14,7 +14,7 @@
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>quarkus</packaging>
     <properties>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/kafka-quickstart/processor/pom.xml
+++ b/kafka-quickstart/processor/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -14,7 +14,7 @@
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>quarkus</packaging>
     <properties>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/kafka-quickstart/producer/pom.xml
+++ b/kafka-quickstart/producer/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>kafka-streams-quickstart-aggregator</artifactId>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -15,8 +15,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/aggregator/pom.xml
+++ b/kafka-streams-quickstart/aggregator/pom.xml
@@ -16,7 +16,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -13,7 +13,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -17,8 +17,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/producer/pom.xml
+++ b/kafka-streams-quickstart/producer/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/kafka-streams-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-streams-quickstart/src/main/docker/Dockerfile.jvm
+++ b/kafka-streams-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-streams-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-streams-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-streams-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-streams-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/kafka-streams-quickstart/src/main/docker/Dockerfile.native
+++ b/kafka-streams-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/kafka-streams-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/lifecycle-quickstart/pom.xml
+++ b/lifecycle-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/lifecycle-quickstart/src/main/docker/Dockerfile.native
+++ b/lifecycle-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/lifecycle-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/liquibase-mongodb-quickstart/pom.xml
+++ b/liquibase-mongodb-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.native
+++ b/liquibase-mongodb-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/liquibase-mongodb-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/liquibase-quickstart/pom.xml
+++ b/liquibase-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/liquibase-quickstart/src/main/docker/Dockerfile.jvm
+++ b/liquibase-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-quickstart/src/main/docker/Dockerfile.jvm
+++ b/liquibase-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/liquibase-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/liquibase-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/liquibase-quickstart/src/main/docker/Dockerfile.native
+++ b/liquibase-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/liquibase-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/pom.xml
+++ b/mailer-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mailer-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mailer-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mailer-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mailer-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mailer-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mailer-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mailer-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mailer-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mailer-quickstart/src/main/docker/Dockerfile.native
+++ b/mailer-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/mailer-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/micrometer-quickstart/pom.xml
+++ b/micrometer-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/micrometer-quickstart/src/main/docker/Dockerfile.jvm
+++ b/micrometer-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/micrometer-quickstart/src/main/docker/Dockerfile.jvm
+++ b/micrometer-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/micrometer-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/micrometer-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/micrometer-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/micrometer-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/micrometer-quickstart/src/main/docker/Dockerfile.native
+++ b/micrometer-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/micrometer-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/microprofile-fault-tolerance-quickstart/pom.xml
+++ b/microprofile-fault-tolerance-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.native
+++ b/microprofile-fault-tolerance-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-fault-tolerance-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -15,7 +15,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/microprofile-graphql-client-quickstart/pom.xml
+++ b/microprofile-graphql-client-quickstart/pom.xml
@@ -12,9 +12,9 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -11,9 +11,9 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
 

--- a/microprofile-graphql-quickstart/pom.xml
+++ b/microprofile-graphql-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
 
   <dependencyManagement>

--- a/microprofile-graphql-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-graphql-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-graphql-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-graphql-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-graphql-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-graphql-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-graphql-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-graphql-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-graphql-quickstart/src/main/docker/Dockerfile.native
+++ b/microprofile-graphql-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-graphql-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/microprofile-health-quickstart/pom.xml
+++ b/microprofile-health-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/microprofile-health-quickstart/src/main/docker/Dockerfile.native
+++ b/microprofile-health-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/microprofile-health-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -11,8 +11,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.27.7</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <assertj.version>3.27.7</assertj.version>

--- a/mongodb-panache-quickstart/pom.xml
+++ b/mongodb-panache-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-panache-quickstart/src/main/docker/Dockerfile.native
+++ b/mongodb-panache-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/mongodb-panache-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <packaging>quarkus</packaging>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/mongodb-quickstart/pom.xml
+++ b/mongodb-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/mongodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mongodb-quickstart/src/main/docker/Dockerfile.native
+++ b/mongodb-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/mongodb-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>

--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/mqtt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mqtt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mqtt-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/mqtt-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/mqtt-quickstart/src/main/docker/Dockerfile.native
+++ b/mqtt-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/mqtt-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -8,7 +8,7 @@
   <packaging>quarkus</packaging>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/neo4j-quickstart/pom.xml
+++ b/neo4j-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/neo4j-quickstart/src/main/docker/Dockerfile.jvm
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/neo4j-quickstart/src/main/docker/Dockerfile.jvm
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/neo4j-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/neo4j-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/neo4j-quickstart/src/main/docker/Dockerfile.native
+++ b/neo4j-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/neo4j-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>quarkus</packaging>
     <properties>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/openapi-swaggerui-quickstart/pom.xml
+++ b/openapi-swaggerui-quickstart/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.native
+++ b/openapi-swaggerui-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/openapi-swaggerui-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/pom.xml
+++ b/opentelemetry-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/opentelemetry-quickstart/src/main/docker/Dockerfile.jvm
+++ b/opentelemetry-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/opentelemetry-quickstart/src/main/docker/Dockerfile.jvm
+++ b/opentelemetry-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/opentelemetry-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/opentelemetry-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/opentelemetry-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/opentelemetry-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/opentelemetry-quickstart/src/main/docker/Dockerfile.native
+++ b/opentelemetry-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/opentelemetry-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <optaplanner-quarkus.version>10.0.0</optaplanner-quarkus.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <optaplanner-quarkus.version>10.0.0</optaplanner-quarkus.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>

--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <optaplanner-quarkus.version>10.0.0</optaplanner-quarkus.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/optaplanner-quickstart/src/main/docker/Dockerfile.jvm
+++ b/optaplanner-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/optaplanner-quickstart/src/main/docker/Dockerfile.jvm
+++ b/optaplanner-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/optaplanner-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/optaplanner-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/optaplanner-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/optaplanner-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/optaplanner-quickstart/src/main/docker/Dockerfile.native
+++ b/optaplanner-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/optaplanner-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/pulsar-quickstart/pulsar-quickstart-processor/pom.xml
+++ b/pulsar-quickstart/pulsar-quickstart-processor/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/pulsar-quickstart/pulsar-quickstart-processor/pom.xml
+++ b/pulsar-quickstart/pulsar-quickstart-processor/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pulsar-quickstart/pulsar-quickstart-processor/pom.xml
+++ b/pulsar-quickstart/pulsar-quickstart-processor/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/pulsar-quickstart/pulsar-quickstart-producer/pom.xml
+++ b/pulsar-quickstart/pulsar-quickstart-producer/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/pulsar-quickstart/pulsar-quickstart-producer/pom.xml
+++ b/pulsar-quickstart/pulsar-quickstart-producer/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pulsar-quickstart/pulsar-quickstart-producer/pom.xml
+++ b/pulsar-quickstart/pulsar-quickstart-producer/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -9,8 +9,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/quartz-quickstart/pom.xml
+++ b/quartz-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/quartz-quickstart/src/main/docker/Dockerfile.jvm
+++ b/quartz-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/quartz-quickstart/src/main/docker/Dockerfile.jvm
+++ b/quartz-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/quartz-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/quartz-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/quartz-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/quartz-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/quartz-quickstart/src/main/docker/Dockerfile.native
+++ b/quartz-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/quartz-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qute-quickstart/pom.xml
+++ b/qute-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/qute-quickstart/src/main/docker/Dockerfile.jvm
+++ b/qute-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/qute-quickstart/src/main/docker/Dockerfile.jvm
+++ b/qute-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/qute-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/qute-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/qute-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/qute-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/qute-quickstart/src/main/docker/Dockerfile.native
+++ b/qute-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/qute-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-producer/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <packaging>quarkus</packaging>
 
     <properties>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/reactive-routes-quickstart/pom.xml
+++ b/reactive-routes-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>

--- a/reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
+++ b/reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
+++ b/reactive-routes-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/reactive-routes-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/reactive-routes-quickstart/src/main/docker/Dockerfile.native
+++ b/reactive-routes-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/reactive-routes-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/pom.xml
+++ b/redis-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <docker-plugin.version>0.28.0</docker-plugin.version>

--- a/redis-quickstart/src/main/docker/Dockerfile.jvm
+++ b/redis-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/redis-quickstart/src/main/docker/Dockerfile.jvm
+++ b/redis-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/redis-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/redis-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/redis-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/redis-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/redis-quickstart/src/main/docker/Dockerfile.native
+++ b/redis-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/redis-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>
   <dependencyManagement>

--- a/rest-client-quickstart/pom.xml
+++ b/rest-client-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -9,8 +9,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/rest-json-quickstart/pom.xml
+++ b/rest-json-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/rest-json-quickstart/src/main/docker/Dockerfile.jvm
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/rest-json-quickstart/src/main/docker/Dockerfile.jvm
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/rest-json-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/rest-json-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/rest-json-quickstart/src/main/docker/Dockerfile.native
+++ b/rest-json-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/rest-json-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/resteasy-client-multipart-quickstart/pom.xml
+++ b/resteasy-client-multipart-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/resteasy-client-multipart-quickstart/pom.xml
+++ b/resteasy-client-multipart-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/resteasy-client-multipart-quickstart/pom.xml
+++ b/resteasy-client-multipart-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
+++ b/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
+++ b/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.native
+++ b/resteasy-client-multipart-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/resteasy-client-multipart-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/resteasy-client-quickstart/pom.xml
+++ b/resteasy-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/resteasy-client-quickstart/pom.xml
+++ b/resteasy-client-quickstart/pom.xml
@@ -10,8 +10,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/resteasy-client-quickstart/pom.xml
+++ b/resteasy-client-quickstart/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <wiremock.version>2.27.2</wiremock.version>

--- a/resteasy-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/resteasy-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/resteasy-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/resteasy-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/resteasy-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/resteasy-client-quickstart/src/main/docker/Dockerfile.native
+++ b/resteasy-client-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/resteasy-client-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/scheduler-quickstart/pom.xml
+++ b/scheduler-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/scheduler-quickstart/src/main/docker/Dockerfile.jvm
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/scheduler-quickstart/src/main/docker/Dockerfile.jvm
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/scheduler-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/scheduler-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/scheduler-quickstart/src/main/docker/Dockerfile.native
+++ b/scheduler-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/scheduler-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -8,7 +8,7 @@
     <packaging>quarkus</packaging>
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -10,8 +10,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-jdbc-quickstart/pom.xml
+++ b/security-jdbc-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jdbc-quickstart/src/main/docker/Dockerfile.native
+++ b/security-jdbc-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-jdbc-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -8,8 +8,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-jpa-quickstart/pom.xml
+++ b/security-jpa-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/security-jpa-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jpa-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jpa-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-quickstart/src/main/docker/Dockerfile.native
+++ b/security-jpa-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-jpa-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-jpa-reactive-quickstart/pom.xml
+++ b/security-jpa-reactive-quickstart/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-jpa-reactive-quickstart/pom.xml
+++ b/security-jpa-reactive-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/security-jpa-reactive-quickstart/pom.xml
+++ b/security-jpa-reactive-quickstart/pom.xml
@@ -8,8 +8,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.native
+++ b/security-jpa-reactive-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-jpa-reactive-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-jpa-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: security-jpa-reactive-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 3.32.0.CR1</li>
+                <li>Quarkus Version: 3.32.1</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jpa-reactive-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/security-jpa-reactive-quickstart/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: security-jpa-reactive-quickstart</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 999-SNAPSHOT</li>
+                <li>Quarkus Version: 3.32.0.CR1</li>
             </ul>
         </div>
         <div class="right-section">

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -9,8 +9,8 @@
   <properties>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/security-jwt-quickstart/pom.xml
+++ b/security-jwt-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-jwt-quickstart/src/main/docker/Dockerfile.native
+++ b/security-jwt-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-jwt-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-keycloak-authorization-quickstart/pom.xml
+++ b/security-keycloak-authorization-quickstart/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.native
+++ b/security-keycloak-authorization-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-keycloak-authorization-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-ldap-quickstart/pom.xml
+++ b/security-ldap-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/security-ldap-quickstart/pom.xml
+++ b/security-ldap-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/security-ldap-quickstart/pom.xml
+++ b/security-ldap-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/security-ldap-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-ldap-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-ldap-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-ldap-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-ldap-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-ldap-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-ldap-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-ldap-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-ldap-quickstart/src/main/docker/Dockerfile.native
+++ b/security-ldap-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-ldap-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -11,8 +11,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <wiremock.version>2.26.3</wiremock.version>

--- a/security-oauth2-quickstart/pom.xml
+++ b/security-oauth2-quickstart/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>quarkus</packaging>
   <properties>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-oauth2-quickstart/src/main/docker/Dockerfile.native
+++ b/security-oauth2-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-oauth2-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-openid-connect-client-quickstart/pom.xml
+++ b/security-openid-connect-client-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-openid-connect-client-quickstart/pom.xml
+++ b/security-openid-connect-client-quickstart/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.native
+++ b/security-openid-connect-client-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-openid-connect-client-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <keycloak.image.version>19.0.1-legacy</keycloak.image.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/pom.xml
+++ b/security-openid-connect-multi-tenancy-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <keycloak.image.version>19.0.1-legacy</keycloak.image.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.native
+++ b/security-openid-connect-multi-tenancy-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-openid-connect-multi-tenancy-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-openid-connect-quickstart/pom.xml
+++ b/security-openid-connect-quickstart/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-openid-connect-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-quickstart/src/main/docker/Dockerfile.native
+++ b/security-openid-connect-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-openid-connect-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/pom.xml
+++ b/security-openid-connect-web-authentication-quickstart/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.native
+++ b/security-openid-connect-web-authentication-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-openid-connect-web-authentication-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-openid-connect-websockets-next-quickstart/pom.xml
+++ b/security-openid-connect-websockets-next-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/security-openid-connect-websockets-next-quickstart/pom.xml
+++ b/security-openid-connect-websockets-next-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/security-openid-connect-websockets-next-quickstart/pom.xml
+++ b/security-openid-connect-websockets-next-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/security-webauthn-quickstart/pom.xml
+++ b/security-webauthn-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/security-webauthn-quickstart/pom.xml
+++ b/security-webauthn-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/security-webauthn-quickstart/pom.xml
+++ b/security-webauthn-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/security-webauthn-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-webauthn-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-webauthn-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-webauthn-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-webauthn-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-quickstart/src/main/docker/Dockerfile.native
+++ b/security-webauthn-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-webauthn-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/security-webauthn-reactive-quickstart/pom.xml
+++ b/security-webauthn-reactive-quickstart/pom.xml
@@ -13,7 +13,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/security-webauthn-reactive-quickstart/pom.xml
+++ b/security-webauthn-reactive-quickstart/pom.xml
@@ -14,7 +14,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/security-webauthn-reactive-quickstart/pom.xml
+++ b/security-webauthn-reactive-quickstart/pom.xml
@@ -12,8 +12,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.jvm
+++ b/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.native
+++ b/security-webauthn-reactive-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/security-webauthn-reactive-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -11,8 +11,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>

--- a/software-transactional-memory-quickstart/pom.xml
+++ b/software-transactional-memory-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>

--- a/software-transactional-memory-quickstart/src/main/docker/Dockerfile.jvm
+++ b/software-transactional-memory-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/software-transactional-memory-quickstart/src/main/docker/Dockerfile.jvm
+++ b/software-transactional-memory-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/software-transactional-memory-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/software-transactional-memory-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/software-transactional-memory-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/software-transactional-memory-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/software-transactional-memory-quickstart/src/main/docker/Dockerfile.native
+++ b/software-transactional-memory-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/software-transactional-memory-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/spring-boot-properties-quickstart/pom.xml
+++ b/spring-boot-properties-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>17</maven.compiler.source>

--- a/spring-boot-properties-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-boot-properties-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-boot-properties-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-boot-properties-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-boot-properties-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-boot-properties-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-boot-properties-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-boot-properties-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-boot-properties-quickstart/src/main/docker/Dockerfile.native
+++ b/spring-boot-properties-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/spring-boot-properties-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -9,8 +9,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/pom.xml
+++ b/spring-data-jpa-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-data-jpa-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-data-jpa-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-jpa-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-data-jpa-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-data-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-data-jpa-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-jpa-quickstart/src/main/docker/Dockerfile.native
+++ b/spring-data-jpa-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/spring-data-jpa-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -14,8 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/spring-data-rest-quickstart/pom.xml
+++ b/spring-data-rest-quickstart/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-data-rest-quickstart/src/main/docker/Dockerfile.native
+++ b/spring-data-rest-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/spring-data-rest-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/pom.xml
+++ b/spring-di-quickstart/pom.xml
@@ -9,8 +9,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <spring.version>5.1.4.RELEASE</spring.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spring-di-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-di-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-di-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-di-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-di-quickstart/src/main/docker/Dockerfile.native
+++ b/spring-di-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/spring-di-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/spring-scheduled-quickstart/pom.xml
+++ b/spring-scheduled-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/spring-scheduled-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-scheduled-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-scheduled-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-scheduled-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-scheduled-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-scheduled-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-scheduled-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-scheduled-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-scheduled-quickstart/src/main/docker/Dockerfile.native
+++ b/spring-scheduled-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/spring-scheduled-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>17</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>17</maven.compiler.source>

--- a/spring-security-quickstart/pom.xml
+++ b/spring-security-quickstart/pom.xml
@@ -16,7 +16,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/spring-security-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-security-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-security-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-security-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-security-quickstart/src/main/docker/Dockerfile.native
+++ b/spring-security-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/spring-security-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -9,8 +9,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/spring-web-quickstart/pom.xml
+++ b/spring-web-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/spring-web-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-web-quickstart/src/main/docker/Dockerfile.jvm
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-web-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-web-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/spring-web-quickstart/src/main/docker/Dockerfile.native
+++ b/spring-web-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/spring-web-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/stork-dns-quickstart/pom.xml
+++ b/stork-dns-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/stork-dns-quickstart/pom.xml
+++ b/stork-dns-quickstart/pom.xml
@@ -9,8 +9,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/stork-dns-quickstart/pom.xml
+++ b/stork-dns-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/stork-dns-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/stork-dns-quickstart/src/main/resources/META-INF/resources/index.html
@@ -146,7 +146,7 @@
                 <li>GroupId: <code>org.acme</code></li>
                 <li>ArtifactId: <code>stork-getting-started</code></li>
                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                <li>Quarkus Version: <code>2.6.1.Final</code></li>
+                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
             </ul>
         </div>
         <div class="right-section">

--- a/stork-dns-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/stork-dns-quickstart/src/main/resources/META-INF/resources/index.html
@@ -146,7 +146,7 @@
                 <li>GroupId: <code>org.acme</code></li>
                 <li>ArtifactId: <code>stork-getting-started</code></li>
                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
+                <li>Quarkus Version: <code>3.32.1</code></li>
             </ul>
         </div>
         <div class="right-section">

--- a/stork-kubernetes-quickstart/pom.xml
+++ b/stork-kubernetes-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/stork-kubernetes-quickstart/pom.xml
+++ b/stork-kubernetes-quickstart/pom.xml
@@ -9,8 +9,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/stork-kubernetes-quickstart/pom.xml
+++ b/stork-kubernetes-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/stork-kubernetes-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/stork-kubernetes-quickstart/src/main/resources/META-INF/resources/index.html
@@ -146,7 +146,7 @@
                 <li>GroupId: <code>org.acme</code></li>
                 <li>ArtifactId: <code>stork-getting-started</code></li>
                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                <li>Quarkus Version: <code>2.6.1.Final</code></li>
+                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
             </ul>
         </div>
         <div class="right-section">

--- a/stork-kubernetes-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/stork-kubernetes-quickstart/src/main/resources/META-INF/resources/index.html
@@ -146,7 +146,7 @@
                 <li>GroupId: <code>org.acme</code></li>
                 <li>ArtifactId: <code>stork-getting-started</code></li>
                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
+                <li>Quarkus Version: <code>3.32.1</code></li>
             </ul>
         </div>
         <div class="right-section">

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -9,8 +9,8 @@
     <packaging>quarkus</packaging>
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/stork-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/stork-quickstart/src/main/resources/META-INF/resources/index.html
@@ -146,7 +146,7 @@
                 <li>GroupId: <code>org.acme</code></li>
                 <li>ArtifactId: <code>stork-getting-started</code></li>
                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                <li>Quarkus Version: <code>2.6.1.Final</code></li>
+                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
             </ul>
         </div>
         <div class="right-section">

--- a/stork-quickstart/src/main/resources/META-INF/resources/index.html
+++ b/stork-quickstart/src/main/resources/META-INF/resources/index.html
@@ -146,7 +146,7 @@
                 <li>GroupId: <code>org.acme</code></li>
                 <li>ArtifactId: <code>stork-getting-started</code></li>
                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
-                <li>Quarkus Version: <code>3.32.0.CR1</code></li>
+                <li>Quarkus Version: <code>3.32.1</code></li>
             </ul>
         </div>
         <div class="right-section">

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <jacoco.version>0.8.14</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <jacoco.version>0.8.14</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/pom.xml
+++ b/tests-with-coverage-quickstart/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <jacoco.version>0.8.14</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/tests-with-coverage-quickstart/src/main/docker/Dockerfile.native
+++ b/tests-with-coverage-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/tests-with-coverage-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -9,8 +9,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/validation-quickstart/pom.xml
+++ b/validation-quickstart/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/validation-quickstart/src/main/docker/Dockerfile.jvm
+++ b/validation-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/validation-quickstart/src/main/docker/Dockerfile.jvm
+++ b/validation-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/validation-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/validation-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/validation-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/validation-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/validation-quickstart/src/main/docker/Dockerfile.native
+++ b/validation-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/validation-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/vertx-quickstart/pom.xml
+++ b/vertx-quickstart/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>3.32.1</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/vertx-quickstart/src/main/docker/Dockerfile.jvm
+++ b/vertx-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/vertx-quickstart/src/main/docker/Dockerfile.jvm
+++ b/vertx-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/vertx-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/vertx-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/vertx-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/vertx-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/vertx-quickstart/src/main/docker/Dockerfile.native
+++ b/vertx-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/vertx-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/websockets-next-quickstart/pom.xml
+++ b/websockets-next-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/websockets-next-quickstart/pom.xml
+++ b/websockets-next-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/websockets-next-quickstart/pom.xml
+++ b/websockets-next-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.32.1</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/websockets-quickstart/pom.xml
+++ b/websockets-quickstart/pom.xml
@@ -8,8 +8,8 @@
   <packaging>quarkus</packaging>
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.32.0.CR1</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/websockets-quickstart/src/main/docker/Dockerfile.jvm
+++ b/websockets-quickstart/src/main/docker/Dockerfile.jvm
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/websockets-quickstart/src/main/docker/Dockerfile.jvm
+++ b/websockets-quickstart/src/main/docker/Dockerfile.jvm
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -80,7 +80,7 @@
 # You can find more information about the UBI base runtime images and their configuration here:
 # https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
+++ b/websockets-quickstart/src/main/docker/Dockerfile.legacy-jar
@@ -77,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/websockets-quickstart/src/main/docker/Dockerfile.native
+++ b/websockets-quickstart/src/main/docker/Dockerfile.native
@@ -13,10 +13,10 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/websockets-quickstart
 #
-# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image is based on UBI 9.
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
The version of Surefire has got rather out of sync with what's in the Quarkus codebase. It looks better if our quickstarts have up to date dependencies. More importantly, some behaviour differences in Surefire affect how tests run, so we want to use the version of Surefire that the Quarkus test framework was designed for. For example,  https://github.com/quarkusio/quarkus/pull/51298 is a case where running recent versions of Quarkus with Surefire 3.5.3 and lower would leak memory, because of a change in how many `LauncherSession`s Surefire uses.