### PR TITLE
Fix stork quickstart as it's missing now optional `vertx-codegen`

### DIFF
--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>smallrye-mutiny-vertx-consul-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>


### PR DESCRIPTION
The https://github.com/quarkusio/quarkus/pull/53924 bumped `smallrye-mutiny-vertx-binding` to 3.22.2 where they make `vertx-codegen` optional. This caused the stork quickstart to fail. This PR adding it

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


