### PR TITLE
Stork - Use consistent defaults between Registration and *Services

### DIFF
--- a/stork-quickstart/src/main/java/org/acme/services/Registration.java
+++ b/stork-quickstart/src/main/java/org/acme/services/Registration.java
@@ -16,8 +16,8 @@ public class Registration {
     @ConfigProperty(name = "consul.host") String host;
     @ConfigProperty(name = "consul.port") int port;
 
-    @ConfigProperty(name = "red-service-port", defaultValue = "9000") int red;
-    @ConfigProperty(name = "blue-service-port", defaultValue = "9001") int blue;
+    @ConfigProperty(name = "red-service-port", defaultValue = "9001") int red;
+    @ConfigProperty(name = "blue-service-port", defaultValue = "9000") int blue;
 
     /**
      * Register our two services in Consul.


### PR DESCRIPTION
@aureamunoz not sure what the value should be but we shouldn't have inconsistent defaults for the same `@ConfigProperty`.

Could you have a look at the PR?
