### PR TITLE
Add quarkus-jackson dependency to stork-quickstart

### DIFF
--- a/stork-quickstart/pom.xml
+++ b/stork-quickstart/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`
- Fixes https://github.com/quarkusio/quarkus/issues/6588

