### PR TITLE
[3.27] Backports Bump io.fabric8:docker-maven-plugin from 0.28.0 to 0.48.1

### DIFF
--- a/mqtt-quickstart/pom.xml
+++ b/mqtt-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.27.4</quarkus.platform.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <docker-plugin.version>0.28.0</docker-plugin.version>
+    <docker-plugin.version>0.48.1</docker-plugin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Old Docker Maven plugin cause failure with newer Docker >=29  

`Execution docker-start of goal io.fabric8:docker-maven-plugin:0.28.0:start failed: Cannot invoke "com.google.gson.JsonElement.isJsonNull()" because the return value of "com.google.gson.JsonObject.get(String)" is null`

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has integration/native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


