### PR TITLE
Align Hibernate quickstarts on guides regarding `schema-management.strategy=drop-and-create`

### DIFF
--- a/context-propagation-quickstart/src/main/resources/application.properties
+++ b/context-propagation-quickstart/src/main/resources/application.properties
@@ -4,6 +4,6 @@
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
+%prod.quarkus.hibernate-orm.schema-management.strategy=create
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.log.sql=true

--- a/hibernate-reactive-quickstart/src/main/resources/application.properties
+++ b/hibernate-reactive-quickstart/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.sql-load-script=import.sql
 
 # Reactive config
 %prod.quarkus.datasource.username=quarkus_test

--- a/spring-data-jpa-quickstart/src/main/resources/application.properties
+++ b/spring-data-jpa-quickstart/src/main/resources/application.properties
@@ -4,6 +4,6 @@
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
+%prod.quarkus.hibernate-orm.schema-management.strategy=create
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/spring-data-rest-quickstart/src/main/resources/application.properties
+++ b/spring-data-rest-quickstart/src/main/resources/application.properties
@@ -4,4 +4,4 @@
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql:quarkus_test
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%prod.quarkus.hibernate-orm.schema-management.strategy=create


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/55001

**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [x] for new quickstart, is located in the directory _component-quickstart_
- [x] for new quickstart, is added to the root `pom.xml` and `README.md`


