### PR TITLE
Fix flaky rabbitmq quickstart test

### DIFF
--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorTest.java
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorTest.java
@@ -57,6 +57,9 @@ public class QuoteProcessorTest {
         AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
             .contentType("text/plain")
             .build();
+
+        await().until(() -> channel.consumerCount("quote-requests") >= 1);
+
         channel.basicPublish("quote-requests", quoteId, props, quoteId.getBytes(UTF_8));
 
         await().atMost(3, SECONDS).untilAtomic(receivedQuote, notNullValue());


### PR DESCRIPTION
Wait until the consumer and quote-requests exchange is created to send messages
