### PR TITLE
[3.27] Rabbitmq Quickstart test: wait until consumer and quote-requests exchange is created to send messages

### DIFF
--- a/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorTest.java
+++ b/rabbitmq-quickstart/rabbitmq-quickstart-processor/src/test/java/org/acme/rabbitmq/processor/QuoteProcessorTest.java
@@ -57,6 +57,9 @@ public class QuoteProcessorTest {
         AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
             .contentType("text/plain")
             .build();
+
+        await().until(() -> channel.consumerCount("quote-requests") >= 1);
+
         channel.basicPublish("quote-requests", quoteId, props, quoteId.getBytes(UTF_8));
 
         await().atMost(3, SECONDS).untilAtomic(receivedQuote, notNullValue());


### PR DESCRIPTION
Rabbitmq Quickstart test: wait until consumer and quote-requests exchange is created to send messages

Backport of https://github.com/quarkusio/quarkus-quickstarts/pull/1638/ into 3.27 LTS branch

(cherry picked from commit d66869dfef5354a028c2651093f4b13a4526bab0)

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


