### PR TITLE
Make GIB incremental profile opt-in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,6 @@
             <activation>
                 <property>
                     <name>incremental</name>
-                    <value>!false</value>
                 </property>
             </activation>
             <build>


### PR DESCRIPTION
## Summary
- Makes the `incremental` Maven profile opt-in instead of opt-out
- Plain `mvn clean test` now runs all tests without requiring `-Dincremental=false`
- To enable GIB selective testing, pass `-Dincremental`

Fixes the issue raised in https://github.com/quarkusio/quarkus-quickstarts/pull/1639#issuecomment-4389724848

## Test plan
- [ ] Verify `mvn clean test -pl jta-quickstart` runs tests (no GIB)
- [ ] Verify `mvn clean test -Dincremental -pl jta-quickstart` activates GIB