### PR TITLE
Fix S3 native integration tests

### DIFF
--- a/amazon-s3-quickstart/src/main/resources/application.properties
+++ b/amazon-s3-quickstart/src/main/resources/application.properties
@@ -2,5 +2,5 @@ bucket.name=quarkus.s3.quickstart
 quarkus.s3.devservices.buckets=${bucket.name}
 
 # Work around issue with Amazon S3 Dev Services
-%dev.quarkus.s3.path-style-access=true
-%test.quarkus.s3.path-style-access=true
+quarkus.s3.path-style-access=true
+


### PR DESCRIPTION
These tests use the `prod` profile and the dev service, so you must enable the "path-style-access" flag.

