### PR TITLE
Fix blocking issue causing test failures in context-propagation and jta-quickstarts

### DIFF
--- a/context-propagation-quickstart/src/main/java/org/acme/context/EmitterResource.java
+++ b/context-propagation-quickstart/src/main/java/org/acme/context/EmitterResource.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.jboss.resteasy.reactive.RestStreamElementType;
 
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
@@ -23,6 +24,7 @@ public class EmitterResource {
     @Channel("prices") Multi<Double> prices;
 
     @Transactional
+    @Blocking
     @GET
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS)

--- a/jta-quickstart/src/main/java/org/acme/quickstart/TransactionalResource.java
+++ b/jta-quickstart/src/main/java/org/acme/quickstart/TransactionalResource.java
@@ -2,6 +2,8 @@ package org.acme.quickstart;
 
 import com.arjuna.ats.jta.TransactionManager;
 import io.quarkus.runtime.StartupEvent;
+import io.smallrye.common.annotation.Blocking;
+
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.spi.ContextManagerProvider;
@@ -56,6 +58,7 @@ public class TransactionalResource {
     @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Transactional
+    @Blocking
     @Path("cmt")
     public int cmt() throws SystemException {
         // the @Transactional annotation will have started a transaction
@@ -83,6 +86,7 @@ public class TransactionalResource {
     @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Transactional
+    @Blocking
     @Path("async-with-suspended")
     public void async1(@Suspended AsyncResponse ar) throws SystemException {
         // the framework will have started a transaction because of the @Transactional annotation
@@ -118,6 +122,7 @@ public class TransactionalResource {
     @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Transactional
+    @Blocking
     @Path("async-with-completion-stage")
     public CompletionStage<Integer> async2() throws SystemException {
         System.out.printf("submitting async job ...%n");
@@ -147,6 +152,7 @@ public class TransactionalResource {
 
     @POST
     @Produces(MediaType.TEXT_PLAIN)
+    @Blocking
     @Transactional
     @Path("async-6471-reproducer")
     public void asyncIssue6471Reproducer(@Suspended AsyncResponse ar) throws SystemException {


### PR DESCRIPTION
### Summary
Fix failing native tests in quickstarts from github action caused by a change in Quarkus, where @'Transactional' methods are no longer implicitly considered blocking.

Fixes https://github.com/quarkusio/quarkus-quickstarts/issues/1636

### Changes
Added @'Blocking' to methods that have @'Transactional' annotation in:
- context-propagation-quickstart
- jta-quickstart

### Reference
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.35#quarkus-rest

### Contributors
@SlimaneAbzar


