### PR TITLE
Add Gitflow-Incremental-Builder (GIB) plugin for selective testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,4 +130,30 @@
             </extension>
         </extensions>
     </build>
+    <profiles>
+        <profile>
+            <id>incremental</id>
+            <activation>
+                <property>
+                    <name>incremental</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.github.gitflow-incremental-builder</groupId>
+                        <artifactId>gitflow-incremental-builder</artifactId>
+                        <version>4.6.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <referenceBranch>HEAD</referenceBranch>
+                            <uncommitted>false</uncommitted>
+                            <untracked>false</untracked>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Introduce an 'incremental' Maven profile that uses the GIB plugin to build and test only modules affected by changes. The profile is activated by the 'incremental' property and compares against HEAD to identify changed modules.

- Required for [QQE-2349](https://redhat.atlassian.net/browse/QQE-2349)

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


